### PR TITLE
LPD-30986 enable database partition on mysql and postgres env

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -6413,6 +6413,7 @@ information. Make sure to commit in all format-javadoc results.
 			<try>
 				<run-modules-integration-test
 					aws.store.enabled="true"
+					database.partition.enabled="true"
 					database.type="mysql"
 					database.version="5.7"
 				/>
@@ -6565,31 +6566,39 @@ information. Make sure to commit in all format-javadoc results.
 	</target>
 
 	<target name="modules-integration-mysql57">
-		<run-modules-integration-test database.type="mysql" database.version="5.7" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="mysql" database.version="5.7" />
 	</target>
 
 	<target name="modules-integration-mysql57-jdk11_open">
-		<run-modules-integration-test database.type="mysql" database.version="5.7" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="mysql" database.version="5.7" />
 	</target>
 
 	<target name="modules-integration-mysql57-jdk17_open">
-		<run-modules-integration-test database.type="mysql" database.version="5.7" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="mysql" database.version="5.7" />
 	</target>
 
 	<target name="modules-integration-mysql57-jdk21_zulu">
-		<run-modules-integration-test database.type="mysql" database.version="5.7" />
+		<run-modules-integration-test
+			database.partition.enabled="true"
+			database.type="mysql"
+			database.version="5.7"
+		/>
 	</target>
 
 	<target name="modules-integration-mysql57_stable">
-		<run-modules-integration-test database.type="mysql" database.version="5.7" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="mysql" database.version="5.7" />
 	</target>
 
 	<target name="modules-integration-mysql80">
-		<run-modules-integration-test database.type="mysql" database.version="8.0" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="mysql" database.version="8.0" />
 	</target>
 
 	<target name="modules-integration-mysql80-jdk11_open">
-		<run-modules-integration-test database.type="mysql" database.version="8.0" />
+		<run-modules-integration-test
+			database.partition.enabled="true"
+			database.type="mysql"
+			database.version="8.0"
+		/>
 	</target>
 
 	<target name="modules-integration-mysql80_stable">
@@ -6609,67 +6618,67 @@ information. Make sure to commit in all format-javadoc results.
 	</target>
 
 	<target name="modules-integration-postgresql121">
-		<run-modules-integration-test database.type="postgresql" database.version="12.1" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="12.1" />
 	</target>
 
 	<target name="modules-integration-postgresql121-jdk11_open">
-		<run-modules-integration-test database.type="postgresql" database.version="12.1" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="12.1" />
 	</target>
 
 	<target name="modules-integration-postgresql121-jdk21_zulu">
-		<run-modules-integration-test database.type="postgresql" database.version="12.1" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="12.1" />
 	</target>
 
 	<target name="modules-integration-postgresql134">
-		<run-modules-integration-test database.type="postgresql" database.version="13.4" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="13.4" />
 	</target>
 
 	<target name="modules-integration-postgresql134-jdk11_open">
-		<run-modules-integration-test database.type="postgresql" database.version="13.4" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="13.4" />
 	</target>
 
 	<target name="modules-integration-postgresql144">
-		<run-modules-integration-test database.type="postgresql" database.version="14.4" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="14.4" />
 	</target>
 
 	<target name="modules-integration-postgresql144-jdk11_open">
-		<run-modules-integration-test database.type="postgresql" database.version="14.4" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="14.4" />
 	</target>
 
 	<target name="modules-integration-postgresql153">
-		<run-modules-integration-test database.type="postgresql" database.version="15.3" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.3" />
 	</target>
 
 	<target name="modules-integration-postgresql153-jdk11_open">
-		<run-modules-integration-test database.type="postgresql" database.version="15.3" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.3" />
 	</target>
 
 	<target name="modules-integration-postgresql155">
-		<run-modules-integration-test database.type="postgresql" database.version="15.5" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.5" />
 	</target>
 
 	<target name="modules-integration-postgresql155-jdk11_open">
-		<run-modules-integration-test database.type="postgresql" database.version="15.5" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.5" />
 	</target>
 
 	<target name="modules-integration-postgresql155-jdk17_open">
-		<run-modules-integration-test database.type="postgresql" database.version="15.5" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.5" />
 	</target>
 
 	<target name="modules-integration-postgresql155-jdk21_zulu">
-		<run-modules-integration-test database.type="postgresql" database.version="15.5" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.5" />
 	</target>
 
 	<target name="modules-integration-postgresql155_stable">
-		<run-modules-integration-test database.type="postgresql" database.version="15.5" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.5" />
 	</target>
 
 	<target name="modules-integration-postgresql163">
-		<run-modules-integration-test database.type="postgresql" database.version="16.3" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="16.3" />
 	</target>
 
 	<target name="modules-integration-postgresql163-jdk11_open">
-		<run-modules-integration-test database.type="postgresql" database.version="16.3" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="16.3" />
 	</target>
 
 	<target name="modules-integration-project-templates">
@@ -8980,13 +8989,13 @@ information. Make sure to commit in all build services results.
 	<target name="subrepository-integration-mysql57">
 		<fail message="Please set the property ${subrepository.name}." unless="subrepository.name" />
 
-		<run-modules-integration-test database.type="mysql" database.version="5.7" refreshdependencies="true" subrepository.name="${subrepository.name}" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="mysql" database.version="5.7" refreshdependencies="true" subrepository.name="${subrepository.name}" />
 	</target>
 
 	<target name="subrepository-integration-postgresql155">
 		<fail message="Please set the property ${subrepository.name}." unless="subrepository.name" />
 
-		<run-modules-integration-test database.type="postgresql" database.version="15.5" refreshdependencies="true" subrepository.name="${subrepository.name}" />
+		<run-modules-integration-test database.partition.enabled="true" database.type="postgresql" database.version="15.5" refreshdependencies="true" subrepository.name="${subrepository.name}" />
 	</target>
 
 	<target name="subrepository-pmd">


### PR DESCRIPTION
The method of activating DB-P would also need to be looked at if we are using cron jobs to switch between enabling and disabling.  

Based on a previous discussion about labeling this on testray,  I think a env varible would have to be created and passed in depending and can be enabled within the actual run-modules-integration-test ant function. 