### PR TITLE
[TS] LPD-18246 Attempt of index creation on non-existing module tables and columns when upgrade.database.auto.run is false

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewFileEntryDisplayContext.java
@@ -5,6 +5,7 @@
 
 package com.liferay.document.library.web.internal.display.context;
 
+import com.liferay.document.library.constants.DLPortletKeys;
 import com.liferay.document.library.display.context.DLDisplayContextProvider;
 import com.liferay.document.library.display.context.DLViewFileVersionDisplayContext;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
@@ -27,6 +28,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -231,21 +233,29 @@ public class DLViewFileEntryDisplayContext {
 			return _redirect;
 		}
 
-		long parentFolderId = _getParentFolderId();
+		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
 
-		String mvcRenderCommandName = "/document_library/view";
+		String portletName = portletDisplay.getPortletName();
 
-		if (parentFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			mvcRenderCommandName = "/document_library/view_folder";
+		if (portletName.equals(DLPortletKeys.DOCUMENT_LIBRARY) ||
+			portletName.equals(DLPortletKeys.DOCUMENT_LIBRARY_ADMIN)) {
+
+			long parentFolderId = _getParentFolderId();
+
+			String mvcRenderCommandName = "/document_library/view";
+
+			if (parentFolderId != DLFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+				mvcRenderCommandName = "/document_library/view_folder";
+			}
+
+			_redirect = PortletURLBuilder.createRenderURL(
+				_renderResponse
+			).setMVCRenderCommandName(
+				mvcRenderCommandName
+			).setParameter(
+				"folderId", parentFolderId
+			).buildString();
 		}
-
-		_redirect = PortletURLBuilder.createRenderURL(
-			_renderResponse
-		).setMVCRenderCommandName(
-			mvcRenderCommandName
-		).setParameter(
-			"folderId", parentFolderId
-		).buildString();
 
 		return _redirect;
 	}

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -23,9 +23,10 @@ if (addPortletBreadcrumbEntries) {
 }
 
 boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getInitParameter("portlet-title-based-navigation"));
+boolean showBackIcon = Validator.isNotNull(dlViewFileEntryDisplayContext.getRedirect());
 
 if (portletTitleBasedNavigation) {
-	portletDisplay.setShowBackIcon(true);
+	portletDisplay.setShowBackIcon(showBackIcon);
 	portletDisplay.setURLBack(dlViewFileEntryDisplayContext.getRedirect());
 
 	renderResponse.setTitle(fileVersion.getTitle());
@@ -84,15 +85,17 @@ if (portletTitleBasedNavigation) {
 			<div class="file-entry-actions management-bar management-bar-light navbar navbar-expand-md">
 				<ul class="navbar-nav navbar-nav-expand">
 					<li class="nav-item nav-item-expand">
-						<clay:link
-							aria-label='<%= LanguageUtil.get(request, "back") %>'
-							borderless="<%= true %>"
-							displayType="secondary"
-							href="<%= dlViewFileEntryDisplayContext.getRedirect() %>"
-							icon="angle-left"
-							monospaced="<%= true %>"
-							type="button"
-						/>
+						<c:if test="<%= showBackIcon %>">
+							<clay:link
+								aria-label='<%= LanguageUtil.get(request, "back") %>'
+								borderless="<%= true %>"
+								displayType="secondary"
+								href="<%= dlViewFileEntryDisplayContext.getRedirect() %>"
+								icon="angle-left"
+								monospaced="<%= true %>"
+								type="button"
+							/>
+						</c:if>
 
 						<h3 class="mb-1 text-secondary"><%= HtmlUtil.escape(dlViewFileEntryDisplayContext.getDocumentTitle()) %></h3>
 					</li>

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.osgi.debug.SystemChecker;
+import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.executor.UpgradeExecutor;
 import com.liferay.portal.upgrade.internal.graph.ReleaseGraphManager;
@@ -100,10 +101,15 @@ public class ReleaseManagerImpl implements ReleaseManager {
 	@Override
 	public String getStatus() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
-			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
-				_isPendingModuleUpgrades()) {
-
+			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
 				return "failure";
+			}
+			else if (_isPendingModuleUpgrades()) {
+				if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
+					return "failure";
+				}
+
+				return "unresolved";
 			}
 		}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -7,7 +7,13 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.db.DBResourceUtil;
