### PR TITLE
LPD-42705 Support same Object Portlet ID when copying virtual instances (approved by BPM)

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -99,6 +99,7 @@ import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -638,8 +639,7 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getCompanyId() + StringPool.AT +
-						objectDefinition.getObjectDefinitionId(),
+					_getObjectDefinitionKey(objectDefinition),
 					objectDefinitionId ->
 						inactiveObjectDefinitionDeployer.deploy(
 							objectDefinition));
@@ -664,8 +664,7 @@ public class ObjectDefinitionLocalServiceImpl
 					objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getCompanyId() + StringPool.AT +
-						objectDefinition.getObjectDefinitionId(),
+					_getObjectDefinitionKey(objectDefinition),
 					objectDefinitionId -> objectDefinitionDeployer.deploy(
 						objectDefinition));
 			}
@@ -942,14 +941,12 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						activeServiceRegistrationsMap.put(
-							companyId + StringPool.AT +
-								objectDefinition.getObjectDefinitionId(),
+							_getObjectDefinitionKey(objectDefinition),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 					else {
 						inactiveServiceRegistrationsMap.put(
-							companyId + StringPool.AT +
-								objectDefinition.getObjectDefinitionId(),
+							_getObjectDefinitionKey(objectDefinition),
 							inactiveObjectDefinitionDeployer.deploy(
 								objectDefinition));
 					}
@@ -1050,8 +1047,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 			List<ServiceRegistration<?>> serviceRegistrations =
 				serviceRegistrationsMap.remove(
-					objectDefinition.getCompanyId() + StringPool.AT +
-						objectDefinition.getObjectDefinitionId());
+					_getObjectDefinitionKey(objectDefinition));
 
 			if (serviceRegistrations != null) {
 				for (ServiceRegistration<?> serviceRegistration :
@@ -1348,8 +1344,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						serviceRegistrationsMap.put(
-							companyId + StringPool.AT +
-								objectDefinition.getObjectDefinitionId(),
+							_getObjectDefinitionKey(objectDefinition),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 				}
@@ -1767,6 +1762,16 @@ public class ObjectDefinitionLocalServiceImpl
 		}
 
 		return name;
+	}
+
+	private String _getObjectDefinitionKey(ObjectDefinition objectDefinition) {
+		String key = String.valueOf(objectDefinition.getObjectDefinitionId());
+
+		if (DBPartition.isPartitionEnabled()) {
+			key = key + StringPool.AT + objectDefinition.getCompanyId();
+		}
+
+		return key;
 	}
 
 	private long _getObjectFolderId(long companyId, long objectFolderId)

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -624,13 +624,13 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<InactiveObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_inactiveObjectDefinitionsServiceRegistrationsMaps.
 						entrySet()) {
 
 			InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer =
 				entry.getKey();
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			try (SafeCloseable safeCloseable =
@@ -638,7 +638,8 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId(),
 					objectDefinitionId ->
 						inactiveObjectDefinitionDeployer.deploy(
 							objectDefinition));
@@ -652,18 +653,19 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_serviceRegistrationsMaps.entrySet()) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 					objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					objectDefinition.getObjectDefinitionId(),
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId(),
 					objectDefinitionId -> objectDefinitionDeployer.deploy(
 						objectDefinition));
 			}
@@ -904,14 +906,14 @@ public class ObjectDefinitionLocalServiceImpl
 	public void setAopProxy(Object aopProxy) {
 		super.setAopProxy(aopProxy);
 
-		Map<Long, List<ServiceRegistration<?>>> activeServiceRegistrationsMap =
-			new ConcurrentHashMap<>();
+		Map<String, List<ServiceRegistration<?>>>
+			activeServiceRegistrationsMap = new ConcurrentHashMap<>();
 		InactiveObjectDefinitionDeployer inactiveObjectDefinitionDeployer =
 			new InactiveObjectDefinitionDeployerImpl(
 				_bundleContext, _objectEntryService, _objectFieldLocalService,
 				_objectRelatedModelsProviderRegistrarHelper,
 				_objectRelationshipLocalService);
-		Map<Long, List<ServiceRegistration<?>>>
+		Map<String, List<ServiceRegistration<?>>>
 			inactiveServiceRegistrationsMap = new ConcurrentHashMap<>();
 		ObjectDefinitionDeployer objectDefinitionDeployer =
 			new ObjectDefinitionDeployerImpl(
@@ -940,12 +942,14 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						activeServiceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 					else {
 						inactiveServiceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							inactiveObjectDefinitionDeployer.deploy(
 								objectDefinition));
 					}
@@ -998,7 +1002,7 @@ public class ObjectDefinitionLocalServiceImpl
 							}
 						});
 
