### PR TITLE
LPD-23830 Clean up companyId references in BackgroundTask

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/background/task/BaseOptimizeImagesBackgroundTaskExecutor.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/background/task/BaseOptimizeImagesBackgroundTaskExecutor.java
@@ -12,7 +12,6 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.backgroundtask.BaseBackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.backgroundtask.display.BackgroundTaskDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.io.Serializable;
 
@@ -39,11 +38,8 @@ public abstract class BaseOptimizeImagesBackgroundTaskExecutor
 
 		String configurationEntryUuid = (String)taskContextMap.get(
 			AMOptimizeImagesBackgroundTaskConstants.CONFIGURATION_ENTRY_UUID);
-		long companyId = GetterUtil.getLong(
-			taskContextMap.get(
-				AMOptimizeImagesBackgroundTaskConstants.COMPANY_ID));
 
-		optimizeImages(configurationEntryUuid, companyId);
+		optimizeImages(configurationEntryUuid, backgroundTask.getCompanyId());
 
 		return BackgroundTaskResult.SUCCESS;
 	}

--- a/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/action/OptimizeImagesMVCActionCommand.java
+++ b/modules/apps/adaptive-media/adaptive-media-web/src/main/java/com/liferay/adaptive/media/web/internal/portlet/action/OptimizeImagesMVCActionCommand.java
@@ -60,25 +60,20 @@ public class OptimizeImagesMVCActionCommand extends BaseMVCActionCommand {
 
 		if (Validator.isNotNull(entryUuid)) {
 			_optimizeImagesSingleConfiguration(
-				themeDisplay.getUserId(), themeDisplay.getCompanyId(), jobName,
-				entryUuid);
+				themeDisplay.getUserId(), jobName, entryUuid);
 		}
 		else {
-			_optimizeImages(
-				themeDisplay.getUserId(), themeDisplay.getCompanyId(), jobName);
+			_optimizeImages(themeDisplay.getUserId(), jobName);
 		}
 
 		SessionMessages.add(actionRequest, "optimizeImages");
 	}
 
