### PR TITLE
LPD-45337 Investigate errors in ci:test:db-partition suite 

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionCopyVirtualInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionCopyVirtualInstanceOperationTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -36,6 +37,10 @@ public class DBPartitionCopyVirtualInstanceOperationTest
 
 		_company = _companyLocalService.fetchCompanyByVirtualHost(
 			TestPropsValues.COMPANY_WEB_ID);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
 	}
 
 	@Override

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionCopyVirtualInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionCopyVirtualInstanceOperationTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 /**
  * @author István András Dézsi
  */
-@DataGuard(scope = DataGuard.Scope.NONE)
+@DataGuard(scope = DataGuard.Scope.CLASS)
 @RunWith(Arquillian.class)
 public class DBPartitionCopyVirtualInstanceOperationTest
 	extends BaseVirtualInstanceOperationTestCase {


### PR DESCRIPTION
Note:
Only the first error was reproduced in this ticket,  I have not be able to reproduce the second error mentioned however they should be the same.

Issue:
We are trying to remove the company's listed in the base test class, however they are not created in the extended class.

Solution:
Overload the annotation and update dataguard. 

