### PR TITLE
LPD-36152 Migrate testcases from DatabasePartitioning to integration tests

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/headless/test/DBPartitionHeadlessTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/headless/test/DBPartitionHeadlessTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.headless.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class DBPartitionHeadlessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	public static void assume() {
+		Assume.assumeTrue(DBPartition.isPartitionEnabled());
+
+		if (db == null) {
+			db = DBManagerUtil.getDB();
+		}
+
+		Assume.assumeTrue(db.isSupportsDBPartition());
+	}
+
+	@Test
+	public void testAddCompanyWithHeadlessAPI() throws Exception {
+		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+			JSONUtil.put(
+				"domain", "able.com"
+			).put(
+				"portalInstanceId", "able.com"
+			).put(
+				"virtualHost", "www.able.com"
+			).toString(),
+			"headless-portal-instances/v1.0/portal-instances",
+			Http.Method.POST);
+
+		long companyId = jsonObject.getLong("companyId");
+
+		Company company = _companyLocalService.fetchCompany(companyId);
+
+		Assert.assertEquals("able.com", company.getWebId());
+
+		_companyLocalService.deleteCompany(company);
+
+		company = _companyLocalService.fetchCompany(companyId);
+
+		Assert.assertNull(company);
+	}
+
+	protected static DB db;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -151,34 +151,6 @@ definition {
 	}
 
 	@priority = 5
-	test CanAddCompanyWithPortalInstancesAdminUI {
-		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
-		property portal.acceptance = "true";
-		property test.assert.warning.exceptions = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
-
-		SignOut.signOut();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://www.able.com:8080",
-			userEmailAddress = "test@www.able.com");
-
-		SQL.assertDatabaseCount(
-			databaseFilter = "ltest_%",
-			databaseSubstring = "ltest_",
-			expectedCount = 1);
-	}
-
-	@priority = 5
 	test CanDeleteCompany {
 		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
 		property portal.acceptance = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -124,64 +124,6 @@ definition {
 			expectedCount = 1);
 	}
 
-	@description = "This is a use case for LPS-160064."
-	@priority = 4
-	test CanAddCompanyWithHeadlessAPI {
-		property custom.properties = "virtual.hosts.valid.hosts=localhost,127.0.0.1,www.baker.com";
-		property test.assert.warning.exceptions = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		HeadlessPortalInstanceAPI.addPortalInstance(
-			domain = "www.baker.com",
-			portalInstanceId = "www.baker.com",
-			virtualHost = "www.baker.com");
-
-		SignOut.signOut();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://www.baker.com:8080",
-			userEmailAddress = "test@www.baker.com");
-
-		SQL.assertDatabaseCount(
-			databaseFilter = "lpartition%",
-			databaseSubstring = "lpartition",
-			expectedCount = 1);
-	}
-
-	@priority = 5
-	test CanDeleteCompany {
-		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
-		property portal.acceptance = "true";
-		property test.assert.warning.exceptions = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		HeadlessPortalInstanceAPI.addPortalInstance(
-			domain = "www.able.com",
-			portalInstanceId = "www.able.com",
-			virtualHost = "www.able.com");
-
-		SignOut.signOut();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://www.able.com:8080",
-			userEmailAddress = "test@www.able.com");
-
-		User.loginPG();
-
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.deleteCP(virtualHost = "www.able.com");
-
-		SQL.assertDatabaseCount(
-			databaseFilter = "ltest_%",
-			databaseSubstring = "ltest_",
-			expectedCount = 0);
-	}
-
 	@description = "This is a use case for LPS-171480."
 	@priority = 3
 	test CanScheduleJobInVariousCompaniesWhenAutoUpgradeIsEnabled {


### PR DESCRIPTION
@achaparro 
When the DB-P ticket gets merged, there will be more tests to remove as there are existing test cases that would be covered.

ScheduleWebContentChangesWithDBPartitioningActivatedAcrossVariousCompanies would be covered by CheckKBArticleSchedulerJobConfigurationTest.


CanScheduleJobInVariousCompaniesWhenAutoUpgradeIsEnabled is similar, however this covers a scenario that occurs during startup in MainServlet.