-					Map<Long, List<ServiceRegistration<?>>>
+					Map<String, List<ServiceRegistration<?>>>
 						serviceRegistrationsMap =
 							_serviceRegistrationsMaps.remove(
 								objectDefinitionDeployer);
@@ -1034,19 +1038,20 @@ public class ObjectDefinitionLocalServiceImpl
 
 		for (Map.Entry
 				<ObjectDefinitionDeployer,
-				 Map<Long, List<ServiceRegistration<?>>>> entry :
+				 Map<String, List<ServiceRegistration<?>>>> entry :
 					_serviceRegistrationsMaps.entrySet()) {
 
 			ObjectDefinitionDeployer objectDefinitionDeployer = entry.getKey();
 
 			objectDefinitionDeployer.undeploy(objectDefinition);
 
-			Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+			Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 				entry.getValue();
 
 			List<ServiceRegistration<?>> serviceRegistrations =
 				serviceRegistrationsMap.remove(
-					objectDefinition.getObjectDefinitionId());
+					objectDefinition.getCompanyId() + StringPool.AT +
+						objectDefinition.getObjectDefinitionId());
 
 			if (serviceRegistrations != null) {
 				for (ServiceRegistration<?> serviceRegistration :
@@ -1332,7 +1337,7 @@ public class ObjectDefinitionLocalServiceImpl
 	private ObjectDefinitionDeployer _addingObjectDefinitionDeployer(
 		ObjectDefinitionDeployer objectDefinitionDeployer) {
 
-		Map<Long, List<ServiceRegistration<?>>> serviceRegistrationsMap =
+		Map<String, List<ServiceRegistration<?>>> serviceRegistrationsMap =
 			new ConcurrentHashMap<>();
 
 		_companyLocalService.forEachCompanyId(
@@ -1343,7 +1348,8 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						serviceRegistrationsMap.put(
-							objectDefinition.getObjectDefinitionId(),
+							companyId + StringPool.AT +
+								objectDefinition.getObjectDefinitionId(),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 				}
@@ -2711,7 +2717,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 	private final Map
 		<InactiveObjectDefinitionDeployer,
-		 Map<Long, List<ServiceRegistration<?>>>>
+		 Map<String, List<ServiceRegistration<?>>>>
 			_inactiveObjectDefinitionsServiceRegistrationsMaps =
 				Collections.synchronizedMap(new LinkedHashMap<>());
 
@@ -2808,7 +2814,7 @@ public class ObjectDefinitionLocalServiceImpl
 	private SearchLocalizationHelper _searchLocalizationHelper;
 
 	private final Map
-		<ObjectDefinitionDeployer, Map<Long, List<ServiceRegistration<?>>>>
+		<ObjectDefinitionDeployer, Map<String, List<ServiceRegistration<?>>>>
 			_serviceRegistrationsMaps = Collections.synchronizedMap(
 				new LinkedHashMap<>());
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -90,6 +90,7 @@ import com.liferay.petra.sql.dsl.Table;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.cluster.ClusterRequest;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
@@ -99,7 +100,6 @@ import com.liferay.portal.kernel.dao.orm.FinderCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
-import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
@@ -639,7 +639,8 @@ public class ObjectDefinitionLocalServiceImpl
 						objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					_getObjectDefinitionKey(objectDefinition),
+					DBPartitionUtil.getPartitionKey(
+						objectDefinition.getObjectDefinitionId()),
 					objectDefinitionId ->
 						inactiveObjectDefinitionDeployer.deploy(
 							objectDefinition));
@@ -664,7 +665,8 @@ public class ObjectDefinitionLocalServiceImpl
 					objectDefinition.getCompanyId())) {
 
 				serviceRegistrationsMap.computeIfAbsent(
-					_getObjectDefinitionKey(objectDefinition),
+					DBPartitionUtil.getPartitionKey(
+						objectDefinition.getObjectDefinitionId()),
 					objectDefinitionId -> objectDefinitionDeployer.deploy(
 						objectDefinition));
 			}
@@ -941,12 +943,14 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						activeServiceRegistrationsMap.put(
-							_getObjectDefinitionKey(objectDefinition),
+							DBPartitionUtil.getPartitionKey(
+								objectDefinition.getObjectDefinitionId()),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 					else {
 						inactiveServiceRegistrationsMap.put(
-							_getObjectDefinitionKey(objectDefinition),
+							DBPartitionUtil.getPartitionKey(
+								objectDefinition.getObjectDefinitionId()),
 							inactiveObjectDefinitionDeployer.deploy(
 								objectDefinition));
 					}
@@ -1047,7 +1051,8 @@ public class ObjectDefinitionLocalServiceImpl
 
 			List<ServiceRegistration<?>> serviceRegistrations =
 				serviceRegistrationsMap.remove(
-					_getObjectDefinitionKey(objectDefinition));
+					DBPartitionUtil.getPartitionKey(
+						objectDefinition.getObjectDefinitionId()));
 
 			if (serviceRegistrations != null) {
 				for (ServiceRegistration<?> serviceRegistration :
@@ -1344,7 +1349,8 @@ public class ObjectDefinitionLocalServiceImpl
 
 					if (objectDefinition.isActive()) {
 						serviceRegistrationsMap.put(
-							_getObjectDefinitionKey(objectDefinition),
+							DBPartitionUtil.getPartitionKey(
+								objectDefinition.getObjectDefinitionId()),
 							objectDefinitionDeployer.deploy(objectDefinition));
 					}
 				}
@@ -1762,16 +1768,6 @@ public class ObjectDefinitionLocalServiceImpl
 		}
 
 		return name;
-	}
-
-	private String _getObjectDefinitionKey(ObjectDefinition objectDefinition) {
-		String key = String.valueOf(objectDefinition.getObjectDefinitionId());
-
-		if (DBPartition.isPartitionEnabled()) {
-			key = key + StringPool.AT + objectDefinition.getCompanyId();
-		}
-
-		return key;
 	}
 
 	private long _getObjectFolderId(long companyId, long objectFolderId)

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/object/entries/application/list/ObjectEntriesPanelApp.java
@@ -56,7 +56,9 @@ public class ObjectEntriesPanelApp extends BasePanelApp {
 		if (portlet == null) {
 			portlet = _supplier.get();
 
-			_portlet = portlet;
+			if (portlet.getCompanyId() == _objectDefinition.getCompanyId()) {
+				_portlet = portlet;
+			}
 		}
 
 		return portlet;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -17,13 +17,18 @@ import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.persistence.PortletPersistence;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
@@ -654,6 +659,57 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testPortlets() throws Exception {
+		Company company = companyLocalService.fetchCompanyByVirtualHost(
+			TestPropsValues.COMPANY_WEB_ID);
+
+		String portletName = RandomTestUtil.randomString();
+
+		try {
+			_deployRemotePortlet(company.getCompanyId(), portletName);
+
+			long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
+			_deployRemotePortlet(defaultCompanyId, portletName);
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						company.getCompanyId())) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(
+					company.getCompanyId(), portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						defaultCompanyId)) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(defaultCompanyId, portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						COMPANY_IDS[0])) {
+
+				Assert.assertNull(
+					_portletLocalService.getPortletById(portletName));
+			}
+		}
+		finally {
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> _destroyRemotePortlet(companyId, portletName));
+		}
+	}
+
+	@Test
 	public void testRegenerateViews() throws Exception {
 		try {
 			DBPartitionUtil.forEachCompanyId(
@@ -805,6 +861,28 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 		}
 	}
 
+	private void _deployRemotePortlet(long companyId, String portletName)
+		throws Exception {
+
+		Portlet portlet = _portletPersistence.create(0);
+
+		portlet.setCompanyId(companyId);
+		portlet.setPortletId(portletName);
+
+		_portletLocalService.deployRemotePortlet(
+			new long[] {companyId}, portlet, new String[] {"category.hidden"},
+			true, true);
+	}
+
+	private void _destroyRemotePortlet(long companyId, String portletName) {
+		Portlet portlet = _portletLocalService.getPortletById(
+			companyId, portletName);
+
+		if (portlet != null) {
+			_portletLocalService.destroyRemotePortlet(portlet);
+		}
+	}
+
 	private static final String _CLASS_NAME = DBPartitionTest.class.getName();
 
 	@Inject
@@ -815,5 +893,11 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 
 	@Inject
 	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private PortletPersistence _portletPersistence;
 
 }

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -520,6 +520,57 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testDeployRemotePortlet() throws Exception {
+		Company company = companyLocalService.fetchCompanyByVirtualHost(
+			TestPropsValues.COMPANY_WEB_ID);
+
+		String portletName = RandomTestUtil.randomString();
+
+		try {
+			_deployRemotePortlet(company.getCompanyId(), portletName);
+
+			long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
+			_deployRemotePortlet(defaultCompanyId, portletName);
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						company.getCompanyId())) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(
+					company.getCompanyId(), portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						defaultCompanyId)) {
+
+				Portlet portlet = _portletLocalService.getPortletById(
+					portletName);
+
+				Assert.assertNotNull(portlet);
+				Assert.assertEquals(defaultCompanyId, portlet.getCompanyId());
+			}
+
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						COMPANY_IDS[0])) {
+
+				Assert.assertNull(
+					_portletLocalService.getPortletById(portletName));
+			}
+		}
+		finally {
+			DBPartitionUtil.forEachCompanyId(
+				companyId -> _destroyRemotePortlet(companyId, portletName));
+		}
+	}
+
+	@Test
 	public void testDropIndexControlTable() throws Exception {
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -656,57 +707,6 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	public void testInitResourceActions() throws Exception {
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> StartupHelperUtil.initResourceActions());
-	}
-
-	@Test
-	public void testPortlets() throws Exception {
-		Company company = companyLocalService.fetchCompanyByVirtualHost(
-			TestPropsValues.COMPANY_WEB_ID);
-
-		String portletName = RandomTestUtil.randomString();
-
-		try {
-			_deployRemotePortlet(company.getCompanyId(), portletName);
-
-			long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
-
-			_deployRemotePortlet(defaultCompanyId, portletName);
-
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						company.getCompanyId())) {
-
-				Portlet portlet = _portletLocalService.getPortletById(
-					portletName);
-
-				Assert.assertNotNull(portlet);
-				Assert.assertEquals(
-					company.getCompanyId(), portlet.getCompanyId());
-			}
-
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						defaultCompanyId)) {
-
-				Portlet portlet = _portletLocalService.getPortletById(
-					portletName);
-
-				Assert.assertNotNull(portlet);
-				Assert.assertEquals(defaultCompanyId, portlet.getCompanyId());
-			}
-
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						COMPANY_IDS[0])) {
-
-				Assert.assertNull(
-					_portletLocalService.getPortletById(portletName));
-			}
-		}
-		finally {
-			DBPartitionUtil.forEachCompanyId(
-				companyId -> _destroyRemotePortlet(companyId, portletName));
-		}
 	}
 
 	@Test

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletConfig;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletInstanceFactory;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
@@ -175,9 +176,13 @@ public class PortletTracker
 		String finalPortletName = portletName;
 		String finalPortletId = portletId;
 
