### PR TITLE
LPD-30976 Add all configurations to upgrade report

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/build.gradle
+++ b/modules/apps/portal/portal-upgrade-impl/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 	compileOnly project(":apps:portal-osgi-debug:portal-osgi-debug-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-file-install:portal-file-install-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-concurrent")

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -8,6 +8,8 @@ package com.liferay.portal.upgrade.internal.report;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.file.install.properties.ConfigurationProperties;
+import com.liferay.portal.file.install.properties.ConfigurationPropertiesFactory;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -57,6 +59,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.TreeMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -295,6 +298,38 @@ public class UpgradeReport {
 				).put(
 					"rootDir", (_rootDir != null) ? _rootDir : "Undefined"
 				).build();
+			}
+		).put(
+			"configuration.set.by.user",
+			() -> {
+				Map<String, Map<String, Object>> configurationMap =
+					new HashMap<>();
+
+				File dir = new File(PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR);
+
+				dir = dir.getCanonicalFile();
+
+				for (File file : _listConfigs(dir)) {
+					Map<String, Object> propertiesMap = new TreeMap<>();
+
+					ConfigurationProperties configurationProperties =
+						ConfigurationPropertiesFactory.create(
+							file, StringPool.UTF8);
+
+					for (String key : configurationProperties.keySet()) {
+						Object value = configurationProperties.get(key);
+
+						if (_isPasswordField(key)) {
+							value = StringPool.EIGHT_STARS;
+						}
+
+						propertiesMap.put(key, value);
+					}
+
+					configurationMap.put(file.getAbsolutePath(), propertiesMap);
+				}
+
+				return new ConfigurationPrinter(configurationMap);
 			}
 		).put(
 			"document.library.storage.size",
@@ -612,6 +647,42 @@ public class UpgradeReport {
 		}
 	}
 
