### PR TITLE
LPD-X Remove UpgradeProcessTest from unit_stable test batch

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -1432,8 +1432,7 @@
 
     test.batch.class.names.includes[unit_stable]=\
         **/test/**/DBInspectorUnitTest.java,\
-        **/test/**/LibraryReferenceTest.java,\
-        **/test/**/UpgradeProcessTest.java
+        **/test/**/LibraryReferenceTest.java
 
     test.batch.class.names.includes.modules[integration-*]=\
         **/test/integration/**/*Test.java,\


### PR DESCRIPTION
Hi Team,

I was adding a test into unit_stable and saw that UpgradeProcessTest is is included in`test.batch.class.names.includes[unit_stable]` but not run. Then, found that it was converted into an integration test in 2021 here: https://github.com/liferay/liferay-portal/commit/ce34ca23676bb4b77893b9a313be53a7c70fbef8
I didn't make a ticket for this but the last commit is the only change needed to remove it

Thank you!