### PR TITLE
LPD-23737 Executor Service does not use the correct instance when performing actions in a paritioned environment.

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -12,7 +12,10 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
@@ -555,6 +558,49 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 			DBPartitionUtil.checkDatabasePartitionSchemaNamePrefix();
 		}
+	}
+
+	@Test
+	public void testParallelWithDBPartitionEnabled() throws Exception {
+		CompanyThreadLocal.setCompanyId(COMPANY_IDS[0]);
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_classNameLocalService.getActionableDynamicQuery();
+
+		ClassName className1 = _classNameLocalService.addClassName(
+			RandomTestUtil.randomString());
+
+		String expectedClassNameValue = RandomTestUtil.randomString();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property classNameIdProperty = PropertyFactoryUtil.forName(
+					"classNameId");
+
+				dynamicQuery.add(
+					classNameIdProperty.eq(className1.getClassNameId()));
+			});
+
+		ActionableDynamicQuery.PerformActionMethod<?> performActionMethod =
+			(ClassName className) -> {
+				ClassName className2 = _classNameLocalService.getClassName(
+					className1.getClassNameId());
+
+				className2.setValue(expectedClassNameValue);
+
+				_classNameLocalService.updateClassName(className2);
+			};
+
+		actionableDynamicQuery.setPerformActionMethod(performActionMethod);
+
+		actionableDynamicQuery.setParallel(true);
+
+		actionableDynamicQuery.performActions();
+
+		ClassName className2 = _classNameLocalService.getClassName(
+			className1.getClassNameId());
+
+		Assert.assertEquals(expectedClassNameValue, className2.getValue());
 	}
 
 	@Test

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/orm/DefaultActionableDynamicQuery.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/orm/DefaultActionableDynamicQuery.java
@@ -6,11 +6,13 @@
 package com.liferay.portal.kernel.dao.orm;
 
 import com.liferay.petra.executor.PortalExecutorManager;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
@@ -274,15 +276,22 @@ public class DefaultActionableDynamicQuery implements ActionableDynamicQuery {
 					DefaultActionableDynamicQuery.class.getName());
 
 			if (_parallel && (executorService != null)) {
+				long companyId = CompanyThreadLocal.getCompanyId();
+
 				List<Future<Void>> futures = new ArrayList<>(objects.size());
 
 				for (final Object object : objects) {
 					futures.add(
 						executorService.submit(
 							() -> {
-								performAction(object);
+								try (SafeCloseable safeCloseable =
+										CompanyThreadLocal.setWithSafeCloseable(
+											companyId)) {
 
-								return null;
+									performAction(object);
+
+									return null;
+								}
 							}));
 				}
 


### PR DESCRIPTION
Issue:
Executor Service opens a new thread with a companyId set to 0, causing failures when fetching from the database.

Solution:
Use safe closable when performing the action.