-	private BackgroundTask _optimizeImages(
-			long userId, long companyId, String jobName)
+	private BackgroundTask _optimizeImages(long userId, String jobName)
 		throws Exception {
 
 		Map<String, Serializable> taskContextMap =
 			HashMapBuilder.<String, Serializable>put(
-				AMOptimizeImagesBackgroundTaskConstants.COMPANY_ID, companyId
-			).put(
 				BackgroundTaskContextMapConstants.DELETE_ON_SUCCESS, true
 			).build();
 
@@ -97,14 +92,11 @@ public class OptimizeImagesMVCActionCommand extends BaseMVCActionCommand {
 	}
 
 	private BackgroundTask _optimizeImagesSingleConfiguration(
-			long userId, long companyId, String jobName,
-			String configurationEntryUuid)
+			long userId, String jobName, String configurationEntryUuid)
 		throws Exception {
 
 		Map<String, Serializable> taskContextMap =
 			HashMapBuilder.<String, Serializable>put(
-				AMOptimizeImagesBackgroundTaskConstants.COMPANY_ID, companyId
-			).put(
 				AMOptimizeImagesBackgroundTaskConstants.
 					CONFIGURATION_ENTRY_UUID,
 				configurationEntryUuid

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/DLOpenerGoogleDriveManager.java
@@ -276,9 +276,6 @@ public class DLOpenerGoogleDriveManager {
 			).put(
 				GoogleDriveBackgroundTaskConstants.CMD, cmd
 			).put(
-				GoogleDriveBackgroundTaskConstants.COMPANY_ID,
-				fileEntry.getCompanyId()
-			).put(
 				GoogleDriveBackgroundTaskConstants.FILE_ENTRY_ID,
 				fileEntry.getFileEntryId()
 			).put(

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/background/task/UploadGoogleDriveDocumentBackgroundTaskExecutor.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/background/task/UploadGoogleDriveDocumentBackgroundTaskExecutor.java
@@ -77,8 +77,7 @@ public class UploadGoogleDriveDocumentBackgroundTaskExecutor
 		Map<String, Serializable> taskContextMap =
 			backgroundTask.getTaskContextMap();
 
-		long companyId = GetterUtil.getLong(
-			taskContextMap.get(GoogleDriveBackgroundTaskConstants.COMPANY_ID));
+		long companyId = backgroundTask.getCompanyId();
 		long fileEntryId = GetterUtil.getLong(
 			taskContextMap.get(
 				GoogleDriveBackgroundTaskConstants.FILE_ENTRY_ID));
@@ -89,6 +88,7 @@ public class UploadGoogleDriveDocumentBackgroundTaskExecutor
 
 		String cmd = (String)taskContextMap.get(
 			GoogleDriveBackgroundTaskConstants.CMD);
+
 		long userId = GetterUtil.getLong(
 			taskContextMap.get(GoogleDriveBackgroundTaskConstants.USER_ID));
 

--- a/modules/apps/document-library/document-library-preview-api/src/main/java/com/liferay/document/library/preview/background/task/BasePreviewBackgroundTaskExecutor.java
+++ b/modules/apps/document-library/document-library-preview-api/src/main/java/com/liferay/document/library/preview/background/task/BasePreviewBackgroundTaskExecutor.java
@@ -19,10 +19,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
-
-import java.io.Serializable;
 
 import java.util.Map;
 import java.util.function.Consumer;
@@ -44,13 +41,8 @@ public abstract class BasePreviewBackgroundTaskExecutor
 	public BackgroundTaskResult execute(BackgroundTask backgroundTask)
 		throws Exception {
 
-		Map<String, Serializable> taskContextMap =
-			backgroundTask.getTaskContextMap();
-
-		long companyId = GetterUtil.getLong(taskContextMap.get("companyId"));
-
 		try {
-			generatePreviews(companyId);
+			generatePreviews(backgroundTask.getCompanyId());
 		}
 		catch (PortalException portalException) {
 			_log.error(portalException);

--- a/modules/apps/portal-background-task/portal-background-task-service/bnd.bnd
+++ b/modules/apps/portal-background-task/portal-background-task-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.portal.kernel.backgroundtask.display;version="[2.0.0,9999.0.0)",\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.0.0
+Liferay-Require-SchemaVersion: 2.0.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskThreadLocalManagerImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskThreadLocalManagerImpl.java
@@ -41,13 +41,13 @@ public class BackgroundTaskThreadLocalManagerImpl
 
 	@Override
 	public void deserializeThreadLocals(
-		Map<String, Serializable> taskContextMap) {
+		Map<String, Serializable> taskContextMap, long companyId) {
 
 		Map<String, Serializable> threadLocalValues =
 			(Map<String, Serializable>)taskContextMap.get(
 				KEY_THREAD_LOCAL_VALUES);
 
-		setThreadLocalValues(threadLocalValues);
+		setThreadLocalValues(threadLocalValues, companyId);
 	}
 
 	@Override
@@ -56,7 +56,6 @@ public class BackgroundTaskThreadLocalManagerImpl
 
 		threadLocalValues.put(
 			"clusterInvoke", ClusterInvokeThreadLocal.isEnabled());
-		threadLocalValues.put("companyId", CompanyThreadLocal.getCompanyId());
 		threadLocalValues.put(
 			"defaultLocale", LocaleThreadLocal.getDefaultLocale());
 		threadLocalValues.put("groupId", GroupThreadLocal.getGroupId());
@@ -92,13 +91,11 @@ public class BackgroundTaskThreadLocalManagerImpl
 
 	@Override
 	public void setThreadLocalValues(
-		Map<String, Serializable> threadLocalValues) {
+		Map<String, Serializable> threadLocalValues, long companyId) {
 
 		if (MapUtil.isEmpty(threadLocalValues)) {
 			return;
 		}
-
-		long companyId = GetterUtil.getLong(threadLocalValues.get("companyId"));
 
 		if (companyId > 0) {
 			CompanyThreadLocal.setCompanyId(_requireCompany(companyId));

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutor.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/ThreadLocalAwareBackgroundTaskExecutor.java
@@ -45,10 +45,12 @@ public class ThreadLocalAwareBackgroundTaskExecutor
 		Map<String, Serializable> threadLocalValues =
 			_backgroundTaskThreadLocalManager.getThreadLocalValues();
 
+		long companyId = backgroundTask.getCompanyId();
+
 		try {
 			try {
 				_backgroundTaskThreadLocalManager.deserializeThreadLocals(
-					backgroundTask.getTaskContextMap());
+					backgroundTask.getTaskContextMap(), companyId);
 			}
 			catch (StaleBackgroundTaskException staleBackgroundTaskException) {
 				if (_log.isInfoEnabled()) {
@@ -64,7 +66,7 @@ public class ThreadLocalAwareBackgroundTaskExecutor
 		}
 		finally {
 			_backgroundTaskThreadLocalManager.setThreadLocalValues(
-				threadLocalValues);
+				threadLocalValues, companyId);
 		}
 	}
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/registry/BackgroundTaskServiceUpgradeStepRegistrator.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/registry/BackgroundTaskServiceUpgradeStepRegistrator.java
@@ -8,11 +8,14 @@ package com.liferay.portal.background.task.internal.upgrade.registry;
 import com.liferay.portal.background.task.internal.upgrade.v1_0_0.SchemaUpgradeProcess;
 import com.liferay.portal.background.task.internal.upgrade.v1_0_0.UpgradeKernelPackage;
 import com.liferay.portal.background.task.internal.upgrade.v2_0_0.util.BackgroundTaskTable;
+import com.liferay.portal.background.task.internal.upgrade.v2_0_1.BackgroundTaskCompanyIdUpgradeProcess;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.upgrade.BaseSQLServerDatetimeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Cristina Rodríguez
@@ -38,6 +41,14 @@ public class BackgroundTaskServiceUpgradeStepRegistrator
 			"1.0.0", "2.0.0",
 			new BaseSQLServerDatetimeUpgradeProcess(
 				new Class<?>[] {BackgroundTaskTable.class}));
+
+		registry.register(
+			"2.0.0", "2.0.1",
+			new BackgroundTaskCompanyIdUpgradeProcess(
+				_backgroundTaskLocalService));
 	}
+
+	@Reference
+	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
 }

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v2_0_1/BackgroundTaskCompanyIdUpgradeProcess.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v2_0_1/BackgroundTaskCompanyIdUpgradeProcess.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/**
+ * @author Jorge Avalos
+ */
+
+package com.liferay.portal.background.task.internal.upgrade.v2_0_1;
+
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+public class BackgroundTaskCompanyIdUpgradeProcess extends UpgradeProcess {
+
+	public BackgroundTaskCompanyIdUpgradeProcess(
+		BackgroundTaskLocalService backgroundTaskLocalService) {
+
+		_backgroundTaskLocalService = backgroundTaskLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			processConcurrently(
+				"Select backgroundTaskId from BackgroundTask",
+				resultSet -> new Object[] {
+					resultSet.getLong("backgroundTaskId")
+				},
+				values -> {
+					BackgroundTask backgroundTask =
+						_backgroundTaskLocalService.getBackgroundTask(
+							(Long)values[0]);
+
+					Map<String, Serializable> taskContextMap =
+						backgroundTask.getTaskContextMap();
+
+					taskContextMap.remove("companyId");
+
+					Map<String, Serializable> threadLocalValues =
+						(Map<String, Serializable>)taskContextMap.get(
+							"threadLocalValues");
+
+					threadLocalValues.remove("companyId");
+
+					taskContextMap.replace(
+						"threadLocalValues", (Serializable)threadLocalValues);
+
+					backgroundTask.setTaskContextMap(taskContextMap);
+
+					_backgroundTaskLocalService.updateBackgroundTask(
+						backgroundTask);
+				},
+				"Failed to clear companyId from task context map");
+		}
+	}
+
+	private final BackgroundTaskLocalService _backgroundTaskLocalService;
+
+}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v2_0_1/BackgroundTaskCompanyIdUpgradeProcess.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/upgrade/v2_0_1/BackgroundTaskCompanyIdUpgradeProcess.java
@@ -3,10 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-/**
- * @author Jorge Avalos
- */
-
 package com.liferay.portal.background.task.internal.upgrade.v2_0_1;
 
 import com.liferay.portal.background.task.model.BackgroundTask;
@@ -18,6 +14,9 @@ import java.io.Serializable;
 
 import java.util.Map;
 
+/**
+ * @author Jorge Avalos
+ */
 public class BackgroundTaskCompanyIdUpgradeProcess extends UpgradeProcess {
 
 	public BackgroundTaskCompanyIdUpgradeProcess(

--- a/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BackgroundTaskThreadLocalManagerImplTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BackgroundTaskThreadLocalManagerImplTest.java
@@ -35,7 +35,7 @@ public class BackgroundTaskThreadLocalManagerImplTest
 				BackgroundTaskThreadLocalManagerImpl.KEY_THREAD_LOCAL_VALUES,
 				initializeThreadLocalValues()
 			).build(),
-			_COMPANY_ID);
+			COMPANY_ID);
 
 		assertThreadLocalValues();
 	}
