### PR TITLE
LPD-30222 wrap site initialization in TransactionCommitCallbackUtil

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.auth.EmailAddressValidator;
 import com.liferay.portal.kernel.service.CompanyService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -120,6 +121,20 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 			portalInstance.getVirtualHost(), portalInstance.getDomain(), 0,
 			true);
 
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setWithSafeCloseable(
+							company.getCompanyId())) {
+
+					_portalInstancesLocalService.initializePortalInstance(
+						company.getCompanyId(),
+						portalInstance.getSiteInitializerKey());
+				}
+
+				return null;
+			});
+
 		if (admin != null) {
 			User defaultAdminUser = _userLocalService.getUserByEmailAddress(
 				company.getCompanyId(),
@@ -149,14 +164,6 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 				contact.getFacebookSn(), contact.getJabberSn(),
 				contact.getSkypeSn(), contact.getTwitterSn(),
 				contact.getJobTitle(), null, null, null, null, null, null);
-		}
-
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
-					company.getCompanyId())) {
-
-			_portalInstancesLocalService.initializePortalInstance(
-				company.getCompanyId(), portalInstance.getSiteInitializerKey());
 		}
 
 		_portalInstancesLocalService.synchronizePortalInstances();

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfigurationFactory.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfigurationFactory.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Map;
@@ -65,14 +66,21 @@ public class PortalInstancesConfigurationFactory {
 				null, webId, virtualHostname, mx, maxUsers, active, null, null,
 				null, null, null, null);
 
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setWithSafeCloseable(
-						company.getCompanyId())) {
+			Company finalCompany = company;
 
-				_portalInstancesLocalService.initializePortalInstance(
-					company.getCompanyId(),
-					portalInstancesConfiguration.siteInitializerKey());
-			}
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					try (SafeCloseable safeCloseable =
+							CompanyThreadLocal.setWithSafeCloseable(
+								finalCompany.getCompanyId())) {
+
+						_portalInstancesLocalService.initializePortalInstance(
+							finalCompany.getCompanyId(),
+							portalInstancesConfiguration.siteInitializerKey());
+					}
+
+					return null;
+				});
 		}
 		else {
 			if (company.getCompanyId() ==

--- a/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/internal/portlet/action/AddInstanceMVCActionCommand.java
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/java/com/liferay/portal/instances/web/internal/portlet/action/AddInstanceMVCActionCommand.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 
 import javax.portlet.ActionRequest;
@@ -143,13 +144,19 @@ public class AddInstanceMVCActionCommand extends BaseMVCActionCommand {
 		String siteInitializerKey = ParamUtil.getString(
 			actionRequest, "siteInitializerKey");
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setWithSafeCloseable(
-					company.getCompanyId())) {
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				try (SafeCloseable safeCloseable =
+						 CompanyThreadLocal.setWithSafeCloseable(
+							 company.getCompanyId())) {
 
-			_portalInstancesLocalService.initializePortalInstance(
-				company.getCompanyId(), siteInitializerKey);
-		}
+					_portalInstancesLocalService.initializePortalInstance(
+						company.getCompanyId(),
+						siteInitializerKey);
+				}
+
+				return null;
+			});
 
 		_synchronizePortalInstances();
 	}


### PR DESCRIPTION
Issue:
DB-partitioning creates a new transaction that does not get committed before the site is initialized with the theme.

Solution:
Possibly a temporary solution, but using the CallbackUtil resolves the issue. 