### PR TITLE
LPD-30983 Add longest running queries to upgrade report

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -78,6 +78,10 @@ public class UpgradeRecorder {
 		return _result;
 	}
 
+	public Map<String, Long> getSQLExecutionTimes() {
+		return UpgradeSQLRecorder.getSQLExecutionTimes();
+	}
+
 	public String getType() {
 		return _type;
 	}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -530,6 +530,50 @@ public class UpgradeReport {
 				return longestRunningUpgradeProcesses;
 			}
 		).put(
+			"longest.running.sqls",
+			() -> {
+				Map<String, Long> sqlExecutionTimes =
+					upgradeRecorder.getSQLExecutionTimes();
+
+				List<RunningSQLQuery> longestRunningSQLQueries =
+					new ArrayList<>();
+
+				List<Map.Entry<String, Long>> entries = new ArrayList<>(
+					sqlExecutionTimes.entrySet());
+
+				entries.sort(
+					(entry1, entry2) -> Long.compare(
+						entry2.getValue(), entry1.getValue()));
+
+				int count = Math.min(_TOP_SQL_QUERIES_COUNT, entries.size());
+
+				for (int i = 0; i < count; i++) {
+					Map.Entry<String, Long> entry = entries.get(i);
+
+					String key = entry.getKey();
+					Long duration = entry.getValue();
+
+					String upgradeProcessName = StringPool.BLANK;
+					String sql;
+
+					if (key.contains(StringPool.PIPE)) {
+						int separatorIndex = key.indexOf(StringPool.PIPE);
+
+						upgradeProcessName = key.substring(0, separatorIndex);
+
+						sql = key.substring(separatorIndex + 1);
+					}
+					else {
+						sql = key;
+					}
+
+					longestRunningSQLQueries.add(
+						new RunningSQLQuery(upgradeProcessName, sql, duration));
+				}
+
+				return longestRunningSQLQueries;
+			}
+		).put(
 			"failed.sqls", upgradeRecorder.getFailedSQLs()
 		).put(
 			"errors", _getMessagesPrinters(upgradeRecorder.getErrorMessages())
@@ -808,6 +852,8 @@ public class UpgradeReport {
 		"com.liferay.portal.store.file.system.configuration." +
 			"FileSystemStoreConfiguration";
 
+	private static final int _TOP_SQL_QUERIES_COUNT = 20;
+
 	private static final int _UPGRADE_PROCESSES_COUNT = 20;
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeReport.class);
@@ -952,6 +998,44 @@ public class UpgradeReport {
 		}
 
 		private final Map<String, Properties> _propertiesMap;
+
+	}
+
+	private class RunningSQLQuery {
+
+		public RunningSQLQuery(
+			String upgradeProcessName, String sql, long duration) {
+
+			_upgradeProcessName = upgradeProcessName;
+			_sql = sql;
+			_duration = duration;
+		}
+
+		public long getDuration() {
+			return _duration;
+		}
+
+		public String getSql() {
+			return _sql;
+		}
+
+		@Override
+		public String toString() {
+			if (_logContext) {
+				return StringBundler.concat(
+					_upgradeProcessName, StringPool.COLON, _sql,
+					StringPool.SEMICOLON, StringPool.COLON, _duration, " ms");
+			}
+
+			return StringBundler.concat(
+				"Upgrade Process: ", _upgradeProcessName, StringPool.NEW_LINE,
+				"SQL: ", _sql, StringPool.SEMICOLON, StringPool.NEW_LINE,
+				"Duration: ", _duration, " ms", StringPool.NEW_LINE);
+		}
+
+		private final long _duration;
+		private final String _sql;
+		private final String _upgradeProcessName;
 
 	}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -1024,13 +1024,13 @@ public class UpgradeReport {
 			if (_logContext) {
 				return StringBundler.concat(
 					_upgradeProcessName, StringPool.COLON, _sql,
-					StringPool.SEMICOLON, StringPool.COLON, _duration, " ms");
+					StringPool.COLON, _duration, " ms");
 			}
 
 			return StringBundler.concat(
 				"Upgrade Process: ", _upgradeProcessName, StringPool.NEW_LINE,
-				"SQL: ", _sql, StringPool.SEMICOLON, StringPool.NEW_LINE,
-				"Duration: ", _duration, " ms", StringPool.NEW_LINE);
+				"SQL: ", _sql, StringPool.NEW_LINE, "Duration: ", _duration,
+				" ms", StringPool.NEW_LINE);
 		}
 
 		private final long _duration;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -705,11 +705,11 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		}
 
 		String recordEntry1 = String.format(
-			"Upgrade Process: %s\nSQL: %s;", upgradeProcess1ClassName,
+			"Upgrade Process: %s\nSQL: %s", upgradeProcess1ClassName,
 			statement1);
 
 		String recordEntry2 = String.format(
-			"Upgrade Process: %s\nSQL: %s;", upgradeProcess2ClassName,
+			"Upgrade Process: %s\nSQL: %s", upgradeProcess2ClassName,
 			statement2);
 
 		_assertReport(recordEntry1);