+	private boolean _isPasswordField(String key) {
+		String[] passwordKeywords = {
+			"password", "secret", "securitycredential"
+		};
+
+		String lowerCaseKey = StringUtil.toLowerCase(key);
+
+		for (String keyword : passwordKeywords) {
+			if (lowerCaseKey.contains(keyword)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private List<File> _listConfigs(File dir) {
+		if (!dir.isDirectory()) {
+			return Collections.<File>emptyList();
+		}
+
+		return Arrays.asList(
+			dir.listFiles(
+				file -> {
+					if (file.isFile()) {
+						String name = file.getName();
+
+						if (name.endsWith(".cfg") || name.endsWith(".config")) {
+							return true;
+						}
+					}
+
+					return false;
+				}));
+	}
+
 	private void _printToLogContext(Map<String, Object> reportData) {
 		if (!PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
 			return;
@@ -759,6 +830,90 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private Map<String, Integer> _initialTableCounts;
 	private String _rootDir;
+
+	private class ConfigurationPrinter {
+
+		public ConfigurationPrinter(
+			Map<String, Map<String, Object>> configurationMap) {
+
+			_configurationMap = configurationMap;
+		}
+
+		@Override
+		public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append(StringPool.NEW_LINE);
+			sb.append(StringPool.NEW_LINE);
+
+			for (Map.Entry<String, Map<String, Object>> sourceEntry :
+					_configurationMap.entrySet()) {
+
+				String source = sourceEntry.getKey();
+
+				Map<String, Object> properties = sourceEntry.getValue();
+
+				sb.append(source);
+
+				sb.append(StringPool.NEW_LINE);
+
+				sb.append(
+					ListUtil.toString(
+						Collections.nCopies(source.length(), StringPool.MINUS),
+						StringPool.NULL, StringPool.BLANK));
+
+				sb.append(StringPool.NEW_LINE);
+
+				for (Map.Entry<String, Object> propertyEntry :
+						properties.entrySet()) {
+
+					sb.append(propertyEntry.getKey());
+					sb.append(StringPool.EQUAL);
+					sb.append(_formatValue(propertyEntry.getValue()));
+					sb.append(StringPool.NEW_LINE);
+				}
+
+				sb.append(StringPool.NEW_LINE);
+			}
+
+			return sb.toString();
+		}
+
+		private String _formatValue(Object value) {
+			StringBundler sb = new StringBundler();
+
+			if (value instanceof String[]) {
+				sb.append(StringPool.OPEN_BRACKET);
+				sb.append(StringPool.NEW_LINE);
+
+				String[] valueArray = (String[])value;
+
+				for (String valueElement : valueArray) {
+					sb.append(StringPool.SPACE);
+					sb.append(StringPool.SPACE);
+					sb.append(StringPool.QUOTE);
+					sb.append(valueElement);
+					sb.append(StringPool.QUOTE);
+					sb.append(StringPool.COMMA);
+					sb.append(StringPool.SPACE);
+					sb.append(StringPool.BACK_SLASH);
+					sb.append(StringPool.NEW_LINE);
+				}
+
+				sb.append(StringPool.CLOSE_BRACKET);
+			}
+			else {
+				sb.append(StringPool.QUOTE);
+				sb.append(value);
+				sb.append(StringPool.QUOTE);
+			}
+
+			return sb.toString();
+		}
+
+		private final Map<String, Map<String, Object>> _configurationMap;
+
+	}
 
 	private class DLSizeThread extends Thread {
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -44,6 +44,10 @@ import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
@@ -147,6 +151,34 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_upgradeReportLogger.removeAppender(_logContextAppender);
 
 		_logContextAppender.stop();
+	}
+
+	@Test
+	public void testConfigurationSetByUser() throws Exception {
+		Path path = Paths.get(
+			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR, "test.config");
+
+		try {
+			String content = "testKey=\"testValue\"";
+
+			Files.write(path, content.getBytes());
+
+			_appender.start();
+
+			_appender.stop();
+
+			_assertReport(path.toString());
+			_assertReport(content);
+
+			_assertLogContextContains(
+				"upgrade.report.configuration.set.by.user", path.toString());
+
+			_assertLogContextContains(
+				"upgrade.report.configuration.set.by.user", content);
+		}
+		finally {
+			Files.deleteIfExists(path);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
This is a preliminary implementation of the Story.

One of the requirements is

> Do not print config values for obfuscated configs (e.g. configKey=********). This can be determined by properties with `type = Meta.Type.Password`

For now, I'm [checking for reserved words is the properties keys](https://github.com/liferay-database-infra/liferay-portal/pull/2259/commits/d175c891a87f33233fb4a5e1675b9271a9150aa1#diff-0cc31e20c7435b0bb5a700efbf64e8728d1867e4216fd2d8f616df6fe619d0dcR650-R664), like "password", "secret" etc. to determine of the property value should be hidden or not.

Analyzing the annotation information for the configuration is a rather involved process. In the Liferay codebase, [it is performed in one occasion](https://github.com/liferay/liferay-portal/blob/master/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/portlet/action/ExportConfigurationMVCResourceCommand.java#L94-L138), by using the module's internal [ConfigurationModelRetriever](https://github.com/liferay/liferay-portal/blob/master/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/util/ConfigurationModelRetrieverImpl.java).

We could use this mechanism in `UpgradeReport` or `UpgradeRecorder` in the following ways:

- export `ConfigurationModel`, `ConfigurationModelRetriever` and `ConfigurationModelRetrieverImpl` in order to be accessible outside `configuration-admin-web`. However, we usually don't do this in *-web modules,
- move `ConfigurationModel`, `ConfigurationModelRetriever`, `ConfigurationModelRetrieverImpl` and dependent classes to `configuration-admin-api`. This would be more involved as it initially seems because `ConfigurationModelRetriever` is deeply integrated and used in a lot of places in the `configuration-admin-web` module,
- extract the minimum logic from `ConfigurationModelRetrieverImpl` that is needed to determine from the annotation information if the `type` of the configuration field is `Meta.Type.Password`, and place it in `configuration-admin-api` or some other *-api module. In my opinion, this seems to be slightly less complex than the previous approach, but I'm not sure if such an API extension is warranted for this story.

Please let me know what you think, @marianoalvarosaiz.
Thank you in advance.