### PR TITLE
LPD-33702 Remove the functionaly to run only the Core Upgrade when executing the upgrade client

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -326,9 +326,7 @@ public class UpgradeRecorder {
 		new ConcurrentHashMap<>();
 
 	static {
-		if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled() ||
-			DBUpgrader.isUpgradeClient()) {
-
+		if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
 			_result = "pending";
 			_type = "pending";
 		}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.osgi.debug.SystemChecker;
-import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.executor.UpgradeExecutor;
 import com.liferay.portal.upgrade.internal.graph.ReleaseGraphManager;
@@ -105,11 +104,7 @@ public class ReleaseManagerImpl implements ReleaseManager {
 				return "failure";
 			}
 			else if (_isPendingModuleUpgrades()) {
-				if (DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
-					return "failure";
-				}
-
-				return "unresolved";
+				return "failure";
 			}
 		}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -136,7 +136,7 @@ public class UpgradeRecorderTest {
 			}
 		}
 
-		Assert.assertEquals("unresolved", _getResult());
+		Assert.assertEquals("failure", _getResult());
 	}
 
 	@Test

--- a/modules/util/portal-tools-db-upgrade-client/src/main/resources/portal-upgrade.properties
+++ b/modules/util/portal-tools-db-upgrade-client/src/main/resources/portal-upgrade.properties
@@ -5,8 +5,6 @@ liferay.home=../../
 
 schema.run.enabled=false
 
-upgrade.database.auto.run=true
-
 hibernate.jdbc.batch_size=250
 
 index.on.startup=false

--- a/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
+++ b/modules/util/portal-tools-db-upgrade-client/src/testFunctional/tests/DatabaseUpgradeClient.testcase
@@ -105,25 +105,6 @@ definition {
 		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-client-sh-disconnect");
 	}
 
-	@description = "LPS-158522: Upgrade client only upgrades core"
-	@priority = 2
-	test CheckUpgradeClientUpgradeCoreOnly {
-		property custom.upgrade.properties = "upgrade.database.auto.run=false";
-		property skip.get.testcase.database.properties = "true";
-		property skip.upgrade-legacy-database = "true";
-		property timeout.explicit.wait = "600";
-
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "run-upgrade-client");
-
-		AntCommands.runCommand("modules/util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml", "check-upgrade-status -Dupgrade.status=unresolved");
-
-		var schemaVersion = ValidateSmokeUpgrade.getSchemaVersion(mysqlStatement = "SELECT schemaVersion FROM Release_ WHERE servletContextName = 'com.liferay.journal.service';");
-
-		if (!(contains(${schemaVersion}, "4.1.0"))) {
-			fail("The upgrade client upgrades core and modules.");
-		}
-	}
-
 	@description = "LPS-158522: Upgrade client contains necessary files"
 	@priority = 3
 	test CheckUpgradeClientZipContents {

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -216,7 +216,6 @@ public class StartupHelperUtil {
 		boolean dbWarmed = true;
 
 		if (_dbNew || DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
-
 			dbWarmed = false;
 		}
 

--- a/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupHelperUtil.java
@@ -215,8 +215,7 @@ public class StartupHelperUtil {
 	private static boolean _isDBWarmed() {
 		boolean dbWarmed = true;
 
-		if (_dbNew || _upgrading ||
-			DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
+		if (_dbNew || DBUpgrader.isUpgradeDatabaseAutoRunEnabled()) {
 
 			dbWarmed = false;
 		}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -125,6 +125,10 @@ public class DBUpgrader {
 	}
 
 	public static boolean isUpgradeDatabaseAutoRunEnabled() {
+		if (_upgradeClient){
+			return true;
+		}
+
 		if (PortalRunMode.isTestMode()) {
 			return GetterUtil.getBoolean(
 				PropsUtil.get(PropsKeys.UPGRADE_DATABASE_AUTO_RUN));

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -125,7 +125,7 @@ public class DBUpgrader {
 	}
 
 	public static boolean isUpgradeDatabaseAutoRunEnabled() {
-		if (_upgradeClient){
+		if (_upgradeClient) {
 			return true;
 		}
 


### PR DESCRIPTION
Issue:
The DBClient can do core-only upgrades,  however this is not a usefull feature.

Solution:
Remove this feature by setting autoupgrade to true when DBClient is used.  