@@ -717,10 +717,10 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_assertReport(recordEntry2);
 
 		String logContextRecordEntry1 = String.format(
-			"%s:%s;", upgradeProcess1ClassName, statement1);
+			"%s:%s", upgradeProcess1ClassName, statement1);
 
 		String logContextRecordEntry2 = String.format(
-			"%s:%s;", upgradeProcess2ClassName, statement2);
+			"%s:%s", upgradeProcess2ClassName, statement2);
 
 		_assertLogContextContains(
 			"upgrade.report.longest.running.sqls", logContextRecordEntry1);
@@ -742,13 +742,13 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			String storedSql = splitKey[1];
 
 			String recordEntry = String.format(
-				"Upgrade Process: %s\nSQL: %s;\nDuration: %d ms",
+				"Upgrade Process: %s\nSQL: %s\nDuration: %d ms",
 				storedUpgradeProcessClassName, storedSql, duration);
 
 			_assertReport(recordEntry);
 
 			String logContextRecordEntry = String.format(
-				"%s:%s;:%d ms", storedUpgradeProcessClassName, storedSql,
+				"%s:%s:%d ms", storedUpgradeProcessClassName, storedSql,
 				duration);
 
 			_assertLogContextContains(

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -704,6 +704,14 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_reportContent = _getReportContent();
 		}
 
+		_assertLogContextContains(
+			"upgrade.report.longest.running.sqls",
+			String.format("%s:%s", upgradeProcess1ClassName, statement1));
+
+		_assertLogContextContains(
+			"upgrade.report.longest.running.sqls",
+			String.format("%s:%s", upgradeProcess2ClassName, statement2));
+
 		_assertReport(
 			String.format(
 				"Upgrade Process: %s\nSQL: %s", upgradeProcess1ClassName,
@@ -714,37 +722,30 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				"Upgrade Process: %s\nSQL: %s", upgradeProcess2ClassName,
 				statement2));
 
-		_assertLogContextContains(
-			"upgrade.report.longest.running.sqls",
-			String.format("%s:%s", upgradeProcess1ClassName, statement1));
-
-		_assertLogContextContains(
-			"upgrade.report.longest.running.sqls",
-			String.format("%s:%s", upgradeProcess2ClassName, statement2));
-
 		Map<String, Long> sqlExecutionTimes = ReflectionTestUtil.invoke(
 			_upgradeRecorder, "getSQLExecutionTimes", new Class<?>[0]);
 
 		for (Map.Entry<String, Long> entry : sqlExecutionTimes.entrySet()) {
-			String sql = entry.getKey();
 			Long duration = entry.getValue();
+
+			String sql = entry.getKey();
 
 			String[] splitKey = sql.split("\\|");
 
-			String storedUpgradeProcessClassName = splitKey[0];
-
 			String storedSql = splitKey[1];
 
-			_assertReport(
-				String.format(
-					"Upgrade Process: %s\nSQL: %s\nDuration: %d ms",
-					storedUpgradeProcessClassName, storedSql, duration));
+			String storedUpgradeProcessClassName = splitKey[0];
 
 			_assertLogContextContains(
 				"upgrade.report.longest.running.sqls",
 				String.format(
 					"%s:%s:%d ms", storedUpgradeProcessClassName, storedSql,
 					duration));
+
+			_assertReport(
+				String.format(
+					"Upgrade Process: %s\nSQL: %s\nDuration: %d ms",
+					storedUpgradeProcessClassName, storedSql, duration));
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -704,29 +704,23 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_reportContent = _getReportContent();
 		}
 