+import com.liferay.portal.db.index.IndexUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -16,10 +22,14 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.SQLException;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -29,6 +39,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.BundleTracker;
 
 /**
  * @author Luis Ortiz
@@ -42,7 +57,7 @@ public class DBUpgraderTest {
 		new LiferayIntegrationTestRule();
 
 	@BeforeClass
-	public static void setUpClass() throws SQLException {
+	public static void setUpClass() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
 			_currentBuildNumber = PortalUpgradeProcess.getCurrentBuildNumber(
 				connection);
@@ -52,17 +67,77 @@ public class DBUpgraderTest {
 
 		_upgrading = ReflectionTestUtil.getAndSetFieldValue(
 			StartupHelperUtil.class, "_upgrading", true);
+
+		Bundle bundle = FrameworkUtil.getBundle(DBUpgraderTest.class);
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		BundleTracker<Bundle> bundleTracker = new BundleTracker<Bundle>(
+			bundle.getBundleContext(), Bundle.ACTIVE, null) {
+
+			@Override
+			public Bundle addingBundle(Bundle bundle, BundleEvent event) {
+				String symbolicName = bundle.getSymbolicName();
+
+				if (symbolicName.equals("com.liferay.portal.lock.service")) {
+					_moduleBundle = bundle;
+
+					countDownLatch.countDown();
+
+					close();
+				}
+
+				return null;
+			}
+
+		};
+
+		bundleTracker.open();
+
+		_connection = DataAccess.getConnection();
+
+		_db = DBManagerUtil.getDB();
+
+		_dbInspector = new DBInspector(_connection);
+
+		_processedServletContextNames = ReflectionTestUtil.getFieldValue(
+			IndexUpdaterUtil.class, "_processedServletContextNames");
+
+		countDownLatch.await(10, TimeUnit.SECONDS);
+
+		_initIndexNames();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		ReflectionTestUtil.setFieldValue(
 			StartupHelperUtil.class, "_upgrading", _upgrading);
+		DataAccess.cleanUp(_connection);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		_updatePortalRelease(_currentBuildNumber, _currentState);
+		_processedServletContextNames.clear();
+	}
+
+	@Test
+	public void testRegenerateModuleIndexes() throws Exception {
+		_dropIndex(_moduleTableIndexName, _moduleIndexName);
+
+		PropsUtil.set("upgrade.database.auto.run", "false");
+
+		DBUpgrader.upgradeModules(false);
+
+		Assert.assertFalse(
+			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
+
+		PropsUtil.set("upgrade.database.auto.run", "true");
+
+		DBUpgrader.upgradeModules(false);
+
+		Assert.assertTrue(
+			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
 	}
 
 	@Test
@@ -98,6 +173,31 @@ public class DBUpgraderTest {
 		DBUpgrader.upgradePortal();
 	}
 
+	private static String _getIndexName(String indexesSQL) {
+		return indexesSQL.substring(
+			indexesSQL.indexOf("IX_"), indexesSQL.indexOf(" on"));
+	}
+
+	private static String _getTableIndexName(String indexesSQL) {
+		return indexesSQL.substring(
+			indexesSQL.indexOf("on ") + 3, indexesSQL.indexOf(" ("));
+	}
+
+	private static void _initIndexNames() throws Exception {
+		String moduleIndexesSQL = DBResourceUtil.getModuleIndexesSQL(
+			_moduleBundle);
+
+		_moduleIndexName = _getIndexName(moduleIndexesSQL);
+		_moduleTableIndexName = _getTableIndexName(moduleIndexesSQL);
+	}
+
+	private void _dropIndex(String tableName, String indexName)
+		throws Exception {
+
+		_db.runSQL(
+			StringBundler.concat("drop index ", indexName, " on ", tableName));
+	}
+
 	private void _updatePortalRelease(int buildNumber, int state)
 		throws Exception {
 
@@ -119,8 +219,15 @@ public class DBUpgraderTest {
 		dclSingleton.destroy(null);
 	}
 
+	private static Connection _connection;
 	private static int _currentBuildNumber;
 	private static int _currentState;
+	private static DB _db;
+	private static DBInspector _dbInspector;
+	private static Bundle _moduleBundle;
+	private static String _moduleIndexName;
+	private static String _moduleTableIndexName;
+	private static Set<String> _processedServletContextNames;
 	private static boolean _upgrading;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 
@@ -60,35 +61,17 @@ public class ReleaseManagerTest {
 	}
 
 	@Test
-	public void testUnsuccessfulUpgradeByMissingModuleUpgrade()
+	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithAutorun()
 		throws Exception {
 
-		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade("true", "failure");
+	}
 
-		BundleContext bundleContext = bundle.getBundleContext();
+	@Test
+	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithoutAutorun()
+		throws Exception {
 
-		_serviceRegistration = bundleContext.registerService(
-			UpgradeStepRegistrator.class,
-			new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
-
-		Release release = _releaseLocalService.fetchRelease(
-			bundle.getSymbolicName());
-
-		try {
-			release.setSchemaVersion("0.0.0");
-
-			release = _releaseLocalService.updateRelease(release);
-
-			Assert.assertEquals("failure", _releaseManager.getStatus());
-			Assert.assertFalse(
-				Validator.isBlank(
-					_releaseManager.getShortStatusMessage(false)));
-			Assert.assertFalse(
-				Validator.isBlank(_releaseManager.getStatusMessage(false)));
-		}
-		finally {
-			_releaseLocalService.deleteRelease(release);
-		}
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade("false", "unresolved");
 	}
 
 	@Test
@@ -113,6 +96,40 @@ public class ReleaseManagerTest {
 			finally {
 				PortalUpgradeProcess.updateSchemaVersion(connection, version);
 			}
+		}
+	}
+
+	private void _testUnsuccessfulUpgradeByMissingModuleUpgrade(
+			String autorun, String status)
+		throws Exception {
+
+		PropsUtil.set("upgrade.database.auto.run", autorun);
+
+		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			UpgradeStepRegistrator.class,
+			new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
+
+		Release release = _releaseLocalService.fetchRelease(
+			bundle.getSymbolicName());
+
+		try {
+			release.setSchemaVersion("0.0.0");
+
+			release = _releaseLocalService.updateRelease(release);
+
+			Assert.assertEquals(status, _releaseManager.getStatus());
+			Assert.assertFalse(
+				Validator.isBlank(
+					_releaseManager.getShortStatusMessage(false)));
+			Assert.assertFalse(
+				Validator.isBlank(_releaseManager.getStatusMessage(false)));
+		}
+		finally {
+			_releaseLocalService.deleteRelease(release);
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -136,7 +136,7 @@ public class UpgradeRecorderTest {
 			}
 		}
 
-		Assert.assertEquals("failure", _getResult());
+		Assert.assertEquals("unresolved", _getResult());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -242,7 +242,12 @@ public class DBUpgrader {
 
 		_registerModuleServiceLifecycle("portlets.initialized");
 
-		IndexUpdaterUtil.updateAllIndexes();
+		if (isUpgradeDatabaseAutoRunEnabled()) {
+			IndexUpdaterUtil.updateAllIndexes();
+		}
+		else {
+			IndexUpdaterUtil.updatePortalIndexes();
+		}
 	}
 
 	public static void upgradePortal() throws Exception {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -207,7 +207,9 @@ public class DBInspector {
 			while (resultSet.next()) {
 				if (Objects.equals(
 						normalizeName(indexName, databaseMetaData),
-						resultSet.getString("index_name"))) {
+						normalizeName(
+							resultSet.getString("index_name"),
+							databaseMetaData))) {
 
 					return true;
 				}


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
If the `upgrade.database.auto.run` property is set to **false** in the `portal-upgrade-ext.properties` file at the upgrade client folder, the module tables will not be created/updated but the indexes will be subsequently attempted to be created on them.

Warning messages like these will appear in the upgrade log.
```
2024-03-01 12:08:56.949 INFO  [ForkJoinPool-14-worker-3][BaseDB:1232] drop index IX_A73B688A on BackgroundTask
2024-03-01 12:08:56.950 WARN  [ForkJoinPool-14-worker-0][BaseDB:1507] Table 'lportal.AssetEntryAssetCategoryRel' doesn't exist: create index IX_B916F797 on AssetEntryAssetCategoryRel (assetCategoryId, assetEntryId);
```
Proposed Solution
========
If autorun is not enabled (`upgrade.database.auto.run` property is set to **false**) then the module indexes shouldn't be updated.
Also, the result status of the upgrade process should be "unresolved" instead of "failure" as the upgrade is incomplete but intendedly so.
Thanks for @LuisOrtiz89 and @achaparro for their help in coming up with the solution!

Please also note that I adjusted the `DBInspector.hasIndex` method to be able to find the indexes in the test.

Steps to Verify
========
Please see the linked LPD for the reproduction steps.
https://liferay.atlassian.net/browse/LPD-18246

Thank you and best regards,
István