+		long companyId = CompanyThreadLocal.getNonsystemCompanyId();
+
 		FutureTask<com.liferay.portal.kernel.model.Portlet> futureTask =
 			new FutureTask<>(
 				() -> {
+					CompanyThreadLocal.setCompanyId(companyId);
+
 					com.liferay.portal.kernel.model.Portlet addedPortletModel =
 						_addingPortlet(
 							serviceReference, portlet, finalPortletName,

--- a/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
+++ b/portal-impl/src/com/liferay/counter/service/persistence/impl/CounterFinderImpl.java
@@ -12,7 +12,7 @@ import com.liferay.counter.model.CounterRegister;
 import com.liferay.counter.model.impl.CounterImpl;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.cache.CacheRegistryItem;
 import com.liferay.portal.kernel.concurrent.CompeteLatch;
 import com.liferay.portal.kernel.dao.orm.LockMode;
@@ -20,11 +20,9 @@ import com.liferay.portal.kernel.dao.orm.ORMException;
 import com.liferay.portal.kernel.dao.orm.ObjectNotFoundException;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
-import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.util.PropsUtil;
@@ -126,7 +124,9 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 		CounterRegister counterRegister = getCounterRegister(oldName);
 
 		synchronized (counterRegister) {
-			if (_counterRegisterMap.containsKey(_encodeKey(newName))) {
+			if (_counterRegisterMap.containsKey(
+					DBPartitionUtil.getPartitionKey(newName))) {
+
 				throw new SystemException(
 					StringBundler.concat(
 						"Cannot rename ", oldName, " to ", newName));
@@ -152,8 +152,10 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 
 			counterRegister.setName(newName);
 
-			_counterRegisterMap.put(_encodeKey(newName), counterRegister);
-			_counterRegisterMap.remove(_encodeKey(oldName));
+			_counterRegisterMap.put(
+				DBPartitionUtil.getPartitionKey(newName), counterRegister);
+			_counterRegisterMap.remove(
+				DBPartitionUtil.getPartitionKey(oldName));
 		}
 	}
 
@@ -189,7 +191,7 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 				closeSession(session);
 			}
 
-			_counterRegisterMap.remove(_encodeKey(name));
+			_counterRegisterMap.remove(DBPartitionUtil.getPartitionKey(name));
 		}
 	}
 
@@ -197,7 +199,8 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 	public void reset(String name, long size) {
 		CounterRegister counterRegister = createCounterRegister(name, size);
 
-		_counterRegisterMap.put(_encodeKey(name), counterRegister);
+		_counterRegisterMap.put(
+			DBPartitionUtil.getPartitionKey(name), counterRegister);
 	}
 
 	protected void closeSession(Session session) throws ORMException {
@@ -253,7 +256,7 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 
 	protected CounterRegister getCounterRegister(String name) {
 		CounterRegister counterRegister = _counterRegisterMap.get(
-			_encodeKey(name));
+			DBPartitionUtil.getPartitionKey(name));
 
 		if (counterRegister != null) {
 			return counterRegister;
@@ -263,12 +266,14 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 
 			// Double check
 
-			counterRegister = _counterRegisterMap.get(_encodeKey(name));
+			counterRegister = _counterRegisterMap.get(
+				DBPartitionUtil.getPartitionKey(name));
 
 			if (counterRegister == null) {
 				counterRegister = createCounterRegister(name);
 
-				_counterRegisterMap.put(_encodeKey(name), counterRegister);
+				_counterRegisterMap.put(
+					DBPartitionUtil.getPartitionKey(name), counterRegister);
 			}
 
 			return counterRegister;
@@ -291,7 +296,8 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 			incrementType = name;
 		}
 
-		Integer rangeSize = _rangeSizeMap.get(_encodeKey(incrementType));
+		Integer rangeSize = _rangeSizeMap.get(
+			DBPartitionUtil.getPartitionKey(incrementType));
 
 		if (rangeSize == null) {
 			rangeSize = GetterUtil.getInteger(
@@ -299,7 +305,8 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 					PropsKeys.COUNTER_INCREMENT_PREFIX + incrementType),
 				PropsValues.COUNTER_INCREMENT);
 
-			_rangeSizeMap.put(_encodeKey(incrementType), rangeSize);
+			_rangeSizeMap.put(
+				DBPartitionUtil.getPartitionKey(incrementType), rangeSize);
 		}
 
 		return rangeSize.intValue();
@@ -391,16 +398,6 @@ public class CounterFinderImpl implements CacheRegistryItem, CounterFinder {
 		}
 
 		return newValue;
-	}
-
-	private String _encodeKey(String name) {
-		if (DBPartition.isPartitionEnabled()) {
-			return StringBundler.concat(
-				name, StringPool.AT,
-				CompanyThreadLocal.getNonsystemCompanyId());
-		}
-
-		return name;
 	}
 
 	private CounterHolder _obtainIncrement(

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -216,6 +216,14 @@ public class DBPartitionUtil {
 		}
 	}
 
