### PR TITLE
LPD-29337 Fix several issues with DatabaseUpgradeClient

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogo-shell-connection.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogo-shell-connection.expect
@@ -14,7 +14,7 @@ expect {
 	timeout {send_user "No Gogoshell messages display";exit 2}
 }
 
-set timeout 50
+set timeout 10
 
 expect {
 	"Unable to open Gogo shell" {send_user "The Gogo shell connection failed";exit 2}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogo-shell-connection.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogo-shell-connection.expect
@@ -2,7 +2,7 @@
 
 spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat] -s
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Connecting to Gogo shell" {}
@@ -14,7 +14,7 @@ expect {
 	timeout {send_user "No Gogoshell messages display";exit 2}
 }
 
-set timeout 5
+set timeout 50
 
 expect {
 	"Unable to open Gogo shell" {send_user "The Gogo shell connection failed";exit 2}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-command-output.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-command-output.expect
@@ -9,7 +9,7 @@ expect {
 	timeout {send_user "No Gogoshell messages display";exit 2}
 }
 
-set timeout 50
+set timeout 10
 
 expect {
 	"upgrade:check" {

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-command-output.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-command-output.expect
@@ -2,14 +2,14 @@
 
 spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat] -s
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Type \"help\" to get available upgrade and verify commands.\r\nType \"help \{command\}\" to get additional information about the command. For example, \"help upgrade:list\"." {send "upgrade:check\r"}
 	timeout {send_user "No Gogoshell messages display";exit 2}
 }
 
-set timeout 5
+set timeout 50
 
 expect {
 	"upgrade:check" {

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-command-output.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-command-output.expect
@@ -21,6 +21,8 @@ expect {
 	timeout {send_user "Command is not printed!";exit 2}
 }
 
+set timeout 60
+
 expect {
 	"g! \r\ng!" {send "exit\r";send_user "PASS"}
 	"g! \r\n\r\ng!" {send_user "White line is printed!";exit 2}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-help-output.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-client-gogoshell-help-output.expect
@@ -2,14 +2,14 @@
 
 spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat] -s
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Type \"help\" to get available upgrade and verify commands.\r\nType \"help \{command\}\" to get additional information about the command. For example, \"help upgrade:list\"." {send "help\r"}
 	timeout {send_user "No Gogoshell messages display";exit 2}
 }
 
-set timeout 5
+set timeout 50
 
 expect {
 	"executeAll - Execute all verify processes\r\r\n   scope: verify" {}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-debug-options.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-debug-options.expect
@@ -2,7 +2,7 @@
 
 spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat] --debug
 
-set timeout 50
+set timeout 10
 
 expect {
 	"agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y" {}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-debug-options.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-debug-options.expect
@@ -2,7 +2,7 @@
 
 spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat] --debug
 
-set timeout 5
+set timeout 50
 
 expect {
 	"agentlib:jdwp=transport=dt_socket,address=8001,server=y,suspend=y" {}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-app-db-set.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-app-db-set.expect
@@ -6,7 +6,7 @@ expect "Please enter your Liferay home" {
 	send "\r"
 }
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Checking to see if all upgrades have completed... done" {send_user "PASS"}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-app-ext-set.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-app-ext-set.expect
@@ -34,7 +34,7 @@ expect "Please enter your database password" {
 	send "[database.password]\r"
 }
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Checking to see if all upgrades have completed... done" {send_user "PASS"}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-db-ext-set.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-db-ext-set.expect
@@ -22,7 +22,7 @@ expect "Please enter your portal directory in application server directory" {
 	send "\r"
 }
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Checking to see if all upgrades have completed... done" {send_user "PASS"}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-none-set.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/check-upgrade-properties-none-set.expect
@@ -58,7 +58,7 @@ expect "Please enter your database password" {
 	send "[database.password]\r"
 }
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Checking to see if all upgrades have completed... done" {send_user "PASS"}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/execute-all-pending-upgrades-from-gogo-shell.expect
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/dependencies/execute-all-pending-upgrades-from-gogo-shell.expect
@@ -2,14 +2,14 @@
 
 spawn [db.upgrade.client.home]/db_upgrade_client[file.suffix.bat] -s
 
-set timeout 900
+set timeout 1200
 
 expect {
 	"Type \"help\" to get available upgrade and verify commands.\r\nType \"help \{command\}\" to get additional information about the command. For example, \"help upgrade:list\"." {send "upgrade:check\r"}
 	timeout {send_user "Missing expected gogo shell message.";exit 2}
 }
 
-set timeout 300
+set timeout 1200
 
 expect {
 	"There are upgrade processes available for com.liferay.*" {send "upgrade:executeAll\r"}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -34,7 +34,7 @@ definition {
 	@description = "LPS-195984:  Upgrade client throws error when Gogo Shell is unable to connect."
 	@priority = 2
 	test CheckUpgradeClientFailedGogoShellReturnsError {
-		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP type_;";
+		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP resourcePrimKey;";
 		property custom.upgrade.properties = "module.framework.properties.osgi.console=80";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
@@ -60,7 +60,7 @@ definition {
 	@description = "LPS-158522: Upgrade client can connect to Gogo Shell with a failed upgrade"
 	@priority = 4
 	test CheckUpgradeClientGogoShellFailedUpgrade {
-		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP type_;";
+		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP resourcePrimKey;";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
 		property timeout.explicit.wait = "600";
@@ -117,9 +117,9 @@ definition {
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-status -Dupgrade.status=unresolved");
 
-		var schemaVersion = ValidateSmokeUpgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName = 'com.liferay.journal.web';");
+		var schemaVersion = ValidateSmokeUpgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName = 'com.liferay.journal.service';");
 
-		if (!(contains(${schemaVersion}, "0.0.1"))) {
+		if (!(contains(${schemaVersion}, "4.1.0"))) {
 			fail("The upgrade client upgrades core and modules.");
 		}
 	}

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -38,7 +38,7 @@ definition {
 		property custom.upgrade.properties = "module.framework.properties.osgi.console=80";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
-		property timeout.explicit.wait = "1200";
+		property timeout.explicit.wait = "600";
 
 		task ("Assert error is printed when the Gogo Shell fails to connect") {
 			AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-gogoshell-failed-connection-error");
@@ -63,7 +63,7 @@ definition {
 		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP type_;";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
-		property timeout.explicit.wait = "1200";
+		property timeout.explicit.wait = "600";
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
 
@@ -111,7 +111,7 @@ definition {
 		property custom.upgrade.properties = "upgrade.database.auto.run=false";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
-		property timeout.explicit.wait = "1200";
+		property timeout.explicit.wait = "600";
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
 

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -38,7 +38,7 @@ definition {
 		property custom.upgrade.properties = "module.framework.properties.osgi.console=80";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
-		property timeout.explicit.wait = "490";
+		property timeout.explicit.wait = "1200";
 
 		task ("Assert error is printed when the Gogo Shell fails to connect") {
 			AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-gogoshell-failed-connection-error");
@@ -63,7 +63,7 @@ definition {
 		property custom.mysql.sql.statement = "ALTER TABLE JournalArticle DROP type_;";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
-		property timeout.explicit.wait = "490";
+		property timeout.explicit.wait = "1200";
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
 
@@ -111,7 +111,7 @@ definition {
 		property custom.upgrade.properties = "upgrade.database.auto.run=false";
 		property skip.get.testcase.database.properties = "true";
 		property skip.upgrade-legacy-database = "true";
-		property timeout.explicit.wait = "490";
+		property timeout.explicit.wait = "1200";
 
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
 


### PR DESCRIPTION
@marianoalvarosaiz @javalosjr96 @LuisOrtiz89 I merged several changes you made to fix issues in the Upgrade client functional tests.

For the timeouts, I agree is ok to increase them because when there is no failure, we do not wait.