-		String recordEntry1 = String.format(
-			"Upgrade Process: %s\nSQL: %s", upgradeProcess1ClassName,
-			statement1);
+		_assertReport(
+			String.format(
+				"Upgrade Process: %s\nSQL: %s", upgradeProcess1ClassName,
+				statement1));
 
-		String recordEntry2 = String.format(
-			"Upgrade Process: %s\nSQL: %s", upgradeProcess2ClassName,
-			statement2);
-
-		_assertReport(recordEntry1);
-
-		_assertReport(recordEntry2);
-
-		String logContextRecordEntry1 = String.format(
-			"%s:%s", upgradeProcess1ClassName, statement1);
-
-		String logContextRecordEntry2 = String.format(
-			"%s:%s", upgradeProcess2ClassName, statement2);
+		_assertReport(
+			String.format(
+				"Upgrade Process: %s\nSQL: %s", upgradeProcess2ClassName,
+				statement2));
 
 		_assertLogContextContains(
-			"upgrade.report.longest.running.sqls", logContextRecordEntry1);
+			"upgrade.report.longest.running.sqls",
+			String.format("%s:%s", upgradeProcess1ClassName, statement1));
 
 		_assertLogContextContains(
-			"upgrade.report.longest.running.sqls", logContextRecordEntry2);
+			"upgrade.report.longest.running.sqls",
+			String.format("%s:%s", upgradeProcess2ClassName, statement2));
 
 		Map<String, Long> sqlExecutionTimes = ReflectionTestUtil.invoke(
 			_upgradeRecorder, "getSQLExecutionTimes", new Class<?>[0]);
@@ -741,18 +735,16 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 			String storedSql = splitKey[1];
 
-			String recordEntry = String.format(
-				"Upgrade Process: %s\nSQL: %s\nDuration: %d ms",
-				storedUpgradeProcessClassName, storedSql, duration);
-
-			_assertReport(recordEntry);
-
-			String logContextRecordEntry = String.format(
-				"%s:%s:%d ms", storedUpgradeProcessClassName, storedSql,
-				duration);
+			_assertReport(
+				String.format(
+					"Upgrade Process: %s\nSQL: %s\nDuration: %d ms",
+					storedUpgradeProcessClassName, storedSql, duration));
 
 			_assertLogContextContains(
-				"upgrade.report.longest.running.sqls", logContextRecordEntry);
+				"upgrade.report.longest.running.sqls",
+				String.format(
+					"%s:%s:%d ms", storedUpgradeProcessClassName, storedSql,
+					duration));
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -676,6 +676,87 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	}
 
 	@Test
