### PR TITLE
LPD-32711 update team name and components in test.properties with a better name

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-upgrades"
+@component-name = "portal-db-infrastructure"
 definition {
 
 	property app.server.types = "tomcat";

--- a/modules/util/portal-tools-db-partition-migration-validator-test/src/testFunctional/tests/DBPartitionMigrationValidator.testcase
+++ b/modules/util/portal-tools-db-partition-migration-validator-test/src/testFunctional/tests/DBPartitionMigrationValidator.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-upgrades"
+@component-name = "portal-db-infrastructure"
 definition {
 
 	property app.server.types = "tomcat";

--- a/modules/util/portal-tools-db-partition-migration-validator-test/src/testFunctional/tests/DBPartitionMigrationValidator.testcase
+++ b/modules/util/portal-tools-db-partition-migration-validator-test/src/testFunctional/tests/DBPartitionMigrationValidator.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-database-partitioning"
+@component-name = "portal-upgrades"
 definition {
 
 	property app.server.types = "tomcat";

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-upgrades"
+@component-name = "portal-db-infrastructure"
 definition {
 
 	property app.server.types = "tomcat";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-upgrades"
+@component-name = "portal-db-infrastructure"
 definition {
 
 	property app.server.types = "tomcat";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioningCache.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioningCache.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-upgrades"
+@component-name = "portal-db-infrastructure"
 definition {
 
 	property app.server.types = "tomcat";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/DatabasePartitioningUpgrade.testcase
@@ -1,4 +1,4 @@
-@component-name = "portal-upgrades"
+@component-name = "portal-db-infrastructure"
 definition {
 
 	property app.server.types = "tomcat";

--- a/test.properties
+++ b/test.properties
@@ -227,6 +227,7 @@
         portal-content-management,\
         portal-content-management-ee,\
         portal-core-infra,\
+        portal-db-infrastructure,\
         portal-developer-tools,\
         portal-frontend-infrastructure,\
         portal-headless,\

--- a/test.properties
+++ b/test.properties
@@ -11417,6 +11417,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         ${testray.team.content-management.component.names},\
         ${testray.team.core-infrastructure.component.names},\
         ${testray.team.customer-solutions.component.names},\
+        ${testray.team.database-infrastructure.component.names},\
         ${testray.team.developer-tools.component.names},\
         ${testray.team.experience-management.component.names},\
         ${testray.team.frontend-infrastructure.component.names},\
@@ -11426,8 +11427,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         ${testray.team.publications.component.names},\
         ${testray.team.search.component.names},\
         ${testray.team.security.component.names},\
-        ${testray.team.solutions.component.names},\
-        ${testray.team.upgrades.component.names}
+        ${testray.team.solutions.component.names}
 
     testray.build.name=$(jenkins.job.name) - $(jenkins.build.number) - $(jenkins.build.start)
     testray.build.name[test-plugins-acceptance-pullrequest(*)]=$(portal.branch.name) - $(pull.request.sender.username) > $(pull.request.receiver.username) - PR#$(pull.request.number) - $(jenkins.build.start)
@@ -11575,6 +11575,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         content-management,\
         core-infrastructure,\
         customer-solutions,\
+        database-infrastructure,\
         developer-tools,\
         experience-management,\
         frontend-infrastructure,\
@@ -11583,8 +11584,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         publications,\
         search,\
         security,\
-        solutions,\
-        upgrades
+        solutions
 
     testray.team.analytics-cloud.component.names=\
         A/B Test,\
@@ -11712,6 +11712,15 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         Customer Portal,\
         Partner Portal,\
         Provisioning
+
+    testray.team.database-infrastructure.component.names=\
+        Data Cleanup,\
+        Database Partitioning,\
+        Database Upgrade Framework,\
+        Database Upgrade Tovol,\
+        Headless Portal Instances API,\
+        Upgrade Logging,\
+        Upgrade Report
 
     testray.team.developer-tools.component.names=\
         Blade Samples,\
@@ -11871,15 +11880,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         Site Initializer Testray,\
         Team Extranet,\
         Upgrades Solutions
-
-    testray.team.upgrades.component.names=\
-        Data Cleanup,\
-        Database Partitioning,\
-        Database Upgrade Framework,\
-        Database Upgrade Tool,\
-        Headless Portal Instances API,\
-        Upgrade Logging,\
-        Upgrade Report
 
 ##
 ## Utilities


### PR DESCRIPTION
I left the portal-upgrades for the upgrade testcases and add portal-db-infrastructure component for the relevant testcases(DB-P,Upgrade Tool).

The changes won't be reflected until it merges into master, besides the @component name. The other changes should upgrade the team name on Testray to Database Infrastructure.  