### PR TITLE
LPD-30976 Add all configurations to upgrade report

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/build.gradle
+++ b/modules/apps/portal/portal-upgrade-impl/build.gradle
@@ -13,11 +13,13 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.metatype", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:gogo-shell:gogo-shell-logging")
 	compileOnly project(":apps:portal-osgi-debug:portal-osgi-debug-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-file-install:portal-file-install-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-concurrent")

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -293,18 +293,6 @@ public class UpgradeRecorder {
 	}
 
 	private boolean _isPasswordField(String key, String pid) {
-		String[] passwordKeywords = {
-			"password", "secret", "securitycredential"
-		};
-
-		String lowerCaseKey = StringUtil.toLowerCase(key);
-
-		for (String keyword : passwordKeywords) {
-			if (lowerCaseKey.contains(keyword)) {
-				return true;
-			}
-		}
-
 		Bundle[] bundles = _bundleContext.getBundles();
 
 		for (Bundle bundle : bundles) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -7,6 +7,12 @@ package com.liferay.portal.upgrade.internal.recorder;
 
 import com.liferay.petra.function.UnsafeBiConsumer;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.definitions.ExtendedAttributeDefinition;
+import com.liferay.portal.configuration.metatype.definitions.ExtendedMetaTypeInformation;
+import com.liferay.portal.configuration.metatype.definitions.ExtendedMetaTypeService;
+import com.liferay.portal.configuration.metatype.definitions.ExtendedObjectClassDefinition;
+import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.ReleaseManager;
@@ -24,18 +30,27 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.sql.DataSource;
 
 import org.apache.logging.log4j.ThreadContext;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.metatype.AttributeDefinition;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
@@ -43,6 +58,10 @@ import org.osgi.util.tracker.ServiceTracker;
  */
 @Component(service = UpgradeRecorder.class)
 public class UpgradeRecorder {
+
+	public Map<String, Map<String, Object>> getConfigurationMap() {
+		return _configurationMap;
+	}
 
 	public Map<String, Map<String, Integer>> getErrorMessages() {
 		return _errorMessages;
@@ -126,6 +145,7 @@ public class UpgradeRecorder {
 	}
 
 	public void start() {
+		_configurationMap.clear();
 		_errorMessages.clear();
 		_result = "running";
 		_schemaVersionsMap.clear();
@@ -149,6 +169,8 @@ public class UpgradeRecorder {
 		_result = _calculateResult();
 
 		_type = _calculateType(_result);
+
+		_populateConfigurationMap(_configurationMap);
 
 		if (PropsValues.UPGRADE_LOG_CONTEXT_ENABLED) {
 			ThreadContext.put("upgrade.type", _type);
@@ -178,6 +200,8 @@ public class UpgradeRecorder {
 
 	@Activate
 	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
 		_serviceTracker = new ServiceTracker<>(
 			bundleContext, ReleaseManager.class, null);
 
@@ -268,6 +292,127 @@ public class UpgradeRecorder {
 		return messages;
 	}
 
+	private boolean _isPasswordField(String key, String pid) {
+		String[] passwordKeywords = {
+			"password", "secret", "securitycredential"
+		};
+
+		String lowerCaseKey = StringUtil.toLowerCase(key);
+
+		for (String keyword : passwordKeywords) {
+			if (lowerCaseKey.contains(keyword)) {
+				return true;
+			}
+		}
+
+		Bundle[] bundles = _bundleContext.getBundles();
+
+		for (Bundle bundle : bundles) {
+			if (bundle.getState() != Bundle.ACTIVE) {
+				continue;
+			}
+
+			ExtendedMetaTypeInformation extendedMetaTypeInformation =
+				_extendedMetaTypeService.getMetaTypeInformation(bundle);
+
+			if ((extendedMetaTypeInformation == null) ||
+				!Arrays.asList(
+					extendedMetaTypeInformation.getPids()
+				).contains(
+					pid
+				)) {
+
+				continue;
+			}
+
+			ExtendedObjectClassDefinition extendedObjectClassDefinition =
+				extendedMetaTypeInformation.getObjectClassDefinition(pid, null);
+
+			if (extendedObjectClassDefinition == null) {
+				continue;
+			}
+
+			ExtendedAttributeDefinition[] attributeDefinitions =
+				extendedObjectClassDefinition.getAttributeDefinitions(
+					ExtendedObjectClassDefinition.ALL);
+
+			for (AttributeDefinition attributeDefinition :
+					attributeDefinitions) {
+
+				if (StringUtil.equals(key, attributeDefinition.getID()) &&
+					(attributeDefinition.getType() ==
+						AttributeDefinition.PASSWORD)) {
+
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	private Map<String, Map<String, Object>> _populateConfigurationMap(
+		Map<String, Map<String, Object>> configurationMap) {
+
+		try {
+			Configuration[] configurations =
+				_configurationAdmin.listConfigurations(
+					"(" + FileInstallConstants.FELIX_FILE_INSTALL_FILENAME +
+						"=*)");
+
+			if (configurations != null) {
+				for (Configuration configuration : configurations) {
+					if (configuration != null) {
+						Dictionary<String, Object> properties =
+							configuration.getProperties();
+
+						if (properties != null) {
+							String pid = configuration.getPid();
+
+							Map<String, Object> propertiesMap = new TreeMap<>();
+
+							Enumeration<String> enumeration = properties.keys();
+
+							while (enumeration.hasMoreElements()) {
+								String key = enumeration.nextElement();
+
+								if (StringUtil.equals(
+										key,
+										FileInstallConstants.
+											FELIX_FILE_INSTALL_FILENAME) ||
+									StringUtil.equals(key, "service.pid") ||
+									StringUtil.equals(
+										key, "service.factoryPid")) {
+
+									continue;
+								}
+
+								Object value = properties.get(key);
+
+								if (_isPasswordField(key, pid)) {
+									value = StringPool.EIGHT_STARS;
+								}
+
+								propertiesMap.put(key, value);
+							}
+
+							configurationMap.put(
+								(String)properties.get(
+									FileInstallConstants.
+										FELIX_FILE_INSTALL_FILENAME),
+								propertiesMap);
+						}
+					}
+				}
+			}
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		return configurationMap;
+	}
+
 	private void _processRelease(
 		UnsafeBiConsumer<SchemaVersions, String, Exception> unsafeBiConsumer) {
 
@@ -317,6 +462,8 @@ public class UpgradeRecorder {
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeRecorder.class);
 
+	private static final Map<String, Map<String, Object>> _configurationMap =
+		new ConcurrentHashMap<>();
 	private static final Map<String, Map<String, Integer>> _errorMessages =
 		new ConcurrentHashMap<>();
 	private static String _result;
@@ -341,6 +488,14 @@ public class UpgradeRecorder {
 			_type = "not enabled";
 		}
 	}
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private ConfigurationAdmin _configurationAdmin;
+
+	@Reference
+	private ExtendedMetaTypeService _extendedMetaTypeService;
 
 	private ServiceTracker<ReleaseManager, ReleaseManager> _serviceTracker;
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -299,7 +299,10 @@ public class UpgradeReport {
 				}
 
 				return LinkedHashMapBuilder.<String, Object>put(
-					"liferay.home", PropsValues.LIFERAY_HOME
+					"liferay.home",
+					new File(
+						PropsValues.LIFERAY_HOME
+					).getCanonicalPath()
 				).put(
 					"locales", Arrays.toString(PropsValues.LOCALES)
 				).put(
@@ -625,7 +628,9 @@ public class UpgradeReport {
 				dlStoreConfigurationPid);
 
 			if (configurations != null) {
-				return configurations.get("rootDir");
+				return new File(
+					configurations.get("rootDir")
+				).getCanonicalPath();
 			}
 		}
 		catch (IOException ioException) {
@@ -851,7 +856,15 @@ public class UpgradeReport {
 			sb.append("Configuration directory:");
 			sb.append(StringPool.NEW_LINE);
 
-			sb.append(PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR);
+			try {
+				sb.append(
+					new File(
+						PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR
+					).getCanonicalPath());
+			}
+			catch (IOException ioException) {
+				throw new RuntimeException(ioException);
+			}
 
 			sb.append(StringPool.NEW_LINE);
 			sb.append(StringPool.NEW_LINE);

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -869,20 +869,21 @@ public class UpgradeReport {
 			sb.append(StringPool.NEW_LINE);
 			sb.append(StringPool.NEW_LINE);
 
-			for (Map.Entry<String, Map<String, Object>> sourceEntry :
+			for (Map.Entry<String, Map<String, Object>> configurationEntry :
 					_configurationMap.entrySet()) {
 
-				String source = sourceEntry.getKey();
+				String sourceFileName = configurationEntry.getKey();
 
-				Map<String, Object> properties = sourceEntry.getValue();
+				Map<String, Object> properties = configurationEntry.getValue();
 
-				sb.append(source);
+				sb.append(sourceFileName);
 
 				sb.append(StringPool.NEW_LINE);
 
 				sb.append(
 					ListUtil.toString(
-						Collections.nCopies(source.length(), StringPool.MINUS),
+						Collections.nCopies(
+							sourceFileName.length(), StringPool.MINUS),
 						StringPool.NULL, StringPool.BLANK));
 
 				sb.append(StringPool.NEW_LINE);

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -266,6 +266,14 @@ public class UpgradeReport {
 					StringPool.PERIOD, db.getMinorVersion());
 			}
 		).put(
+			"configurations.set.by.user",
+			() -> {
+				Map<String, Map<String, Object>> configurationMap =
+					upgradeRecorder.getConfigurationMap();
+
+				return new ConfigurationPrinter(configurationMap);
+			}
+		).put(
 			"property",
 			() -> {
 				if (StringUtil.equals(
@@ -824,6 +832,98 @@ public class UpgradeReport {
 	private final int _initialBuildNumber;
 	private Map<String, Integer> _initialTableCounts;
 	private String _rootDir;
+
+	private class ConfigurationPrinter {
+
+		public ConfigurationPrinter(
+			Map<String, Map<String, Object>> configurationMap) {
+
+			_configurationMap = configurationMap;
+		}
+
+		@Override
+		public String toString() {
+			StringBundler sb = new StringBundler();
+
+			sb.append(StringPool.NEW_LINE);
+			sb.append(StringPool.NEW_LINE);
+
+			sb.append("Configuration directory:");
+			sb.append(StringPool.NEW_LINE);
+
+			sb.append(PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR);
+
+			sb.append(StringPool.NEW_LINE);
+			sb.append(StringPool.NEW_LINE);
+
+			for (Map.Entry<String, Map<String, Object>> sourceEntry :
+					_configurationMap.entrySet()) {
+
+				String source = sourceEntry.getKey();
+
+				Map<String, Object> properties = sourceEntry.getValue();
+
+				sb.append(source);
+
+				sb.append(StringPool.NEW_LINE);
+
+				sb.append(
+					ListUtil.toString(
+						Collections.nCopies(source.length(), StringPool.MINUS),
+						StringPool.NULL, StringPool.BLANK));
+
+				sb.append(StringPool.NEW_LINE);
+
+				for (Map.Entry<String, Object> propertyEntry :
+						properties.entrySet()) {
+
+					sb.append(propertyEntry.getKey());
+					sb.append(StringPool.EQUAL);
+					sb.append(_formatValue(propertyEntry.getValue()));
+					sb.append(StringPool.NEW_LINE);
+				}
+
+				sb.append(StringPool.NEW_LINE);
+			}
+
+			return sb.toString();
+		}
+
+		private String _formatValue(Object value) {
+			StringBundler sb = new StringBundler();
+
+			if (value instanceof String[]) {
+				sb.append(StringPool.OPEN_BRACKET);
+				sb.append(StringPool.NEW_LINE);
+
+				String[] valueArray = (String[])value;
+
+				for (String valueElement : valueArray) {
+					sb.append(StringPool.SPACE);
+					sb.append(StringPool.SPACE);
+					sb.append(StringPool.QUOTE);
+					sb.append(valueElement);
+					sb.append(StringPool.QUOTE);
+					sb.append(StringPool.COMMA);
+					sb.append(StringPool.SPACE);
+					sb.append(StringPool.BACK_SLASH);
+					sb.append(StringPool.NEW_LINE);
+				}
+
+				sb.append(StringPool.CLOSE_BRACKET);
+			}
+			else {
+				sb.append(StringPool.QUOTE);
+				sb.append(value);
+				sb.append(StringPool.QUOTE);
+			}
+
+			return sb.toString();
+		}
+
+		private final Map<String, Map<String, Object>> _configurationMap;
+
+	}
 
 	private class DLSizeThread extends Thread {
 

--- a/modules/apps/portal/portal-upgrade-test/build.gradle
+++ b/modules/apps/portal/portal-upgrade-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationImplementation group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.26.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "com.liferay", name: "org.apache.logging.log4j.core", version: "2.17.1.LIFERAY-PATCHED-1"
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
@@ -9,8 +10,10 @@ dependencies {
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
+	testIntegrationImplementation project(":apps:static:portal-file-install:portal-file-install-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -10,10 +10,13 @@ import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.file.install.constants.FileInstallConstants;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayOutputStream;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -28,6 +31,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ReleaseInfo;
@@ -50,16 +54,22 @@ import java.io.Writer;
 
 import java.lang.reflect.Field;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
 import java.util.Arrays;
+import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.felix.cm.file.ConfigurationHandler;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
@@ -155,6 +165,70 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_upgradeReportLogger.removeAppender(_logContextAppender);
 
 		_logContextAppender.stop();
+	}
+
+	@Test
+	public void testConfigurationSetByUser() throws Exception {
+		String serviceFactoryPid = "test.configuration";
+
+		String fileName = serviceFactoryPid + ".config";
+
+		Path path = Paths.get(
+			PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR, fileName);
+
+		Dictionary<String, Object> dictionary =
+			HashMapDictionaryBuilder.<String, Object>put(
+				FileInstallConstants.FELIX_FILE_INSTALL_FILENAME, fileName
+			).put(
+				"password", "superSecret"
+			).put(
+				"testKey", "testValue"
+			).build();
+
+		String pid = ConfigurationTestUtil.createFactoryConfiguration(
+			serviceFactoryPid, dictionary);
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+
+		ConfigurationHandler.write(unsyncByteArrayOutputStream, dictionary);
+
+		Files.write(path, unsyncByteArrayOutputStream.toByteArray());
+
+		try {
+			_appender.start();
+
+			_appender.stop();
+
+			_assertReport(PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR);
+
+			_assertReport(fileName);
+
+			_assertReport("testKey=\"testValue\"");
+
+			_assertReport("password=\"********\"");
+
+			_assertLogContextContains(
+				"upgrade.report.configurations.set.by.user",
+				PropsValues.MODULE_FRAMEWORK_CONFIGS_DIR);
+
+			_assertLogContextContains(
+				"upgrade.report.configurations.set.by.user", fileName);
+
+			_assertLogContextContains(
+				"upgrade.report.configurations.set.by.user",
+				"testKey=\"testValue\"");
+
+			_assertLogContextContains(
+				"upgrade.report.configurations.set.by.user",
+				"password=\"********\"");
+		}
+		finally {
+			ConfigurationTestUtil.deleteFactoryConfiguration(
+				pid, serviceFactoryPid);
+
+			Files.deleteIfExists(path);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Hi @IstvanD, I made some small changes, but I think for some reason the code is not working properly. In commit https://github.com/liferay/liferay-portal/commit/6cef49bb5086c3631782149703337761654f0c63 I removed the statement to check directly for some keywords, as I think the idea is to rely solely in the type of the properties, masking the ones with type `Meta.Type.Password`.
Since that change, the code does not work anymore.
To test it I followed the next steps:
- Start a previous version of Liferay (in my case I started a 2024.q1.5 bundle).
- Create the `com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration.config` file in the folder `osgi/configs` with the next content:
```
securityCredential="12345678"
serverName="ldap-invented"
```
- Let the portal to persist the configuration.
- Stop the bundle.
- Start a bundle with the changes on the PR pointing to the previous database (remember to copy the config file in the bundle `osgi/configs` folder).
- Start the portal

After following the previous steps, the upgrade report is generated, but the property `securityCredential` is not masked.
It should be masked because in the `LDAPServerConfiguration` file, that property is configured as `type = Meta.Type.Password`.
I debugged the code a little bit and I saw that in the `_isPasswordField` method, when calling to `extendedMetaTypeInformation.getPids()`, the pid for this configuration is not returned.

Would you mind checking this?