### PR TITLE
LPD-40015 Virtual Instances created with API do not use the admin email provided if verify company strangers is enabled.

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -12,21 +12,16 @@ import com.liferay.portal.instances.service.PortalInstancesLocalService;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.Contact;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.EmailAddressValidator;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CompanyService;
-import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.EmailAddressValidatorFactory;
 import com.liferay.portal.util.PortalInstances;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -116,42 +111,26 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 		long finalCompanyId = companyId;
 
-		Company company = PortalInstances.addCompany(
-			portalInstance.getSiteInitializerKey(),
-			() -> _companyService.addCompany(
-				finalCompanyId, portalInstance.getPortalInstanceId(),
-				portalInstance.getVirtualHost(), portalInstance.getDomain(), 0,
-				true));
+		Company company;
 
 		if (admin != null) {
-			User defaultAdminUser = _userLocalService.getUserByEmailAddress(
-				company.getCompanyId(),
-				PropsValues.DEFAULT_ADMIN_EMAIL_ADDRESS_PREFIX + "@" +
-					company.getMx());
+			_validateAdmin(admin);
 
-			Contact contact = defaultAdminUser.getContact();
-
-			Calendar calendar = CalendarFactoryUtil.getCalendar();
-
-			calendar.setTime(contact.getBirthday());
-
-			_userLocalService.updateUser(
-				defaultAdminUser.getUserId(), null, null, null, false,
-				defaultAdminUser.getReminderQueryQuestion(),
-				defaultAdminUser.getReminderQueryAnswer(),
-				defaultAdminUser.getScreenName(), admin.getEmailAddress(), true,
-				null, defaultAdminUser.getLanguageId(),
-				defaultAdminUser.getTimeZoneId(),
-				defaultAdminUser.getGreeting(), defaultAdminUser.getComments(),
-				admin.getGivenName(), defaultAdminUser.getMiddleName(),
-				admin.getFamilyName(), contact.getPrefixListTypeId(),
-				contact.getSuffixListTypeId(), defaultAdminUser.isMale(),
-				calendar.get(Calendar.MONTH),
-				calendar.get(Calendar.DAY_OF_MONTH),
-				calendar.get(Calendar.YEAR), contact.getSmsSn(),
-				contact.getFacebookSn(), contact.getJabberSn(),
-				contact.getSkypeSn(), contact.getTwitterSn(),
-				contact.getJobTitle(), null, null, null, null, null, null);
+			company = PortalInstances.addCompany(
+				portalInstance.getSiteInitializerKey(),
+				() -> _companyLocalService.addCompany(
+					finalCompanyId, portalInstance.getPortalInstanceId(),
+					portalInstance.getVirtualHost(), portalInstance.getDomain(),
+					0, true, true, null, null, admin.getEmailAddress(),
+					admin.getGivenName(), null, admin.getFamilyName()));
+		}
+		else {
+			company = PortalInstances.addCompany(
+				portalInstance.getSiteInitializerKey(),
+				() -> _companyService.addCompany(
+					finalCompanyId, portalInstance.getPortalInstanceId(),
+					portalInstance.getVirtualHost(), portalInstance.getDomain(),
+					0, true));
 		}
 
 		_portalInstancesLocalService.synchronizePortalInstances();
@@ -211,12 +190,12 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	}
 
 	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
 	private CompanyService _companyService;
 
 	@Reference
 	private PortalInstancesLocalService _portalInstancesLocalService;
-
-	@Reference
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -10,20 +10,20 @@ import com.liferay.headless.portal.instances.client.dto.v1_0.Admin;
 import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstance;
 import com.liferay.headless.portal.instances.client.pagination.Page;
 import com.liferay.headless.portal.instances.client.problem.Problem;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.instances.service.PortalInstancesLocalService;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.util.PropsValues;
 
 import java.util.List;
 
@@ -92,16 +92,14 @@ public class PortalInstanceResourceTest
 	@Override
 	@Test
 	public void testPostPortalInstance() throws Exception {
-		boolean originalCompanySecurityStrangersVerify =
-			ReflectionTestUtil.getAndSetFieldValue(
-				PropsValues.class, "COMPANY_SECURITY_STRANGERS_VERIFY", true);
-
 		_testPostPortalInstanceWithoutAdmin();
-		_testPostPortalInstanceWithAdmin();
 
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "COMPANY_SECURITY_STRANGERS_VERIFY",
-			originalCompanySecurityStrangersVerify);
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"COMPANY_SECURITY_STRANGERS_VERIFY", true)) {
+
+			_testPostPortalInstanceWithAdmin();
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -16,12 +16,14 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.List;
 
@@ -90,8 +92,16 @@ public class PortalInstanceResourceTest
 	@Override
 	@Test
 	public void testPostPortalInstance() throws Exception {
+		boolean originalCompanySecurityStrangersVerify =
+			ReflectionTestUtil.getAndSetFieldValue(
+				PropsValues.class, "COMPANY_SECURITY_STRANGERS_VERIFY", true);
+
 		_testPostPortalInstanceWithoutAdmin();
 		_testPostPortalInstanceWithAdmin();
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "COMPANY_SECURITY_STRANGERS_VERIFY",
+			originalCompanySecurityStrangersVerify);
 	}
 
 	@Override


### PR DESCRIPTION
Issue:
When creating an instance through the API, and an admin user is passed in,  the portal instance will be created with the default admin email and not the email provided.

Cause:
The issue is caused by company.security.strangers.verify when set to true.
This causes an email verification to be sent rather than updating the user,  since this is disable by default on CI, the issue was not caught. 

Solution:
Create the company with the admin user rather than creating the company first and updating the user.