+	public void testSQLStatementsWithClassNameAndDuration() throws Exception {
+		String statement1 = "insert into UpgradeReportTable1 (id_) values (2)";
+		String statement2 = "delete from UpgradeReportTable1 where id_ = 2";
+
+		UpgradeProcess upgradeProcess1 = UpgradeProcessFactory.runSQL(
+			statement1);
+
+		UpgradeProcess upgradeProcess2 = UpgradeProcessFactory.runSQL(
+			statement2);
+
+		String upgradeProcess1ClassName = upgradeProcess1.getClass(
+		).getName();
+
+		String upgradeProcess2ClassName = upgradeProcess2.getClass(
+		).getName();
+
+		_appender.start();
+
+		upgradeProcess1.upgrade();
+
+		upgradeProcess2.upgrade();
+
+		_appender.stop();
+
+		if (_reportContent == null) {
+			_reportContent = _getReportContent();
+		}
+
+		String recordEntry1 = String.format(
+			"Upgrade Process: %s\nSQL: %s;", upgradeProcess1ClassName,
+			statement1);
+
+		String recordEntry2 = String.format(
+			"Upgrade Process: %s\nSQL: %s;", upgradeProcess2ClassName,
+			statement2);
+
+		_assertReport(recordEntry1);
+
+		_assertReport(recordEntry2);
+
+		String logContextRecordEntry1 = String.format(
+			"%s:%s;", upgradeProcess1ClassName, statement1);
+
+		String logContextRecordEntry2 = String.format(
+			"%s:%s;", upgradeProcess2ClassName, statement2);
+
+		_assertLogContextContains(
+			"upgrade.report.longest.running.sqls", logContextRecordEntry1);
+
+		_assertLogContextContains(
+			"upgrade.report.longest.running.sqls", logContextRecordEntry2);
+
+		Map<String, Long> sqlExecutionTimes = ReflectionTestUtil.invoke(
+			_upgradeRecorder, "getSQLExecutionTimes", new Class<?>[0]);
+
+		for (Map.Entry<String, Long> entry : sqlExecutionTimes.entrySet()) {
+			String sql = entry.getKey();
+			Long duration = entry.getValue();
+
+			String[] splitKey = sql.split("\\|");
+
+			String storedUpgradeProcessClassName = splitKey[0];
+
+			String storedSql = splitKey[1];
+
+			String recordEntry = String.format(
+				"Upgrade Process: %s\nSQL: %s;\nDuration: %d ms",
+				storedUpgradeProcessClassName, storedSql, duration);
+
+			_assertReport(recordEntry);
+
+			String logContextRecordEntry = String.format(
+				"%s:%s;:%d ms", storedUpgradeProcessClassName, storedSql,
+				duration);
+
+			_assertLogContextContains(
+				"upgrade.report.longest.running.sqls", logContextRecordEntry);
+		}
+	}
+
+	@Test
 	public void testUpgradeReportDirectory() throws Exception {
 		String originalUpgradeReportDir =
 			ReflectionTestUtil.getAndSetFieldValue(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ThrowableCollector;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeSQLRecorder;
+import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.NotificationThreadLocal;
@@ -312,7 +313,8 @@ public abstract class BaseDBProcess implements DBProcess {
 			(Connection)ProxyUtil.newProxyInstance(
 				ClassLoader.getSystemClassLoader(),
 				new Class<?>[] {Connection.class},
-				new ConnectionThreadProxyInvocationHandler()));
+				new ConnectionThreadProxyInvocationHandler()),
+			ClassUtil.getClassName(this));
 	}
 
 	protected String[] getPrimaryKeyColumnNames(

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeSQLRecorder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeSQLRecorder.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.upgrade.recorder;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.util.CallableStatementWrapper;
 import com.liferay.portal.kernel.dao.jdbc.util.ConnectionWrapper;
 import com.liferay.portal.kernel.dao.jdbc.util.PreparedStatementWrapper;
@@ -21,7 +22,9 @@ import java.sql.SQLException;
 import java.sql.Statement;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author István András Dézsi
@@ -29,6 +32,14 @@ import java.util.List;
 public class UpgradeSQLRecorder {
 
 	public static Connection getConnectionWrapper(Connection connection) {
+		return getConnectionWrapper(connection, StringPool.BLANK);
+	}
+
+	public static Connection getConnectionWrapper(
+		Connection connection, String upgradeProcessClassName) {
+
+		_upgradeProcessClassName = upgradeProcessClassName;
+
 		if (!_enabled) {
 			return connection;
 		}
@@ -153,8 +164,14 @@ public class UpgradeSQLRecorder {
 		return _failedSQLs;
 	}
 
+	public static Map<String, Long> getSQLExecutionTimes() {
+		return _sqlExecutionTimes;
+	}
+
 	public static void start() {
 		_failedSQLs.clear();
+
+		_sqlExecutionTimes.clear();
 
 		_enabled = true;
 	}
@@ -165,6 +182,8 @@ public class UpgradeSQLRecorder {
 
 	private static <T> T _execute(SQLCallable<T> sqlCallable, Object object)
 		throws SQLException {
+
+		long startTime = System.currentTimeMillis();
 
 		try {
 			return sqlCallable.call();
@@ -186,6 +205,24 @@ public class UpgradeSQLRecorder {
 			}
 
 			throw sqlException;
+		}
+		finally {
+			long endTime = System.currentTimeMillis();
+
+			String sql = _extractSQL(object);
+
+			if (sql != null) {
+				long duration = endTime - startTime;
+
+				if (Validator.isBlank(_upgradeProcessClassName)) {
+					_sqlExecutionTimes.put(sql, duration);
+				}
+				else {
+					_sqlExecutionTimes.put(
+						_upgradeProcessClassName + StringPool.PIPE + sql,
+						duration);
+				}
+			}
 		}
 	}
 
@@ -333,6 +370,8 @@ public class UpgradeSQLRecorder {
 
 	private static boolean _enabled;
 	private static final List<String> _failedSQLs = new ArrayList<>();
+	private static final Map<String, Long> _sqlExecutionTimes = new HashMap<>();
+	private static String _upgradeProcessClassName = StringPool.BLANK;
 
 	@FunctionalInterface
 	private interface SQLCallable<R> {

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeSQLRecorder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeSQLRecorder.java
@@ -21,10 +21,10 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * @author István András Dézsi
@@ -371,8 +371,10 @@ public class UpgradeSQLRecorder {
 	}
 
 	private static boolean _enabled;
-	private static final List<String> _failedSQLs = new ArrayList<>();
-	private static final Map<String, Long> _sqlExecutionTimes = new HashMap<>();
+	private static final List<String> _failedSQLs =
+		new CopyOnWriteArrayList<>();
+	private static final Map<String, Long> _sqlExecutionTimes =
+		new ConcurrentHashMap<>();
 	private static String _upgradeProcessClassName = StringPool.BLANK;
 
 	@FunctionalInterface

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeSQLRecorder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeSQLRecorder.java
@@ -214,6 +214,8 @@ public class UpgradeSQLRecorder {
 			if (sql != null) {
 				long duration = endTime - startTime;
 
+				sql += StringPool.SEMICOLON;
+
 				if (Validator.isBlank(_upgradeProcessClassName)) {
 					_sqlExecutionTimes.put(sql, duration);
 				}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Hi @IstvanD, I made some changes in the code, they are just small changes, but there is one that I have some concerns about it. As far as I remember, the upgrades are executed sequentially, but with database partitioning enabled, the same upgrade process could be executed concurrently by several threads for different companies. 
For that reason I added the commit https://github.com/liferay/liferay-portal/commit/4342e2420da8972b1fc7c92e6838c76c099ed710, where I did not modified the `_upgradeProcessClassName` variable and let it be static, as the concurrency should only happen inside the same upgrade process (what I am not sure is if we should make it `volatile`, as it could be possible that a process would access it while other is rewriting it). 
But my real concern is how could be store the timing for the same query for the same upgrade process in different companies when database partitioning is enabled.

Imagine the next scenario:
- An upgrade process executes this query `alter table User_ modify password_ varchar(255) null;`
- The first company to apply it would be the default one (in LXC this company is just for administration purposes, so I guess this does not have many data).
- This company records the query in the HashMap.
- Then the rest of the companies execute the query (for those, probably the execution time will be higher, as there will be more data on those partitions).
- For those companies, the value stored in the HashMap is going to be overwritten, as they will share the same key. But the stored is the last one that executed, not necessarily the longest one.

I think that when storing the execution times with database partitioning enabled, we should stored them with a key like `_upgradeProcessClassName + StringPool.AT + CompanyThreadLocal.getCompanyId() + StringPool.PIPE + sql` or something similar, so we would have the information for all the queries in all the partitions, which is important, as a query could take a long time only when there is a lot of data in that partition.

Could you review the two concerns I mentioned please?