### PR TITLE
LPD-18246 Attempt of index creation on non-existing module tables and columns when upgrade.database.auto.run is false 

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.osgi.debug.SystemChecker;
+import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.executor.UpgradeExecutor;
 import com.liferay.portal.upgrade.internal.graph.ReleaseGraphManager;
@@ -100,10 +101,15 @@ public class ReleaseManagerImpl implements ReleaseManager {
 	@Override
 	public String getStatus() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
-			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
-				_isPendingModuleUpgrades()) {
-
+			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
 				return "failure";
+			}
+			else if (_isPendingModuleUpgrades()) {
+				if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
+					return "failure";
+				}
+
+				return "unresolved";
 			}
 		}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/AutoUpgradeProcessTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -43,13 +44,14 @@ public class AutoUpgradeProcessTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_originalUpgradeDatabaseAutoRun = PropsUtil.get(
-			"upgrade.database.auto.run");
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		PropsUtil.set(
-			"upgrade.database.auto.run", _originalUpgradeDatabaseAutoRun);
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN,
+			_originalUpgradeDatabaseAutoRun);
 
 		_upgradeProcessRun = false;
 
@@ -67,7 +69,7 @@ public class AutoUpgradeProcessTest {
 
 	@Test
 	public void testInitializationWhenAutoUpgradeDisabled() throws Exception {
-		PropsUtil.set("upgrade.database.auto.run", "false");
+		PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "false");
 
 		Assert.assertEquals(
 			"2.0.0", _registerNewUpgradeProcess().getSchemaVersion());
@@ -83,7 +85,7 @@ public class AutoUpgradeProcessTest {
 			_upgradeExecutor, "_portalUpgraded", false);
 
 		try {
-			PropsUtil.set("upgrade.database.auto.run", "false");
+			PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "false");
 
 			Assert.assertNull(_registerNewUpgradeProcess());
 		}
@@ -99,7 +101,7 @@ public class AutoUpgradeProcessTest {
 
 		_releaseLocalService.addRelease(_SERVLET_CONTEXT_NAME, "1.0.0");
 
-		PropsUtil.set("upgrade.database.auto.run", "false");
+		PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "false");
 
 		Assert.assertEquals(
 			"1.0.0", _registerNewUpgradeProcess().getSchemaVersion());