+	public static String getPartitionKey(Object key) {
+		if (!DBPartition.isPartitionEnabled()) {
+			return key.toString();
+		}
+
+		return key + StringPool.AT + CompanyThreadLocal.getNonsystemCompanyId();
+	}
+
 	public static String getPartitionName(long companyId) {
 		if ((companyId == CompanyConstants.SYSTEM) ||
 			(companyId == _defaultCompanyId)) {

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2988,7 +2988,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				return super.put(key, value);
 			}
 
-			return super.put(key + StringPool.AT + value.getCompanyId(), value);
+			return super.put(DBPartitionUtil.getPartitionKey(key), value);
 		}
 
 		@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2927,7 +2927,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		new ConcurrentHashMap<>();
 	private static volatile Map<String, String> _portletIdsByStrutsPath;
 	private static final Map<String, Portlet> _portletsMap =
-		new GlobalPortletsMap();
+		new ShardedPortletsMap();
 	private static final Map<Long, Map<String, Portlet>> _portletsMaps =
 		new ConcurrentHashMap<>();
 
@@ -2961,7 +2961,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 	private ServiceTracker<FriendlyURLMapper, String[]> _serviceTracker;
 	private ServiceTrackerList<Consumer<Long>> _serviceTrackerList;
 
-	private static class GlobalPortletsMap
+	private static class ShardedPortletsMap
 		extends ConcurrentHashMap<String, Portlet> {
 
 		@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -2927,7 +2927,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		new ConcurrentHashMap<>();
 	private static volatile Map<String, String> _portletIdsByStrutsPath;
 	private static final Map<String, Portlet> _portletsMap =
-		new ConcurrentHashMap<>();
+		new GlobalPortletsMap();
 	private static final Map<Long, Map<String, Portlet>> _portletsMaps =
 		new ConcurrentHashMap<>();
 
@@ -2960,6 +2960,50 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 	private ServiceTracker<FriendlyURLMapper, String[]> _serviceTracker;
 	private ServiceTrackerList<Consumer<Long>> _serviceTrackerList;
+
+	private static class GlobalPortletsMap
+		extends ConcurrentHashMap<String, Portlet> {
+
+		@Override
+		public Portlet get(Object key) {
+			Portlet portlet = super.get(key);
+
+			if ((portlet != null) &&
+				(portlet.getCompanyId() == CompanyConstants.SYSTEM)) {
+
+				return portlet;
+			}
+
+			return super.get(
+				key + StringPool.AT +
+					CompanyThreadLocal.getNonsystemCompanyId());
+		}
+
+		@Override
+		public Portlet put(String key, Portlet value) {
+			if ((value == null) ||
+				(value.getCompanyId() == CompanyConstants.SYSTEM)) {
+
+				return super.put(key, value);
+			}
+
+			return super.put(key + StringPool.AT + value.getCompanyId(), value);
+		}
+
+		@Override
+		public Portlet remove(Object key) {
+			Portlet portlet = super.remove(
+				key + StringPool.AT +
+					CompanyThreadLocal.getNonsystemCompanyId());
+
+			if (portlet != null) {
+				return portlet;
+			}
+
+			return super.remove(key);
+		}
+
+	}
 
 	private class FriendlyURLMapperServiceTrackerCustomizer
 		implements ServiceTrackerCustomizer<FriendlyURLMapper, String[]> {

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.change.tracking.CTAware;
 import com.liferay.portal.kernel.cluster.Clusterable;
 import com.liferay.portal.kernel.configuration.Configuration;
 import com.liferay.portal.kernel.configuration.ConfigurationFactoryUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.PortletIdException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -2968,8 +2969,9 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		public Portlet get(Object key) {
 			Portlet portlet = super.get(key);
 
-			if ((portlet != null) &&
-				(portlet.getCompanyId() == CompanyConstants.SYSTEM)) {
+			if (!DBPartition.isPartitionEnabled() ||
+				((portlet != null) &&
+				 (portlet.getCompanyId() == CompanyConstants.SYSTEM))) {
 
 				return portlet;
 			}
@@ -2981,7 +2983,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		@Override
 		public Portlet put(String key, Portlet value) {
-			if ((value == null) ||
+			if (!DBPartition.isPartitionEnabled() || (value == null) ||
 				(value.getCompanyId() == CompanyConstants.SYSTEM)) {
 
 				return super.put(key, value);
@@ -2992,12 +2994,14 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 		@Override
 		public Portlet remove(Object key) {
-			Portlet portlet = super.remove(
-				key + StringPool.AT +
-					CompanyThreadLocal.getNonsystemCompanyId());
+			if (DBPartition.isPartitionEnabled()) {
+				Portlet portlet = super.remove(
+					key + StringPool.AT +
+						CompanyThreadLocal.getNonsystemCompanyId());
 
-			if (portlet != null) {
-				return portlet;
+				if (portlet != null) {
+					return portlet;
+				}
 			}
 
 			return super.remove(key);

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.ConfigurationFactoryImpl;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.application.type.ApplicationType;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.PortalCache;
@@ -2976,9 +2977,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 				return portlet;
 			}
 
-			return super.get(
-				key + StringPool.AT +
-					CompanyThreadLocal.getNonsystemCompanyId());
+			return super.get(DBPartitionUtil.getPartitionKey(key));
 		}
 
 		@Override
@@ -2996,8 +2995,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 		public Portlet remove(Object key) {
 			if (DBPartition.isPartitionEnabled()) {
 				Portlet portlet = super.remove(
-					key + StringPool.AT +
-						CompanyThreadLocal.getNonsystemCompanyId());
+					DBPartitionUtil.getPartitionKey(key));
 
 				if (portlet != null) {
 					return portlet;

--- a/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ResourceActionLocalServiceImpl.java
@@ -7,11 +7,11 @@ package com.liferay.portal.service.impl;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
-import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.ResourcePermission;
 import com.liferay.portal.kernel.model.role.RoleConstants;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -353,14 +352,8 @@ public class ResourceActionLocalServiceImpl
 	}
 
 	protected String encodeKey(String name, String actionId) {
-		String key = StringBundler.concat(name, StringPool.POUND, actionId);
-
-		if (DBPartition.isPartitionEnabled()) {
-			return StringBundler.concat(
-				key, StringPool.AT, CompanyThreadLocal.getNonsystemCompanyId());
-		}
-
-		return key;
+		return DBPartitionUtil.getPartitionKey(
+			StringBundler.concat(name, StringPool.POUND, actionId));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(


### PR DESCRIPTION
- LPD-42705 Adding test to expose the issue of company scoped portlets in database partitioning with the same portlet id
- LPD-42705 The key for the object definition must include the companyId. This also impact regular db partitioning since ids can collide
- LPD-42705 Wrapper for the map to partition it
- LPD-42705 Binding the portlet only if it belongs to the company of the object definition
- LPD-42705 Applying the sharding only when database partitioning is enabled
- LPD-42705 Rename
- LPD-42705 Applying the sharded cache only when database partitioning is enabled
- LPD-42705 SF
- LPD-42705 Add utility to get a partition key so we can track usages
- LPD-42705 Apply
- LPD-42705 Inherit the companyThreadLocal. We do not need to close the safeCloseable since the thread is also closed
- f
- LPD-42705 Now we can use the DBPartitionUtil method
