### PR TITLE
 LPD-47033 Create backend tests for each DB we support 

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -40,7 +40,13 @@ ci.test.available.suites=\
     app-servers,\
     auto-tagging,\
     backend,\
+    backend-db2,\
     backend-hypersonic,\
+    backend-mariadb,\
+    backend-mysql,\
+    backend-oracle,\
+    backend-postgresql,\
+    backend-sqlserver,\
     blade,\
     bundle,\
     bundles,\
@@ -227,7 +233,13 @@ ci.test.suite.description[analytics-cloud]=Test Analytics Cloud tests.
 ci.test.suite.description[app-servers]=Test Deployments on App Servers.
 ci.test.suite.description[auto-tagging]=Test Auto Tagging tests.
 ci.test.suite.description[backend]=Test backend tests.
+ci.test.suite.description[backend-db2]=Test backend tests on DB2.
 ci.test.suite.description[backend-hypersonic]=Test backend tests on Hypersonic.
+ci.test.suite.description[backend-mariadb]=Test backend tests on MariaDB.
+ci.test.suite.description[backend-mysql]=Test backend tests on MySQL.
+ci.test.suite.description[backend-oracle]=Test backend tests on Oracle.
+ci.test.suite.description[backend-postgresql]=Test backend tests on Postgres SQL.
+ci.test.suite.description[backend-sqlserver]=Test backend tests on SQL Server.
 ci.test.suite.description[blade]=Test Blade samples tests.
 ci.test.suite.description[bundle]=Saves a compiled tomcat bundle.
 ci.test.suite.description[calendar]=Test Calendar tests.

--- a/test.properties
+++ b/test.properties
@@ -3587,6 +3587,15 @@
         unit
 
     #
+    # Backend DB2
+    #
+
+    test.batch.dist.app.servers[backend-db2]=tomcat
+
+    test.batch.names[backend-db2]=\
+        modules-integration-db2111
+
+    #
     # Backend Hypersonic
     #
 
@@ -3611,6 +3620,67 @@
         service-builder,\
         source-format,\
         unit
+
+    #
+    # Backend MariaDB
+    #
+
+    test.batch.dist.app.servers[backend-mariadb]=tomcat
+
+    test.batch.names[backend-mariadb]=\
+        modules-integration-mariadb102,\
+        modules-integration-mariadb104,\
+        modules-integration-mariadb106
+
+    #
+    # Backend MySQL
+    #
+
+    test.batch.dist.app.servers[backend-mysql]=tomcat
+
+    test.batch.names[backend-mysql]=\
+        bundle-blacklist-restart-mysql57,\
+        central-requirements,\
+        lpkg-container-mysql57,\
+        lpkg-controller-mysql57,\
+        lpkg-override-mysql57,\
+        lpkg-persistence-mysql57,\
+        lpkg-startup-mysql57,\
+        modules-integration-mysql57,\
+        release-osgi-state-exploded-test-mysql57,\
+        release-osgi-state-lpkg-change-directory-test-mysql57,\
+        release-osgi-state-lpkg-test-mysql57
+
+    #
+    # Backend Oracle
+    #
+
+    test.batch.dist.app.servers[backend-oracle]=tomcat
+
+    test.batch.names[backend-oracle]=\
+        modules-integration-oracle193
+
+    #
+    # Backend Postgres
+    #
+
+    test.batch.dist.app.servers[backend-postgresql]=tomcat
+
+    test.batch.names[backend-postgresql]=\
+        modules-integration-postgresql134,\
+        modules-integration-postgresql144,\
+        modules-integration-postgresql153,\
+        modules-integration-postgresql163
+
+    #
+    # Backend SQLServer
+    #
+
+    test.batch.dist.app.servers[backend-sqlserver]=tomcat
+
+    test.batch.names[backend-sqlserver]=\
+        modules-integration-sqlserver2017,\
+        modules-integration-sqlserver2019
 
     #
     # Blade


### PR DESCRIPTION
`ci:test:backend` is still present, we are just branching off each specific DB we support.

1. ` ci:test:backend-mysql`
 Will run all integration tests under MySQL as well as the mysql specific test batches:
>         bundle-blacklist-restart-mysql57,\
>         central-requirements,\
>         lpkg-container-mysql57,\
>         lpkg-controller-mysql57,\
>         lpkg-override-mysql57,\
>         lpkg-persistence-mysql57,\
>         lpkg-startup-mysql57,\
>         modules-integration-mysql57,\
>         release-osgi-state-exploded-test-mysql57,\
>         release-osgi-state-lpkg-change-directory-test-mysql57,\
>         release-osgi-state-lpkg-test-mysql57 

 2. `ci:test:backend-hypersonic`
    This did not change, however this also runs the unit tests and modules-unit test so this suite can be used to check those.

These just run the integration test under the respective DB(all version available for each)
3.`ci:test:backend-oracle`
4.`ci:test:backend-postgresql`
5.`ci:test:backend-db2`
6.`ci:test:backend-sqlserver`
7.`ci:test:backend-mariadb`

Note:
These will not run until it gets merged(?)