@@ -67,7 +67,7 @@ public class BackgroundTaskThreadLocalManagerImplTest
 	@Test
 	public void testSetThreadLocalValues() {
 		backgroundTaskThreadLocalManagerImpl.setThreadLocalValues(
-			initializeThreadLocalValues(), _COMPANY_ID);
+			initializeThreadLocalValues(), COMPANY_ID);
 
 		assertThreadLocalValues();
 	}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BackgroundTaskThreadLocalManagerImplTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BackgroundTaskThreadLocalManagerImplTest.java
@@ -34,7 +34,8 @@ public class BackgroundTaskThreadLocalManagerImplTest
 			HashMapBuilder.<String, Serializable>put(
 				BackgroundTaskThreadLocalManagerImpl.KEY_THREAD_LOCAL_VALUES,
 				initializeThreadLocalValues()
-			).build());
+			).build(),
+			_COMPANY_ID);
 
 		assertThreadLocalValues();
 	}
@@ -66,7 +67,7 @@ public class BackgroundTaskThreadLocalManagerImplTest
 	@Test
 	public void testSetThreadLocalValues() {
 		backgroundTaskThreadLocalManagerImpl.setThreadLocalValues(
-			initializeThreadLocalValues());
+			initializeThreadLocalValues(), _COMPANY_ID);
 
 		assertThreadLocalValues();
 	}

