### PR TITLE
LPD-42488 Prioritize Company Model Classname when using Dataguard

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -53,7 +53,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -275,7 +275,7 @@ public class DataGuardTestRuleUtil {
 
 		StringBundler sb = new StringBundler();
 
-		Map<String, List<BaseModel<?>>> dataMap = _captureDataMap();
+		LinkedHashMap<String, List<BaseModel<?>>> dataMap = _captureDataMap();
 
 		for (Map.Entry<String, List<BaseModel<?>>> entry : dataMap.entrySet()) {
 			String className = entry.getKey();
@@ -334,13 +334,14 @@ public class DataGuardTestRuleUtil {
 			Map<String, List<BaseModel<?>>> previousDataMap)
 		throws Throwable {
 
-		Map<String, PersistedModelLocalService> persistedModelLocalServices =
-			_getPersistedModelLocalServices();
+		LinkedHashMap<String, PersistedModelLocalService>
+			persistedModelLocalServices = _getPersistedModelLocalServices();
 
 		while (true) {
 			boolean deleted = false;
 
-			Map<String, List<BaseModel<?>>> dataMap = _captureDataMap();
+			LinkedHashMap<String, List<BaseModel<?>>> dataMap =
+				_captureDataMap();
 
 			for (Map.Entry<String, List<BaseModel<?>>> entry :
 					dataMap.entrySet()) {
@@ -399,11 +400,12 @@ public class DataGuardTestRuleUtil {
 		}
 	}
 
-	private static Map<String, List<BaseModel<?>>> _captureDataMap() {
-		Map<String, PersistedModelLocalService> persistedModelLocalServices =
-			_getPersistedModelLocalServices();
+	private static LinkedHashMap<String, List<BaseModel<?>>> _captureDataMap() {
+		LinkedHashMap<String, PersistedModelLocalService>
+			persistedModelLocalServices = _getPersistedModelLocalServices();
 
-		Map<String, List<BaseModel<?>>> dataMap = new HashMap<>();
+		LinkedHashMap<String, List<BaseModel<?>>> dataMap =
+			new LinkedHashMap<>();
 
 		for (Map.Entry<String, PersistedModelLocalService> entry :
 				persistedModelLocalServices.entrySet()) {
@@ -519,32 +521,34 @@ public class DataGuardTestRuleUtil {
 		return persistedModelLocalService.getBasePersistence();
 	}
 
-	private static Map<String, PersistedModelLocalService>
+	private static LinkedHashMap<String, PersistedModelLocalService>
 		_getPersistedModelLocalServices() {
 
-		Map<String, PersistedModelLocalService>
-			scrubbedPersistedModelLocalServices = new HashMap<>();
+		LinkedHashMap<String, PersistedModelLocalService>
+			scrubbedPersistedModelLocalServices = new LinkedHashMap<>();
 
 		ServiceTrackerMap<String, PersistedModelLocalService>
 			serviceTrackerMap = ReflectionTestUtil.getFieldValue(
 				PersistedModelLocalServiceRegistryUtil.class,
 				"_serviceTrackerMap");
 
-		for (String modeClassName : _prioritizedModelClassNames) {
-			if (serviceTrackerMap.containsKey(modeClassName) &&
-				(modeClassName.indexOf(CharPool.POUND) == -1)) {
+		for (String modelClassName : _prioritizedModelClassNames) {
+			if (serviceTrackerMap.containsKey(modelClassName) &&
+				(modelClassName.indexOf(CharPool.POUND) == -1)) {
 
 				scrubbedPersistedModelLocalServices.put(
-					modeClassName, serviceTrackerMap.getService(modeClassName));
+					modelClassName,
+					serviceTrackerMap.getService(modelClassName));
 			}
 		}
 
-		for (String modeClassName : serviceTrackerMap.keySet()) {
-			if (!_blacklistedModelClassNames.contains(modeClassName) &&
-				(modeClassName.indexOf(CharPool.POUND) == -1)) {
+		for (String modelClassName : serviceTrackerMap.keySet()) {
+			if (!_blacklistedModelClassNames.contains(modelClassName) &&
+				(modelClassName.indexOf(CharPool.POUND) == -1)) {
 
 				scrubbedPersistedModelLocalServices.put(
-					modeClassName, serviceTrackerMap.getService(modeClassName));
+					modelClassName,
+					serviceTrackerMap.getService(modelClassName));
 			}
 		}
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -529,6 +530,15 @@ public class DataGuardTestRuleUtil {
 				PersistedModelLocalServiceRegistryUtil.class,
 				"_serviceTrackerMap");
 
+		for (String modeClassName : _prioritizedModelClassNames) {
+			if (serviceTrackerMap.containsKey(modeClassName) &&
+				(modeClassName.indexOf(CharPool.POUND) == -1)) {
+
+				scrubbedPersistedModelLocalServices.put(
+					modeClassName, serviceTrackerMap.getService(modeClassName));
+			}
+		}
+
 		for (String modeClassName : serviceTrackerMap.keySet()) {
 			if (!_blacklistedModelClassNames.contains(modeClassName) &&
 				(modeClassName.indexOf(CharPool.POUND) == -1)) {
@@ -647,6 +657,8 @@ public class DataGuardTestRuleUtil {
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
+	private static final List<String> _prioritizedModelClassNames =
+		ListUtil.fromArray("com.liferay.portal.kernel.model.Company");
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -54,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -661,8 +661,9 @@ public class DataGuardTestRuleUtil {
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
-	private static final List<String> _prioritizedModelClassNames =
-		ListUtil.fromArray("com.liferay.portal.kernel.model.Company");
+	private static final Set<String> _prioritizedModelClassNames =
+		new LinkedHashSet<>(
+			Arrays.<String>asList("com.liferay.portal.kernel.model.Company"));
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =


### PR DESCRIPTION
Issue:
Data that is required to be present for the removal of a Company that is added during a test will be removed by data guard at the end of the test
Dataguard will remove test data according to the available persisted local services, which seems to be returned at a random order.  

Potential Solution:
Prioritize certain model classnames to ensure proper removal.

In this case,  the dataguard was removing a layout causing the company to improperly be deleted,  leaving behind the webID cached.