### PR TITLE
LPD-15994 Persistence models company integrity validation

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/internal/service/persistence/TableMapperImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/service/persistence/TableMapperImpl.java
@@ -22,9 +22,11 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.internal.cache.DummyPortalCache;
 import com.liferay.portal.kernel.internal.dao.orm.TableMapperArgumentResolver;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ModelListenerRegistrationUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.service.persistence.impl.TableMapper;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -36,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -444,12 +447,23 @@ public class TableMapperImpl<L extends BaseModel<L>, R extends BaseModel<R>>
 			return Collections.emptyList();
 		}
 
+		long currentCompanyId = CompanyThreadLocal.getCompanyId();
 		List<T> slaveBaseModels = new ArrayList<>(slavePrimaryKeys.length);
 
 		try {
 			for (long slavePrimaryKey : slavePrimaryKeys) {
-				slaveBaseModels.add(
-					slaveBasePersistence.findByPrimaryKey(slavePrimaryKey));
+				T slaveBaseModel =
+					slaveBasePersistence.findByPrimaryKey(slavePrimaryKey);
+
+				long checkableCompanyId =
+					_getCheckableCompanyId(slaveBaseModel);
+
+				boolean isSkipCheck =
+					checkableCompanyId == CompanyConstants.SYSTEM;
+
+				if (isSkipCheck || checkableCompanyId == currentCompanyId) {
+					slaveBaseModels.add(slaveBaseModel);
+				}
 			}
 		}
 		catch (NoSuchModelException noSuchModelException) {
@@ -696,6 +710,15 @@ public class TableMapperImpl<L extends BaseModel<L>, R extends BaseModel<R>>
 		}
 
 		return false;
+	}
+
+	private static <T extends BaseModel<T>> long _getCheckableCompanyId(T model) {
+
+		Map<String, Object> modelAttributes =
+			model.getModelAttributes();
+
+		return (long) modelAttributes.getOrDefault(
+			"companyId", CompanyConstants.SYSTEM);
 	}
 
 	private final ServiceRegistration<?> _serviceRegistration;

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/service/persistence/TableMapperImpl.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/service/persistence/TableMapperImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.ModelListenerRegistrationUtil;
+import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
@@ -38,7 +39,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import javax.sql.DataSource;
 
@@ -452,16 +452,12 @@ public class TableMapperImpl<L extends BaseModel<L>, R extends BaseModel<R>>
 
 		try {
 			for (long slavePrimaryKey : slavePrimaryKeys) {
-				T slaveBaseModel =
-					slaveBasePersistence.findByPrimaryKey(slavePrimaryKey);
+				T slaveBaseModel = slaveBasePersistence.findByPrimaryKey(
+					slavePrimaryKey);
 
-				long checkableCompanyId =
-					_getCheckableCompanyId(slaveBaseModel);
+				if ((currentCompanyId == CompanyConstants.SYSTEM) ||
+					(currentCompanyId == _getCompanyId(slaveBaseModel))) {
 
-				boolean isSkipCheck =
-					checkableCompanyId == CompanyConstants.SYSTEM;
-
-				if (isSkipCheck || checkableCompanyId == currentCompanyId) {
 					slaveBaseModels.add(slaveBaseModel);
 				}
 			}
@@ -628,6 +624,18 @@ public class TableMapperImpl<L extends BaseModel<L>, R extends BaseModel<R>>
 	protected final Class<R> rightModelClass;
 	protected final PortalCache<Long, long[]> rightToLeftPortalCache;
 
+	private static <T extends BaseModel<T>> long _getCompanyId(T model) {
+		long companyId = CompanyConstants.SYSTEM;
+
+		if (model instanceof ShardedModel) {
+			ShardedModel shardedModel = (ShardedModel)model;
+
+			companyId = shardedModel.getCompanyId();
+		}
+
+		return companyId;
+	}
+
 	private void _addTableMapping(
 		long companyId, long leftPrimaryKey, long rightPrimaryKey) {
 
@@ -710,15 +718,6 @@ public class TableMapperImpl<L extends BaseModel<L>, R extends BaseModel<R>>
 		}
 
 		return false;
-	}
-
-	private static <T extends BaseModel<T>> long _getCheckableCompanyId(T model) {
-
-		Map<String, Object> modelAttributes =
-			model.getModelAttributes();
-
-		return (long) modelAttributes.getOrDefault(
-			"companyId", CompanyConstants.SYSTEM);
 	}
 
 	private final ServiceRegistration<?> _serviceRegistration;


### PR DESCRIPTION
Original ticket: https://liferay.atlassian.net/browse/LPD-15994

Original PR: https://github.com/liferay-commerce/liferay-portal/pull/4735.

The fix has been already discussed a validated at length with the kind help of @achaparro 

In the original PR you'll find that the CI was run and test reports were generated: multiple tests are failing and the analysis brought to the tentative conclusion that many of them are in fact creating ad hoc companies without setting them in the `CompanyThreadLocal`, which should not be the case. The change in the PR fixes the LPD-15994 vulnerability on the UI part by introducing a check on the `TableMapperImpl` to make sure persistence services are accessing entities **only** pertaining to the current company, on the basis of the `CompanyThreadLocal`.

@achaparro suggested a deeper analysis should be run for this kind of issues, both at db-partition level and other relevant cases, so here's why this PR has been opened directly to team Uniform.