### PR TITLE
LPD-36152 remove creating company with PortalInstanceAdminUI

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/databasepartitioning/DatabasePartitioning.testcase
@@ -151,34 +151,6 @@ definition {
 	}
 
 	@priority = 5
-	test CanAddCompanyWithPortalInstancesAdminUI {
-		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
-		property portal.acceptance = "true";
-		property test.assert.warning.exceptions = "true";
-		property test.liferay.virtual.instance = "false";
-		property test.run.type = "single";
-
-		PortalInstances.openVirtualInstancesAdmin();
-
-		PortalInstances.addCP(
-			mailDomain = "www.able.com",
-			virtualHost = "www.able.com",
-			webId = "www.able.com");
-
-		SignOut.signOut();
-
-		User.firstLoginUI(
-			password = PropsUtil.get("default.admin.password"),
-			specificURL = "http://www.able.com:8080",
-			userEmailAddress = "test@www.able.com");
-
-		SQL.assertDatabaseCount(
-			databaseFilter = "ltest_%",
-			databaseSubstring = "ltest_",
-			expectedCount = 1);
-	}
-
-	@priority = 5
 	test CanDeleteCompany {
 		property custom.properties = "database.partition.schema.name.prefix=ltest_${line.separator}virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com";
 		property portal.acceptance = "true";


### PR DESCRIPTION
The UI is tested in other functional tests and an integration test for adding a company is already present.

There was additional tests in this ticket, however they would become redundant after enabling DB-P for all integration tests.  

A ticket will be created to purge more functional tests.