### PR TITLE
LPD-18246 Attempt of index creation on non-existing module tables and columns when upgrade.database.auto.run is false

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.osgi.debug.SystemChecker;
+import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.executor.UpgradeExecutor;
 import com.liferay.portal.upgrade.internal.graph.ReleaseGraphManager;
@@ -100,10 +101,15 @@ public class ReleaseManagerImpl implements ReleaseManager {
 	@Override
 	public String getStatus() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
-			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
-				_isPendingModuleUpgrades()) {
-
+			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
 				return "failure";
+			}
+			else if (_isPendingModuleUpgrades()) {
+				if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
+					return "failure";
+				}
+
+				return "unresolved";
 			}
 		}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -7,7 +7,13 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.db.DBResourceUtil;
+import com.liferay.portal.db.index.IndexUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -16,10 +22,14 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.SQLException;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -29,6 +39,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.BundleTracker;
 
 /**
  * @author Luis Ortiz
@@ -42,7 +57,7 @@ public class DBUpgraderTest {
 		new LiferayIntegrationTestRule();
 
 	@BeforeClass
-	public static void setUpClass() throws SQLException {
+	public static void setUpClass() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
 			_currentBuildNumber = PortalUpgradeProcess.getCurrentBuildNumber(
 				connection);
@@ -52,17 +67,77 @@ public class DBUpgraderTest {
 
 		_upgrading = ReflectionTestUtil.getAndSetFieldValue(
 			StartupHelperUtil.class, "_upgrading", true);
+
+		Bundle bundle = FrameworkUtil.getBundle(DBUpgraderTest.class);
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		BundleTracker<Bundle> bundleTracker = new BundleTracker<Bundle>(
+			bundle.getBundleContext(), Bundle.ACTIVE, null) {
+
+			@Override
+			public Bundle addingBundle(Bundle bundle, BundleEvent event) {
+				String symbolicName = bundle.getSymbolicName();
+
+				if (symbolicName.equals("com.liferay.portal.lock.service")) {
+					_moduleBundle = bundle;
+
+					countDownLatch.countDown();
+
+					close();
+				}
+
+				return null;
+			}
+
+		};
+
+		bundleTracker.open();
+
+		_connection = DataAccess.getConnection();
+
+		_db = DBManagerUtil.getDB();
+
+		_dbInspector = new DBInspector(_connection);
+
+		_processedServletContextNames = ReflectionTestUtil.getFieldValue(
+			IndexUpdaterUtil.class, "_processedServletContextNames");
+
+		countDownLatch.await(10, TimeUnit.SECONDS);
+
+		_initIndexNames();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		ReflectionTestUtil.setFieldValue(
 			StartupHelperUtil.class, "_upgrading", _upgrading);
+		DataAccess.cleanUp(_connection);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		_updatePortalRelease(_currentBuildNumber, _currentState);
+		_processedServletContextNames.clear();
+	}
+
+	@Test
+	public void testRegenerateModuleIndexes() throws Exception {
+		_dropIndex(_moduleTableIndexName, _moduleIndexName);
+
+		PropsUtil.set("upgrade.database.auto.run", "false");
+
+		DBUpgrader.upgradeModules(false);
+
+		Assert.assertFalse(
+			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
+
+		PropsUtil.set("upgrade.database.auto.run", "true");
+
+		DBUpgrader.upgradeModules(false);
+
+		Assert.assertTrue(
+			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
 	}
 
 	@Test
@@ -98,6 +173,31 @@ public class DBUpgraderTest {
 		DBUpgrader.upgradePortal();
 	}
 
+	private static String _getIndexName(String indexesSQL) {
+		return indexesSQL.substring(
+			indexesSQL.indexOf("IX_"), indexesSQL.indexOf(" on"));
+	}
+
+	private static String _getTableIndexName(String indexesSQL) {
+		return indexesSQL.substring(
+			indexesSQL.indexOf("on ") + 3, indexesSQL.indexOf(" ("));
+	}
+
+	private static void _initIndexNames() throws Exception {
+		String moduleIndexesSQL = DBResourceUtil.getModuleIndexesSQL(
+			_moduleBundle);
+
+		_moduleIndexName = _getIndexName(moduleIndexesSQL);
+		_moduleTableIndexName = _getTableIndexName(moduleIndexesSQL);
+	}
+
+	private void _dropIndex(String tableName, String indexName)
+		throws Exception {
+
+		_db.runSQL(
+			StringBundler.concat("drop index ", indexName, " on ", tableName));
+	}
+
 	private void _updatePortalRelease(int buildNumber, int state)
 		throws Exception {
 
@@ -119,8 +219,15 @@ public class DBUpgraderTest {
 		dclSingleton.destroy(null);
 	}
 
+	private static Connection _connection;
 	private static int _currentBuildNumber;
 	private static int _currentState;
+	private static DB _db;
+	private static DBInspector _dbInspector;
+	private static Bundle _moduleBundle;
+	private static String _moduleIndexName;
+	private static String _moduleTableIndexName;
+	private static Set<String> _processedServletContextNames;
 	private static boolean _upgrading;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 
@@ -60,35 +61,17 @@ public class ReleaseManagerTest {
 	}
 
 	@Test
-	public void testUnsuccessfulUpgradeByMissingModuleUpgrade()
+	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithAutorun()
 		throws Exception {
 
-		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade("true", "failure");
+	}
 
-		BundleContext bundleContext = bundle.getBundleContext();
+	@Test
+	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithoutAutorun()
+		throws Exception {
 
-		_serviceRegistration = bundleContext.registerService(
-			UpgradeStepRegistrator.class,
-			new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
-
-		Release release = _releaseLocalService.fetchRelease(
-			bundle.getSymbolicName());
-
-		try {
-			release.setSchemaVersion("0.0.0");
-
-			release = _releaseLocalService.updateRelease(release);
-
-			Assert.assertEquals("failure", _releaseManager.getStatus());
-			Assert.assertFalse(
-				Validator.isBlank(
-					_releaseManager.getShortStatusMessage(false)));
-			Assert.assertFalse(
-				Validator.isBlank(_releaseManager.getStatusMessage(false)));
-		}
-		finally {
-			_releaseLocalService.deleteRelease(release);
-		}
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade("false", "unresolved");
 	}
 
 	@Test
@@ -113,6 +96,40 @@ public class ReleaseManagerTest {
 			finally {
 				PortalUpgradeProcess.updateSchemaVersion(connection, version);
 			}
+		}
+	}
+
+	private void _testUnsuccessfulUpgradeByMissingModuleUpgrade(
+			String autorun, String status)
+		throws Exception {
+
+		PropsUtil.set("upgrade.database.auto.run", autorun);
+
+		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			UpgradeStepRegistrator.class,
+			new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
+
+		Release release = _releaseLocalService.fetchRelease(
+			bundle.getSymbolicName());
+
+		try {
+			release.setSchemaVersion("0.0.0");
+
+			release = _releaseLocalService.updateRelease(release);
+
+			Assert.assertEquals(status, _releaseManager.getStatus());
+			Assert.assertFalse(
+				Validator.isBlank(
+					_releaseManager.getShortStatusMessage(false)));
+			Assert.assertFalse(
+				Validator.isBlank(_releaseManager.getStatusMessage(false)));
+		}
+		finally {
+			_releaseLocalService.deleteRelease(release);
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -136,7 +136,7 @@ public class UpgradeRecorderTest {
 			}
 		}
 
-		Assert.assertEquals("failure", _getResult());
+		Assert.assertEquals("unresolved", _getResult());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -245,9 +245,6 @@ public class DBUpgrader {
 		if (isUpgradeDatabaseAutoRunEnabled()) {
 			IndexUpdaterUtil.updateAllIndexes();
 		}
-		else {
-			IndexUpdaterUtil.updatePortalIndexes();
-		}
 	}
 
 	public static void upgradePortal() throws Exception {

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -242,7 +242,12 @@ public class DBUpgrader {
 
 		_registerModuleServiceLifecycle("portlets.initialized");
 
-		IndexUpdaterUtil.updateAllIndexes();
+		if (isUpgradeDatabaseAutoRunEnabled()) {
+			IndexUpdaterUtil.updateAllIndexes();
+		}
+		else {
+			IndexUpdaterUtil.updatePortalIndexes();
+		}
 	}
 
 	public static void upgradePortal() throws Exception {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -207,9 +207,7 @@ public class DBInspector {
 			while (resultSet.next()) {
 				if (Objects.equals(
 						normalizeName(indexName, databaseMetaData),
-						normalizeName(
-							resultSet.getString("index_name"),
-							databaseMetaData))) {
+						resultSet.getString("index_name"))) {
 
 					return true;
 				}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -207,7 +207,9 @@ public class DBInspector {
 			while (resultSet.next()) {
 				if (Objects.equals(
 						normalizeName(indexName, databaseMetaData),
-						resultSet.getString("index_name"))) {
+						normalizeName(
+							resultSet.getString("index_name"),
+							databaseMetaData))) {
 
 					return true;
 				}


### PR DESCRIPTION
Hi @IstvanD, good work!!!

Please check my last commits:
- For the first one, there is no need to normalize the value returned by the database, it should already be normalized. I will run the tests suites to make sure of that, but I tested locally with MySQL and Postgre.
- For the second one, after talking with Alberto, we do not need the `else` to call the `updatePortalIndexes` method, as it has already been called when updating the portal. The thing is that by calling it, we are reindexing again the portal, because the method does not check the `IndexUpdaterUtil._processedServletContextNames` set. If you take a look to the `updateAllIndexes` method, it checks that set, so the portal is not reindexed again.

Meanwhile the test suites run, please check in your previous [PR](https://github.com/liferay-database-infra/liferay-portal/pull/1841) if any functional test needs to be updated because of the status change. I will write you on Slack to give you some guidance on that.

Thanks!!