### PR TITLE
LPD-36152 Migrate testcases from DatabasePartitioning to integration tests

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -16,16 +16,22 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.model.impl.ClassNameImpl;
 import com.liferay.portal.model.impl.ResourceActionImpl;
@@ -92,6 +98,32 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> _counterLocalService.reset(_CLASS_NAME));
+	}
+
+	@Test
+	public void testAddCompanyWithHeadlessAPI() throws Exception {
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"domain", "able.com"
+			).put(
+				"portalInstanceId", "able.com"
+			).put(
+				"virtualHost", "www.able.com"
+			).toString(),
+			"headless-portal-instances/v1.0/portal-instances",
+			Http.Method.POST);
+
+		long companyId = jsonObject.getLong("companyId");
+
+		Company company = _companyLocalService.fetchCompany(companyId);
+
+		Assert.assertEquals("able.com", company.getWebId());
+
+		_companyLocalService.deleteCompany(company);
+
+		company = _companyLocalService.fetchCompany(companyId);
+
+		Assert.assertNull(company);
 	}
 
 	@Test
@@ -764,6 +796,9 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private CounterLocalService _counterLocalService;

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -151,34 +151,6 @@ definition {
 	}
 
 	@priority = 5
-	test CanAddCompanyWithPortalInstancesAdminUI {
-		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
-		property portal.acceptance = "true";
-		property test.assert.warning.exceptions = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
-
-		SignOut.signOut();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://www.able.com:8080",
-			userEmailAddress = "test@www.able.com");
-
-		SQL.assertDatabaseCount(
-			databaseFilter = "ltest_%",
-			databaseSubstring = "ltest_",
-			expectedCount = 1);
-	}
-
-	@priority = 5
 	test CanDeleteCompany {
 		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
 		property portal.acceptance = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -124,64 +124,6 @@ definition {
 			expectedCount = 1);
 	}
 
-	@description = "This is a use case for LPS-160064."
-	@priority = 4
-	test CanAddCompanyWithHeadlessAPI {
-		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.baker.com";
-		property test.assert.warning.exceptions = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		HeadlessPortalInstanceAPI.addPortalInstance(
-			domain = "www.baker.com",
-			portalInstanceId = "www.baker.com",
-			virtualHost = "www.baker.com");
-
-		SignOut.signOut();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://www.baker.com:8080",
-			userEmailAddress = "test@www.baker.com");
-
-		SQL.assertDatabaseCount(
-			databaseFilter = "lpartition%",
-			databaseSubstring = "lpartition",
-			expectedCount = 1);
-	}
-
-	@priority = 5
-	test CanDeleteCompany {
-		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
-		property portal.acceptance = "true";
-		property test.assert.warning.exceptions = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		HeadlessPortalInstanceAPI.addPortalInstance(
-			domain = "www.able.com",
-			portalInstanceId = "www.able.com",
-			virtualHost = "www.able.com");
-
-		SignOut.signOut();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://www.able.com:8080",
-			userEmailAddress = "test@www.able.com");
-
-		User.loginPG();
-
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.deleteCP(virtualHost = "www.able.com");
-
-		SQL.assertDatabaseCount(
-			databaseFilter = "ltest_%",
-			databaseSubstring = "ltest_",
-			expectedCount = 0);
-	}
-
 	@description = "This is a use case for LPS-171480."
 	@priority = 3
 	test CanScheduleJobInVariousCompaniesWhenAutoUpgradeIsEnabled {


### PR DESCRIPTION
@achaparro 
There is one more test case that will become redundant with the changes in:
[LPD-30986](https://liferay.atlassian.net/browse/LPD-30986)

ScheduleWebContentChangesWithDBPartitioningActivatedAcrossVariousCompanies has non-DB-P integration test for KBArticles that will cover this once DB-P enabled.

[LPD-30986]: https://liferay.atlassian.net/browse/LPD-30986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