### PR TITLE
LPD-21825 Resolve com.liferay.journal.service failure in LocalFile.DatabaseUpgradeClient#ExecuteAllPendingUpgradesFromGogoShell

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.capabilities.PortalCapabilityLocator;
@@ -496,10 +497,10 @@ public class JournalServiceUpgradeStepRegistrator
 	@Reference
 	private Portal _portal;
 
-	// See LPS-82746
-
 	@Reference
 	private PortalCapabilityLocator _portalCapabilityLocator;
+
+	// See LPS-82746
 
 	@Reference
 	private PortletFileRepository _portletFileRepository;
@@ -514,6 +515,11 @@ public class JournalServiceUpgradeStepRegistrator
 	@Reference
 	private PrefsPropsToConfigurationUpgradeHelper
 		_prefsPropsToConfigurationUpgradeHelper;
+
+	@Reference(
+		target = "(&(release.bundle.symbolic.name=com.liferay.layout.service)(&(release.schema.version>=1.0.1)))"
+	)
+	private Release _release;
 
 	@Reference
 	private ResourceActionLocalService _resourceActionLocalService;

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -180,7 +180,6 @@ definition {
 	@description = "LPS-163243: The user can execute the upgrade:executeAll command on Gogo shell to execute all remaining upgrade processes"
 	@priority = 3
 	test ExecuteAllPendingUpgradesFromGogoShell {
-		property portal.upstream = "quarantine";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
 


### PR DESCRIPTION
Issue:
When the module upgrade process is ran from the gogo-shell, the upgrade processes for journal.service will be executed prematurely and will fail due to a layout.service table not existing.  
This table is added in a layout.service upgrade process.

Solution:
Add the release as a reference to the upgrade step registration for journal service so that the upgrade process is ran only after the layout.service version reaches the appropriate release.