@@ -111,7 +113,7 @@ public class AutoUpgradeProcessTest {
 	public void testUpgradeProcessWhenAutoUpgradeEnabled() throws Exception {
 		_releaseLocalService.addRelease(_SERVLET_CONTEXT_NAME, "1.0.0");
 
-		PropsUtil.set("upgrade.database.auto.run", "true");
+		PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "true");
 
 		Assert.assertEquals(
 			"2.0.0", _registerNewUpgradeProcess().getSchemaVersion());

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -83,7 +83,16 @@ public class DBUpgraderTest {
 	}
 
 	@Test
-	public void testRegenerateModuleIndexes() throws Exception {
+	public void testUpgrade() throws Exception {
+		_updatePortalRelease(
+			ReleaseInfo.RELEASE_7_1_0_BUILD_NUMBER,
+			ReleaseConstants.STATE_GOOD);
+
+		DBUpgrader.upgradePortal();
+	}
+
+	@Test
+	public void testUpgradeModuleIndexes() throws Exception {
 		_db.runSQL("create index IX_TEST on Lock_ (createDate)");
 
 		PropsUtil.set("upgrade.database.auto.run", "false");
@@ -97,15 +106,6 @@ public class DBUpgraderTest {
 		DBUpgrader.upgradeModules(false);
 
 		Assert.assertFalse(_dbInspector.hasIndex("Lock_", "IX_TEST"));
-	}
-
-	@Test
-	public void testUpgrade() throws Exception {
-		_updatePortalRelease(
-			ReleaseInfo.RELEASE_7_1_0_BUILD_NUMBER,
-			ReleaseConstants.STATE_GOOD);
-
-		DBUpgrader.upgradePortal();
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -89,7 +89,7 @@ public class DBUpgraderTest {
 			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 
 		try {
-			PropsUtil.set("upgrade.database.auto.run", "false");
+			PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "false");
 
 			DBUpgrader.upgradeModules(false);
 
@@ -97,7 +97,7 @@ public class DBUpgraderTest {
 
 			Assert.assertTrue(dbInspector.hasIndex("Lock_", "IX_TEST"));
 
-			PropsUtil.set("upgrade.database.auto.run", "true");
+			PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "true");
 
 			DBUpgrader.upgradeModules(false);
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -7,7 +7,13 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.db.DBResourceUtil;
+import com.liferay.portal.db.index.IndexUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -16,10 +22,14 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
+import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-import java.sql.SQLException;
+
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -29,6 +39,11 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.util.tracker.BundleTracker;
 
 /**
  * @author Luis Ortiz
@@ -42,7 +57,7 @@ public class DBUpgraderTest {
 		new LiferayIntegrationTestRule();
 
 	@BeforeClass
-	public static void setUpClass() throws SQLException {
+	public static void setUpClass() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
 			_currentBuildNumber = PortalUpgradeProcess.getCurrentBuildNumber(
 				connection);
@@ -52,17 +67,77 @@ public class DBUpgraderTest {
 
 		_upgrading = ReflectionTestUtil.getAndSetFieldValue(
 			StartupHelperUtil.class, "_upgrading", true);
+
+		Bundle bundle = FrameworkUtil.getBundle(DBUpgraderTest.class);
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+
+		BundleTracker<Bundle> bundleTracker = new BundleTracker<Bundle>(
+			bundle.getBundleContext(), Bundle.ACTIVE, null) {
+
+			@Override
+			public Bundle addingBundle(Bundle bundle, BundleEvent event) {
+				String symbolicName = bundle.getSymbolicName();
+
+				if (symbolicName.equals("com.liferay.portal.lock.service")) {
+					_moduleBundle = bundle;
+
+					countDownLatch.countDown();
+
+					close();
+				}
+
+				return null;
+			}
+
+		};
+
+		bundleTracker.open();
+
+		_connection = DataAccess.getConnection();
+
+		_db = DBManagerUtil.getDB();
+
+		_dbInspector = new DBInspector(_connection);
+
+		_processedServletContextNames = ReflectionTestUtil.getFieldValue(
+			IndexUpdaterUtil.class, "_processedServletContextNames");
+
+		countDownLatch.await(10, TimeUnit.SECONDS);
+
+		_initIndexNames();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		ReflectionTestUtil.setFieldValue(
 			StartupHelperUtil.class, "_upgrading", _upgrading);
+		DataAccess.cleanUp(_connection);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		_updatePortalRelease(_currentBuildNumber, _currentState);
+		_processedServletContextNames.clear();
+	}
+
+	@Test
+	public void testRegenerateModuleIndexes() throws Exception {
+		_dropIndex(_moduleTableIndexName, _moduleIndexName);
+
+		PropsUtil.set("upgrade.database.auto.run", "false");
+
+		DBUpgrader.upgradeModules(false);
+
+		Assert.assertFalse(
+			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
+
+		PropsUtil.set("upgrade.database.auto.run", "true");
+
+		DBUpgrader.upgradeModules(false);
+
+		Assert.assertTrue(
+			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
 	}
 
 	@Test
@@ -98,6 +173,31 @@ public class DBUpgraderTest {
 		DBUpgrader.upgradePortal();
 	}
 
+	private static String _getIndexName(String indexesSQL) {
+		return indexesSQL.substring(
+			indexesSQL.indexOf("IX_"), indexesSQL.indexOf(" on"));
+	}
+
+	private static String _getTableIndexName(String indexesSQL) {
+		return indexesSQL.substring(
+			indexesSQL.indexOf("on ") + 3, indexesSQL.indexOf(" ("));
+	}
+
+	private static void _initIndexNames() throws Exception {
+		String moduleIndexesSQL = DBResourceUtil.getModuleIndexesSQL(
+			_moduleBundle);
+
+		_moduleIndexName = _getIndexName(moduleIndexesSQL);
+		_moduleTableIndexName = _getTableIndexName(moduleIndexesSQL);
+	}
+
+	private void _dropIndex(String tableName, String indexName)
+		throws Exception {
+
+		_db.runSQL(
+			StringBundler.concat("drop index ", indexName, " on ", tableName));
+	}
+
 	private void _updatePortalRelease(int buildNumber, int state)
 		throws Exception {
 
@@ -119,8 +219,15 @@ public class DBUpgraderTest {
 		dclSingleton.destroy(null);
 	}
 
+	private static Connection _connection;
 	private static int _currentBuildNumber;
 	private static int _currentState;
+	private static DB _db;
+	private static DBInspector _dbInspector;
+	private static Bundle _moduleBundle;
+	private static String _moduleIndexName;
+	private static String _moduleTableIndexName;
+	private static Set<String> _processedServletContextNames;
 	private static boolean _upgrading;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -7,7 +7,6 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
-import com.liferay.portal.db.index.IndexUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
@@ -24,8 +23,6 @@ import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
-
-import java.util.Set;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -64,9 +61,6 @@ public class DBUpgraderTest {
 		_db = DBManagerUtil.getDB();
 
 		_dbInspector = new DBInspector(_connection);
-
-		_processedServletContextNames = ReflectionTestUtil.getFieldValue(
-			IndexUpdaterUtil.class, "_processedServletContextNames");
 	}
 
 	@AfterClass
@@ -79,7 +73,6 @@ public class DBUpgraderTest {
 	@After
 	public void tearDown() throws Exception {
 		_updatePortalRelease(_currentBuildNumber, _currentState);
-		_processedServletContextNames.clear();
 	}
 
 	@Test
@@ -158,7 +151,6 @@ public class DBUpgraderTest {
 	private static int _currentState;
 	private static DB _db;
 	private static DBInspector _dbInspector;
-	private static Set<String> _processedServletContextNames;
 	private static boolean _upgrading;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -7,8 +7,6 @@ package com.liferay.portal.upgrade.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.db.DBResourceUtil;
 import com.liferay.portal.db.index.IndexUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -28,8 +26,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -39,11 +35,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleEvent;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.util.tracker.BundleTracker;
 
 /**
  * @author Luis Ortiz
@@ -68,32 +59,6 @@ public class DBUpgraderTest {
 		_upgrading = ReflectionTestUtil.getAndSetFieldValue(
 			StartupHelperUtil.class, "_upgrading", true);
 
-		Bundle bundle = FrameworkUtil.getBundle(DBUpgraderTest.class);
-
-		CountDownLatch countDownLatch = new CountDownLatch(1);
-
-		BundleTracker<Bundle> bundleTracker = new BundleTracker<Bundle>(
-			bundle.getBundleContext(), Bundle.ACTIVE, null) {
-
-			@Override
-			public Bundle addingBundle(Bundle bundle, BundleEvent event) {
-				String symbolicName = bundle.getSymbolicName();
-
-				if (symbolicName.equals("com.liferay.portal.lock.service")) {
-					_moduleBundle = bundle;
-
-					countDownLatch.countDown();
-
-					close();
-				}
-
-				return null;
-			}
-
-		};
-
-		bundleTracker.open();
-
 		_connection = DataAccess.getConnection();
 
 		_db = DBManagerUtil.getDB();
@@ -102,10 +67,6 @@ public class DBUpgraderTest {
 
 		_processedServletContextNames = ReflectionTestUtil.getFieldValue(
 			IndexUpdaterUtil.class, "_processedServletContextNames");
-
-		countDownLatch.await(10, TimeUnit.SECONDS);
-
-		_initIndexNames();
 	}
 
 	@AfterClass
@@ -123,21 +84,19 @@ public class DBUpgraderTest {
 
 	@Test
 	public void testRegenerateModuleIndexes() throws Exception {
-		_dropIndex(_moduleTableIndexName, _moduleIndexName);
+		_db.runSQL("create index IX_TEST on Lock_ (createDate)");
 
 		PropsUtil.set("upgrade.database.auto.run", "false");
 
 		DBUpgrader.upgradeModules(false);
 
-		Assert.assertFalse(
-			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
+		Assert.assertTrue(_dbInspector.hasIndex("Lock_", "IX_TEST"));
 
 		PropsUtil.set("upgrade.database.auto.run", "true");
 
 		DBUpgrader.upgradeModules(false);
 
-		Assert.assertTrue(
-			_dbInspector.hasIndex(_moduleTableIndexName, _moduleIndexName));
+		Assert.assertFalse(_dbInspector.hasIndex("Lock_", "IX_TEST"));
 	}
 
 	@Test
@@ -173,31 +132,6 @@ public class DBUpgraderTest {
 		DBUpgrader.upgradePortal();
 	}
 
-	private static String _getIndexName(String indexesSQL) {
-		return indexesSQL.substring(
-			indexesSQL.indexOf("IX_"), indexesSQL.indexOf(" on"));
-	}
-
-	private static String _getTableIndexName(String indexesSQL) {
-		return indexesSQL.substring(
-			indexesSQL.indexOf("on ") + 3, indexesSQL.indexOf(" ("));
-	}
-
-	private static void _initIndexNames() throws Exception {
-		String moduleIndexesSQL = DBResourceUtil.getModuleIndexesSQL(
-			_moduleBundle);
-
-		_moduleIndexName = _getIndexName(moduleIndexesSQL);
-		_moduleTableIndexName = _getTableIndexName(moduleIndexesSQL);
-	}
-
-	private void _dropIndex(String tableName, String indexName)
-		throws Exception {
-
-		_db.runSQL(
-			StringBundler.concat("drop index ", indexName, " on ", tableName));
-	}
-
 	private void _updatePortalRelease(int buildNumber, int state)
 		throws Exception {
 
@@ -224,9 +158,6 @@ public class DBUpgraderTest {
 	private static int _currentState;
 	private static DB _db;
 	private static DBInspector _dbInspector;
-	private static Bundle _moduleBundle;
-	private static String _moduleIndexName;
-	private static String _moduleTableIndexName;
 	private static Set<String> _processedServletContextNames;
 	private static boolean _upgrading;
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -46,21 +46,15 @@ public class DBUpgraderTest {
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
-		try (Connection connection = DataAccess.getConnection()) {
-			_currentBuildNumber = PortalUpgradeProcess.getCurrentBuildNumber(
-				connection);
+		_connection = DataAccess.getConnection();
 
-			_currentState = PortalUpgradeProcess.getCurrentState(connection);
-		}
+		_currentBuildNumber = PortalUpgradeProcess.getCurrentBuildNumber(
+			_connection);
+
+		_currentState = PortalUpgradeProcess.getCurrentState(_connection);
 
 		_upgrading = ReflectionTestUtil.getAndSetFieldValue(
 			StartupHelperUtil.class, "_upgrading", true);
-
-		_connection = DataAccess.getConnection();
-
-		_db = DBManagerUtil.getDB();
-
-		_dbInspector = new DBInspector(_connection);
 	}
 
 	@AfterClass
@@ -86,19 +80,23 @@ public class DBUpgraderTest {
 
 	@Test
 	public void testUpgradeModuleIndexes() throws Exception {
-		_db.runSQL("create index IX_TEST on Lock_ (createDate)");
+		DB db = DBManagerUtil.getDB();
+
+		db.runSQL("create index IX_TEST on Lock_ (createDate)");
 
 		PropsUtil.set("upgrade.database.auto.run", "false");
 
 		DBUpgrader.upgradeModules(false);
 
-		Assert.assertTrue(_dbInspector.hasIndex("Lock_", "IX_TEST"));
+		DBInspector dbInspector = new DBInspector(_connection);
+
+		Assert.assertTrue(dbInspector.hasIndex("Lock_", "IX_TEST"));
 
 		PropsUtil.set("upgrade.database.auto.run", "true");
 
 		DBUpgrader.upgradeModules(false);
 
-		Assert.assertFalse(_dbInspector.hasIndex("Lock_", "IX_TEST"));
+		Assert.assertFalse(dbInspector.hasIndex("Lock_", "IX_TEST"));
 	}
 
 	@Test
@@ -149,8 +147,6 @@ public class DBUpgraderTest {
 	private static Connection _connection;
 	private static int _currentBuildNumber;
 	private static int _currentState;
-	private static DB _db;
-	private static DBInspector _dbInspector;
 	private static boolean _upgrading;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
@@ -84,19 +85,28 @@ public class DBUpgraderTest {
 
 		db.runSQL("create index IX_TEST on Lock_ (createDate)");
 
-		PropsUtil.set("upgrade.database.auto.run", "false");
+		String upgradeDatabaseAutoRun = PropsUtil.get(
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 
-		DBUpgrader.upgradeModules(false);
+		try {
+			PropsUtil.set("upgrade.database.auto.run", "false");
 
-		DBInspector dbInspector = new DBInspector(_connection);
+			DBUpgrader.upgradeModules(false);
 
-		Assert.assertTrue(dbInspector.hasIndex("Lock_", "IX_TEST"));
+			DBInspector dbInspector = new DBInspector(_connection);
 
-		PropsUtil.set("upgrade.database.auto.run", "true");
+			Assert.assertTrue(dbInspector.hasIndex("Lock_", "IX_TEST"));
 
-		DBUpgrader.upgradeModules(false);
+			PropsUtil.set("upgrade.database.auto.run", "true");
 
-		Assert.assertFalse(dbInspector.hasIndex("Lock_", "IX_TEST"));
+			DBUpgrader.upgradeModules(false);
+
+			Assert.assertFalse(dbInspector.hasIndex("Lock_", "IX_TEST"));
+		}
+		finally {
+			PropsUtil.set(
+				PropsKeys.UPGRADE_DATABASE_AUTO_RUN, upgradeDatabaseAutoRun);
+		}
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -64,14 +64,14 @@ public class ReleaseManagerTest {
 	public void testUnsuccessfulUpgradeByMissingModuleUpgrade()
 		throws Exception {
 
-		_testUnsuccessfulUpgradeByMissingModuleUpgrade("false", "unresolved");
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade(false, "unresolved");
 	}
 
 	@Test
 	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithAutorun()
 		throws Exception {
 
-		_testUnsuccessfulUpgradeByMissingModuleUpgrade("true", "failure");
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade(true, "failure");
 	}
 
 	@Test
@@ -100,10 +100,10 @@ public class ReleaseManagerTest {
 	}
 
 	private void _testUnsuccessfulUpgradeByMissingModuleUpgrade(
-			String autorun, String status)
+			boolean autorun, String status)
 		throws Exception {
 
-		PropsUtil.set("upgrade.database.auto.run", autorun);
+		PropsUtil.set("upgrade.database.auto.run", String.valueOf(autorun));
 
 		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -61,17 +61,17 @@ public class ReleaseManagerTest {
 	}
 
 	@Test
+	public void testUnsuccessfulUpgradeByMissingModuleUpgrade()
+		throws Exception {
+
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade("false", "unresolved");
+	}
+
+	@Test
 	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithAutorun()
 		throws Exception {
 
 		_testUnsuccessfulUpgradeByMissingModuleUpgrade("true", "failure");
-	}
-
-	@Test
-	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithoutAutorun()
-		throws Exception {
-
-		_testUnsuccessfulUpgradeByMissingModuleUpgrade("false", "unresolved");
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.util.PropsUtil;
 
 import java.sql.Connection;
 
@@ -60,35 +61,17 @@ public class ReleaseManagerTest {
 	}
 
 	@Test
-	public void testUnsuccessfulUpgradeByMissingModuleUpgrade()
+	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithAutorun()
 		throws Exception {
 
-		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade("true", "failure");
+	}
 
-		BundleContext bundleContext = bundle.getBundleContext();
+	@Test
+	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithoutAutorun()
+		throws Exception {
 
-		_serviceRegistration = bundleContext.registerService(
-			UpgradeStepRegistrator.class,
-			new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
-
-		Release release = _releaseLocalService.fetchRelease(
-			bundle.getSymbolicName());
-
-		try {
-			release.setSchemaVersion("0.0.0");
-
-			release = _releaseLocalService.updateRelease(release);
-
-			Assert.assertEquals("failure", _releaseManager.getStatus());
-			Assert.assertFalse(
-				Validator.isBlank(
-					_releaseManager.getShortStatusMessage(false)));
-			Assert.assertFalse(
-				Validator.isBlank(_releaseManager.getStatusMessage(false)));
-		}
-		finally {
-			_releaseLocalService.deleteRelease(release);
-		}
+		_testUnsuccessfulUpgradeByMissingModuleUpgrade("false", "unresolved");
 	}
 
 	@Test
@@ -113,6 +96,40 @@ public class ReleaseManagerTest {
 			finally {
 				PortalUpgradeProcess.updateSchemaVersion(connection, version);
 			}
+		}
+	}
+
+	private void _testUnsuccessfulUpgradeByMissingModuleUpgrade(
+			String autorun, String status)
+		throws Exception {
+
+		PropsUtil.set("upgrade.database.auto.run", autorun);
+
+		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_serviceRegistration = bundleContext.registerService(
+			UpgradeStepRegistrator.class,
+			new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
+
+		Release release = _releaseLocalService.fetchRelease(
+			bundle.getSymbolicName());
+
+		try {
+			release.setSchemaVersion("0.0.0");
+
+			release = _releaseLocalService.updateRelease(release);
+
+			Assert.assertEquals(status, _releaseManager.getStatus());
+			Assert.assertFalse(
+				Validator.isBlank(
+					_releaseManager.getShortStatusMessage(false)));
+			Assert.assertFalse(
+				Validator.isBlank(_releaseManager.getStatusMessage(false)));
+		}
+		finally {
+			_releaseLocalService.deleteRelease(release);
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.ReleaseManager;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.test.rule.Inject;
@@ -103,33 +104,43 @@ public class ReleaseManagerTest {
 			boolean autorun, String status)
 		throws Exception {
 
-		PropsUtil.set("upgrade.database.auto.run", String.valueOf(autorun));
-
-		Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		_serviceRegistration = bundleContext.registerService(
-			UpgradeStepRegistrator.class,
-			new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
-
-		Release release = _releaseLocalService.fetchRelease(
-			bundle.getSymbolicName());
+		String upgradeDatabaseAutoRun = PropsUtil.get(
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 
 		try {
-			release.setSchemaVersion("0.0.0");
+			PropsUtil.set(
+				PropsKeys.UPGRADE_DATABASE_AUTO_RUN, String.valueOf(autorun));
 
-			release = _releaseLocalService.updateRelease(release);
+			Bundle bundle = FrameworkUtil.getBundle(ReleaseManagerTest.class);
 
-			Assert.assertEquals(status, _releaseManager.getStatus());
-			Assert.assertFalse(
-				Validator.isBlank(
-					_releaseManager.getShortStatusMessage(false)));
-			Assert.assertFalse(
-				Validator.isBlank(_releaseManager.getStatusMessage(false)));
+			BundleContext bundleContext = bundle.getBundleContext();
+
+			_serviceRegistration = bundleContext.registerService(
+				UpgradeStepRegistrator.class,
+				new ReleaseManagerTest.TestUpgradeStepRegistrator(), null);
+
+			Release release = _releaseLocalService.fetchRelease(
+				bundle.getSymbolicName());
+
+			try {
+				release.setSchemaVersion("0.0.0");
+
+				release = _releaseLocalService.updateRelease(release);
+
+				Assert.assertEquals(status, _releaseManager.getStatus());
+				Assert.assertFalse(
+					Validator.isBlank(
+						_releaseManager.getShortStatusMessage(false)));
+				Assert.assertFalse(
+					Validator.isBlank(_releaseManager.getStatusMessage(false)));
+			}
+			finally {
+				_releaseLocalService.deleteRelease(release);
+			}
 		}
 		finally {
-			_releaseLocalService.deleteRelease(release);
+			PropsUtil.set(
+				PropsKeys.UPGRADE_DATABASE_AUTO_RUN, upgradeDatabaseAutoRun);
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeManagerTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.upgrade.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsUtil;
@@ -47,13 +48,14 @@ public class UpgradeManagerTest {
 	@BeforeClass
 	public static void setUpClass() {
 		_originalUpgradeDatabaseAutoRun = PropsUtil.get(
-			"upgrade.database.auto.run");
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
 		PropsUtil.set(
-			"upgrade.database.auto.run", _originalUpgradeDatabaseAutoRun);
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN,
+			_originalUpgradeDatabaseAutoRun);
 	}
 
 	@After
@@ -144,7 +146,7 @@ public class UpgradeManagerTest {
 		promise.getValue();
 
 		PropsUtil.set(
-			"upgrade.database.auto.run",
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN,
 			String.valueOf(upgradeDatabaseAutoRun));
 
 		promise = _serviceComponentRuntime.enableComponent(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeModulesFactoryTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeModulesFactoryTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.upgrade.util.UpgradeModulesFactory;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -47,15 +48,16 @@ public class UpgradeModulesFactoryTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_originalUpgradeDatabaseAutoRun = PropsUtil.get(
-			"upgrade.database.auto.run");
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 
-		PropsUtil.set("upgrade.database.auto.run", "true");
+		PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "true");
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
 		PropsUtil.set(
-			"upgrade.database.auto.run", _originalUpgradeDatabaseAutoRun);
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN,
+			_originalUpgradeDatabaseAutoRun);
 	}
 
 	@After

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -136,7 +136,7 @@ public class UpgradeRecorderTest {
 			}
 		}
 
-		Assert.assertEquals("failure", _getResult());
+		Assert.assertEquals("unresolved", _getResult());
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRegistryTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRegistryTest.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.ReleaseLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -42,15 +43,16 @@ public class UpgradeRegistryTest {
 	@Before
 	public void setUp() throws Exception {
 		_originalUpgradeDatabaseAutoRun = PropsUtil.get(
-			"upgrade.database.auto.run");
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 
-		PropsUtil.set("upgrade.database.auto.run", "true");
+		PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "true");
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		PropsUtil.set(
-			"upgrade.database.auto.run", _originalUpgradeDatabaseAutoRun);
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN,
+			_originalUpgradeDatabaseAutoRun);
 
 		if (_serviceRegistration != null) {
 			_serviceRegistration.unregister();

--- a/modules/test/external-data-source-test-controller-test/src/testIntegration/java/com/liferay/external/data/source/test/controller/test/ExternalDataSourceControllerTest.java
+++ b/modules/test/external-data-source-test-controller-test/src/testIntegration/java/com/liferay/external/data/source/test/controller/test/ExternalDataSourceControllerTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsUtil;
@@ -76,16 +77,17 @@ public class ExternalDataSourceControllerTest {
 		_apiBundle.start();
 
 		String originalUpgradeDatabaseAutoRun = PropsUtil.get(
-			"upgrade.database.auto.run");
+			PropsKeys.UPGRADE_DATABASE_AUTO_RUN);
 
 		try {
-			PropsUtil.set("upgrade.database.auto.run", "true");
+			PropsUtil.set(PropsKeys.UPGRADE_DATABASE_AUTO_RUN, "true");
 
 			_serviceBundle.start();
 		}
 		finally {
 			PropsUtil.set(
-				"upgrade.database.auto.run", originalUpgradeDatabaseAutoRun);
+				PropsKeys.UPGRADE_DATABASE_AUTO_RUN,
+				originalUpgradeDatabaseAutoRun);
 		}
 	}
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -124,7 +124,7 @@ definition {
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
 
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-status -Dupgrade.status=failure");
+		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-status -Dupgrade.status=unresolved");
 
 		var schemaVersion = ValidateSmokeUpgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName = 'com.liferay.journal.web';");
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -245,9 +245,6 @@ public class DBUpgrader {
 		if (isUpgradeDatabaseAutoRunEnabled()) {
 			IndexUpdaterUtil.updateAllIndexes();
 		}
-		else {
-			IndexUpdaterUtil.updatePortalIndexes();
-		}
 	}
 
 	public static void upgradePortal() throws Exception {

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -242,7 +242,12 @@ public class DBUpgrader {
 
 		_registerModuleServiceLifecycle("portlets.initialized");
 
-		IndexUpdaterUtil.updateAllIndexes();
+		if (isUpgradeDatabaseAutoRunEnabled()) {
+			IndexUpdaterUtil.updateAllIndexes();
+		}
+		else {
+			IndexUpdaterUtil.updatePortalIndexes();
+		}
 	}
 
 	public static void upgradePortal() throws Exception {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -207,9 +207,7 @@ public class DBInspector {
 			while (resultSet.next()) {
 				if (Objects.equals(
 						normalizeName(indexName, databaseMetaData),
-						normalizeName(
-							resultSet.getString("index_name"),
-							databaseMetaData))) {
+						resultSet.getString("index_name"))) {
 
 					return true;
 				}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -207,7 +207,9 @@ public class DBInspector {
 			while (resultSet.next()) {
 				if (Objects.equals(
 						normalizeName(indexName, databaseMetaData),
-						resultSet.getString("index_name"))) {
+						normalizeName(
+							resultSet.getString("index_name"),
+							databaseMetaData))) {
 
 					return true;
 				}


### PR DESCRIPTION
@IstvanD and @LuisOrtiz89 I made a few minor changes, check especially this one:
https://github.com/liferay-database-infra/liferay-portal/pull/1876/commits/6fc6062b9e00c10a914fd1cdd69c6a3b6b1db162

Thanks!
