### PR TITLE
LPD-45451 Fixing flakiness of UpgradePartitionedConfigurationTableTest

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -405,6 +406,23 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testForEachCompanyIdOrdering() throws Exception {
+		boolean originalThreadPoolEnabled = ReflectionTestUtil.getFieldValue(
+			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED");
+
+		try {
+			_testForEachCompanyIdOrdering(false);
+			_testForEachCompanyIdOrdering(true);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				DBPartitionUtil.class,
+				"_DATABASE_PARTITION_THREAD_POOL_ENABLED",
+				originalThreadPoolEnabled);
+		}
+	}
+
+	@Test
 	public void testRemoveDBPartition() throws Exception {
 		addDBPartitions();
 
@@ -606,6 +624,22 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 		_schedulerEngine.schedule(
 			trigger, StringPool.BLANK, _JOB_GROUP_NAME, message,
 			StorageType.PERSISTED);
+	}
+
+	private void _testForEachCompanyIdOrdering(boolean threadPoolEnabled)
+		throws Exception {
+
+		List<Long> companyIds = new CopyOnWriteArrayList<>();
+
+		ReflectionTestUtil.setFieldValue(
+			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
+			threadPoolEnabled);
+
+		DBPartitionUtil.forEachCompanyId(companyIds::add);
+
+		Assert.assertEquals(
+			companyIds.toString(),
+			(Long)PortalInstancePool.getDefaultCompanyId(), companyIds.get(0));
 	}
 
 	private static final String _JOB_GROUP_NAME = "liferay/test";

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -629,11 +629,11 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	private void _testForEachCompanyIdOrdering(boolean threadPoolEnabled)
 		throws Exception {
 
-		List<Long> companyIds = new CopyOnWriteArrayList<>();
-
 		ReflectionTestUtil.setFieldValue(
 			DBPartitionUtil.class, "_DATABASE_PARTITION_THREAD_POOL_ENABLED",
 			threadPoolEnabled);
+
+		List<Long> companyIds = new CopyOnWriteArrayList<>();
 
 		DBPartitionUtil.forEachCompanyId(companyIds::add);
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -28,9 +28,8 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
@@ -99,7 +98,8 @@ public class UpgradePartitionedConfigurationTableTest
 
 	@Test
 	public void testUpgradeProcess() throws Exception {
-		_company = CompanyTestUtil.addCompany(true);
+		Company company = companyLocalService.fetchCompanyByVirtualHost(
+			TestPropsValues.COMPANY_WEB_ID);
 
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> {
@@ -113,9 +113,6 @@ public class UpgradePartitionedConfigurationTableTest
 				}
 			});
 
-		Group group = GroupLocalServiceUtil.getGroup(
-			_company.getCompanyId(), GroupConstants.GUEST);
-
 		Map<Long, ConfigurationEntry> validConfigurationEntries =
 			HashMapBuilder.<Long, ConfigurationEntry>put(
 				_companyId,
@@ -127,15 +124,20 @@ public class UpgradePartitionedConfigurationTableTest
 					ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
 					RandomTestUtil.randomLong())
 			).put(
-				_company.getCompanyId(),
-				new ConfigurationEntry(
-					ExtendedObjectClassDefinition.Scope.GROUP,
-					group.getGroupId())
+				company.getCompanyId(),
+				() -> {
+					Group group = GroupLocalServiceUtil.getGroup(
+						company.getCompanyId(), GroupConstants.GUEST);
+
+					return new ConfigurationEntry(
+						ExtendedObjectClassDefinition.Scope.GROUP,
+						group.getGroupId());
+				}
 			).put(
-				_company.getCompanyId(),
+				company.getCompanyId(),
 				new ConfigurationEntry(
 					ExtendedObjectClassDefinition.Scope.COMPANY,
-					_company.getCompanyId())
+					company.getCompanyId())
 			).build();
 
 		long randomCompanyId = RandomTestUtil.randomLong();
@@ -309,9 +311,6 @@ public class UpgradePartitionedConfigurationTableTest
 	private static ResourceActionLocalService _resourceActionLocalService;
 
 	private static Map<String, ResourceAction> _resourceActions;
-
-	@DeleteAfterTestRun
-	private Company _company;
 
 	private class ConfigurationEntry {
 

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedConfigurationTableTest.java
@@ -209,6 +209,7 @@ public class UpgradePartitionedConfigurationTableTest
 						configurationEntryEntry.getValue();
 
 					Assert.assertTrue(
+						logMessage,
 						logMessage.contains(
 							StringBundler.concat(
 								StringUtil.upperCaseFirstLetter(

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -160,11 +160,19 @@ public class DBPartitionUtil {
 			unsafeConsumer.accept(null);
 		}
 		else {
-			for (long companyId : companyIds) {
-				try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
-						companyId)) {
+			try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
+					_defaultCompanyId)) {
 
-					unsafeConsumer.accept(companyId);
+				unsafeConsumer.accept(_defaultCompanyId);
+			}
+
+			for (long companyId : companyIds) {
+				if (companyId != _defaultCompanyId) {
+					try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
+							companyId)) {
+
+						unsafeConsumer.accept(companyId);
+					}
 				}
 			}
 		}
@@ -846,15 +854,14 @@ public class DBPartitionUtil {
 				unsafeConsumer.accept(null);
 			}
 			else {
-				for (long companyId : companyIds) {
-					if (companyId == _defaultCompanyId) {
-						try (SafeCloseable safeCloseable =
-								CompanyThreadLocal.lock(companyId)) {
+				try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
+						_defaultCompanyId)) {
 
-							unsafeConsumer.accept(companyId);
-						}
-					}
-					else {
+					unsafeConsumer.accept(_defaultCompanyId);
+				}
+
+				for (long companyId : companyIds) {
+					if (companyId != _defaultCompanyId) {
 						Future<Void> future = executorService.submit(
 							() -> {
 								try (SafeCloseable safeCloseable =


### PR DESCRIPTION
Finally the issue was that during normal upgrade process, it was ensured the execution order of the upgrades through the partitions in a way that the default partition was always upgraded first before upgrading the rest of partitions.
This was not enforced during the upgrade execution in tests, as the company IDs are already cached and not retrieved from database.

This PR adds the next things:
- Enforces the execution of `DBPartitionUtil.forEachCompanyId` in the default partition first, and then in the rest of partitions, in any case.
- Adds a new test for the previous change.
- Improves the performance of the `UpgradePartitionedConfigurationTableTest` by using the partition that is already created by the test framework instead of creating a new one.
- In case the assert of the `UpgradePartitionedConfigurationTableTest` fails, the log content is printed in the assert message for debugging.