--- a/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
@@ -147,8 +147,7 @@ public abstract class BaseBackgroundTaskTestCase {
 
 		Assert.assertTrue(MapUtil.isNotEmpty(threadLocalValues));
 		Assert.assertEquals(
-			threadLocalValues.toString(), 7, threadLocalValues.size());
-		Assert.assertEquals(_COMPANY_ID, threadLocalValues.get("companyId"));
+			threadLocalValues.toString(), 6, threadLocalValues.size());
 		Assert.assertEquals(
 			_CLUSTER_INVOKE_ENABLED, threadLocalValues.get("clusterInvoke"));
 		Assert.assertEquals(
@@ -177,8 +176,6 @@ public abstract class BaseBackgroundTaskTestCase {
 		return HashMapBuilder.<String, Serializable>put(
 			"clusterInvoke", _CLUSTER_INVOKE_ENABLED
 		).put(
-			"companyId", _COMPANY_ID
-		).put(
 			"defaultLocale", _defaultLocale
 		).put(
 			"groupId", _GROUP_ID
@@ -202,7 +199,7 @@ public abstract class BaseBackgroundTaskTestCase {
 
 	private static final boolean _CLUSTER_INVOKE_ENABLED = true;
 
-	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+	public static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static final long _GROUP_ID = RandomTestUtil.randomLong();
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/test/java/com/liferay/portal/background/task/internal/BaseBackgroundTaskTestCase.java
@@ -44,6 +44,8 @@ import org.mockito.Mockito;
  */
 public abstract class BaseBackgroundTaskTestCase {
 
+	public static final long COMPANY_ID = RandomTestUtil.randomLong();
+
 	@Before
 	public void setUp() throws Exception {
 		backgroundTaskThreadLocalManagerImpl =
@@ -69,7 +71,7 @@ public abstract class BaseBackgroundTaskTestCase {
 		Mockito.when(
 			group.getCompanyId()
 		).thenReturn(
-			_COMPANY_ID
+			COMPANY_ID
 		);
 
 		Mockito.when(
@@ -106,7 +108,7 @@ public abstract class BaseBackgroundTaskTestCase {
 		Mockito.when(
 			user.getCompanyId()
 		).thenReturn(
-			_COMPANY_ID
+			COMPANY_ID
 		);
 
 		Mockito.when(
@@ -127,7 +129,7 @@ public abstract class BaseBackgroundTaskTestCase {
 
 	protected void assertThreadLocalValues() {
 		Assert.assertEquals(
-			Long.valueOf(_COMPANY_ID), CompanyThreadLocal.getCompanyId());
+			Long.valueOf(COMPANY_ID), CompanyThreadLocal.getCompanyId());
 		Assert.assertEquals(
 			_CLUSTER_INVOKE_ENABLED, ClusterInvokeThreadLocal.isEnabled());
 		Assert.assertEquals(
@@ -163,7 +165,7 @@ public abstract class BaseBackgroundTaskTestCase {
 	}
 
 	protected void initalizeThreadLocals() {
-		CompanyThreadLocal.setCompanyId(_COMPANY_ID);
+		CompanyThreadLocal.setCompanyId(COMPANY_ID);
 		ClusterInvokeThreadLocal.setEnabled(true);
 		GroupThreadLocal.setGroupId(_GROUP_ID);
 		LocaleThreadLocal.setDefaultLocale(_defaultLocale);
@@ -198,8 +200,6 @@ public abstract class BaseBackgroundTaskTestCase {
 	}
 
 	private static final boolean _CLUSTER_INVOKE_ENABLED = true;
-
-	public static final long _COMPANY_ID = RandomTestUtil.randomLong();
 
 	private static final long _GROUP_ID = RandomTestUtil.randomLong();
 

--- a/modules/apps/portal-background-task/portal-background-task-test/build.gradle
+++ b/modules/apps/portal-background-task/portal-background-task-test/build.gradle
@@ -1,5 +1,8 @@
 dependencies {
+	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation project(":apps:portal-background-task:portal-background-task-api")
 	testIntegrationImplementation project(":apps:portal-background-task:portal-background-task-service")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/internal/upgrade/v2_0_1/test/BackgroundTaskCompanyIdUpgradeProcessTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/internal/upgrade/v2_0_1/test/BackgroundTaskCompanyIdUpgradeProcessTest.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.background.task.internal.upgrade.v2_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.io.Serializable;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class BackgroundTaskCompanyIdUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(new LiferayIntegrationTestRule());
+
+	@Before
+	public void setUp() {
+		BackgroundTask backgroundTask =
+			_backgroundTaskLocalService.createBackgroundTask(
+				_BACKGROUND_TASK_ID);
+
+		backgroundTask.setTaskContextMap(
+			HashMapBuilder.<String, Serializable>put(
+				_KEY_THREAD_LOCAL_VALUES, initializeThreadLocalValues()
+			).build());
+
+		_backgroundTaskLocalService.updateBackgroundTask(backgroundTask);
+	}
+
+	@Test
+	public void testUpgradeProcess() throws PortalException {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.portal.background.task.internal.upgrade.v2_0_1." +
+				"BackgroundTaskCompanyIdUpgradeProcess");
+
+		BackgroundTask backgroundTask =
+			_backgroundTaskLocalService.getBackgroundTask(_BACKGROUND_TASK_ID);
+
+		Map<String, Serializable> taskContextMap =
+			backgroundTask.getTaskContextMap();
+
+		Map<String, Serializable> threadLocalValues =
+			(Map<String, Serializable>)taskContextMap.get(
+				_KEY_THREAD_LOCAL_VALUES);
+
+		Assert.assertEquals(_COMPANY_ID, threadLocalValues.get("companyId"));
+
+		upgradeProcess.upgrade();
+
+		backgroundTask = _backgroundTaskLocalService.getBackgroundTask(
+			_BACKGROUND_TASK_ID);
+
+		taskContextMap = backgroundTask.getTaskContextMap();
+
+		threadLocalValues = (Map<String, Serializable>)taskContextMap.get(
+			_KEY_THREAD_LOCAL_VALUES);
+
+		Assert.assertEquals(
+			_CLUSTER_INVOKE_ENABLED, threadLocalValues.get("clusterInvoke"));
+		Assert.assertEquals(
+			_defaultLocale, threadLocalValues.get("defaultLocale"));
+		Assert.assertEquals(_GROUP_ID, threadLocalValues.get("groupId"));
+		Assert.assertEquals(
+			_PRINCIPAL_NAME, threadLocalValues.get("principalName"));
+		Assert.assertNull(threadLocalValues.get("principalPassword"));
+		Assert.assertEquals(
+			_siteDefaultLocale, threadLocalValues.get("siteDefaultLocale"));
+		Assert.assertEquals(
+			_themeDisplayLocale, threadLocalValues.get("themeDisplayLocale"));
+
+		Assert.assertNull(threadLocalValues.get("companyId"));
+	}
+
+	protected HashMap<String, Serializable> initializeThreadLocalValues() {
+		return HashMapBuilder.<String, Serializable>put(
+			"clusterInvoke", _CLUSTER_INVOKE_ENABLED
+		).put(
+			"companyId", _COMPANY_ID
+		).put(
+			"defaultLocale", _defaultLocale
+		).put(
+			"groupId", _GROUP_ID
+		).put(
+			"principalName", _PRINCIPAL_NAME
+		).put(
+			"siteDefaultLocale", _siteDefaultLocale
+		).put(
+			"themeDisplayLocale", _themeDisplayLocale
+		).build();
+	}
+
+	private static final long _BACKGROUND_TASK_ID = RandomTestUtil.randomLong();
+
+	private static final boolean _CLUSTER_INVOKE_ENABLED = true;
+
+	private static final long _COMPANY_ID = RandomTestUtil.randomLong();
+
+	private static final long _GROUP_ID = RandomTestUtil.randomLong();
+
+	private static final String _KEY_THREAD_LOCAL_VALUES = "threadLocalValues";
+
+	private static final String _PRINCIPAL_NAME = String.valueOf(
+		RandomTestUtil.randomLong());
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.background.task.internal.upgrade.registry.BackgroundTaskServiceUpgradeStepRegistrator"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private BackgroundTaskLocalService _backgroundTaskLocalService;
+
+	private final Locale _defaultLocale = LocaleUtil.US;
+	private final Locale _siteDefaultLocale = LocaleUtil.CANADA;
+	private final Locale _themeDisplayLocale = LocaleUtil.FRANCE;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTaskThreadLocalManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/BackgroundTaskThreadLocalManager.java
@@ -15,13 +15,13 @@ import java.util.Map;
 public interface BackgroundTaskThreadLocalManager {
 
 	public void deserializeThreadLocals(
-		Map<String, Serializable> taskContextMap);
+		Map<String, Serializable> taskContextMap, long companyId);
 
 	public Map<String, Serializable> getThreadLocalValues();
 
 	public void serializeThreadLocals(Map<String, Serializable> taskContextMap);
 
 	public void setThreadLocalValues(
-		Map<String, Serializable> threadLocalValues);
+		Map<String, Serializable> threadLocalValues, long companyId);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/backgroundtask/packageinfo
@@ -1,1 +1,1 @@
-version 11.0.0
+version 12.0.0


### PR DESCRIPTION
Task:
Clear out any companyId references in the taskcontextmap and replace the usage with the companyId column.
The exception would be for re-indexing background tasks as they are only available in the default OOTB liferay partition.