### PR TITLE
LPD-42518 return database-partition-liferay.com when adding company

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/util/CompanyTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/CompanyTestUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.test.util;
 
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
@@ -34,6 +35,11 @@ import javax.portlet.PortletPreferences;
 public class CompanyTestUtil {
 
 	public static Company addCompany() throws Exception {
+		if (DBPartition.isPartitionEnabled()) {
+			return CompanyLocalServiceUtil.getCompanyByWebId(
+				TestPropsValues.COMPANY_WEB_ID);
+		}
+
 		return addCompany(RandomTestUtil.randomString());
 	}
 


### PR DESCRIPTION
@achaparro 
The only issue would be the cases where two companies are being created.  

We can have the second company needed use a string so that it returns a new company.
e.g CompanyTestUtil.addCompany(RandomTestUtil.randomString)