### PR TITLE
LPD-47033 Create backend suites for each database type

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -40,7 +40,13 @@ ci.test.available.suites=\
     app-servers,\
     auto-tagging,\
     backend,\
+    backend-db2,\
     backend-hypersonic,\
+    backend-mariadb,\
+    backend-mysql,\
+    backend-oracle,\
+    backend-postgresql,\
+    backend-sqlserver,\
     blade,\
     bundle,\
     bundles,\
@@ -227,7 +233,13 @@ ci.test.suite.description[analytics-cloud]=Test Analytics Cloud tests.
 ci.test.suite.description[app-servers]=Test Deployments on App Servers.
 ci.test.suite.description[auto-tagging]=Test Auto Tagging tests.
 ci.test.suite.description[backend]=Test backend tests.
+ci.test.suite.description[backend-db2]=Test backend tests on DB2.
 ci.test.suite.description[backend-hypersonic]=Test backend tests on Hypersonic.
+ci.test.suite.description[backend-mariadb]=Test backend tests on MariaDB.
+ci.test.suite.description[backend-mysql]=Test backend tests on MySQL.
+ci.test.suite.description[backend-oracle]=Test backend tests on Oracle.
+ci.test.suite.description[backend-postgresql]=Test backend tests on Postgres SQL.
+ci.test.suite.description[backend-sqlserver]=Test backend tests on SQL Server.
 ci.test.suite.description[blade]=Test Blade samples tests.
 ci.test.suite.description[bundle]=Saves a compiled tomcat bundle.
 ci.test.suite.description[calendar]=Test Calendar tests.

--- a/test.properties
+++ b/test.properties
@@ -3602,24 +3602,7 @@
     test.batch.dist.app.servers[backend-hypersonic]=tomcat
 
     test.batch.names[backend-hypersonic]=\
-        bundle-blacklist-restart-mysql57,\
-        central-requirements,\
-        lpkg-container-mysql57,\
-        lpkg-controller-mysql57,\
-        lpkg-override-mysql57,\
-        lpkg-persistence-mysql57,\
-        lpkg-startup-mysql57,\
-        modules-compile,\
-        modules-integration-hypersonic20,\
-        modules-semantic-versioning,\
-        modules-unit,\
-        release-osgi-state-exploded-test-mysql57,\
-        release-osgi-state-lpkg-change-directory-test-mysql57,\
-        release-osgi-state-lpkg-test-mysql57,\
-        rest-builder,\
-        service-builder,\
-        source-format,\
-        unit
+        modules-integration-hypersonic20
 
     #
     # Backend MariaDB
@@ -3628,8 +3611,6 @@
     test.batch.dist.app.servers[backend-mariadb]=tomcat
 
     test.batch.names[backend-mariadb]=\
-        modules-integration-mariadb102,\
-        modules-integration-mariadb104,\
         modules-integration-mariadb106
 
     #
@@ -3667,9 +3648,6 @@
     test.batch.dist.app.servers[backend-postgresql]=tomcat
 
     test.batch.names[backend-postgresql]=\
-        modules-integration-postgresql134,\
-        modules-integration-postgresql144,\
-        modules-integration-postgresql153,\
         modules-integration-postgresql163
 
     #
@@ -3679,7 +3657,6 @@
     test.batch.dist.app.servers[backend-sqlserver]=tomcat
 
     test.batch.names[backend-sqlserver]=\
-        modules-integration-sqlserver2017,\
         modules-integration-sqlserver2019
 
     #

--- a/test.properties
+++ b/test.properties
@@ -3587,6 +3587,15 @@
         unit
 
     #
+    # Backend DB2
+    #
+
+    test.batch.dist.app.servers[backend-db2]=tomcat
+
+    test.batch.names[backend-db2]=\
+        modules-integration-db2111
+
+    #
     # Backend Hypersonic
     #
 
@@ -3611,6 +3620,67 @@
         service-builder,\
         source-format,\
         unit
+
+    #
+    # Backend MariaDB
+    #
+
+    test.batch.dist.app.servers[backend-mariadb]=tomcat
+
+    test.batch.names[backend-mariadb]=\
+        modules-integration-mariadb102,\
+        modules-integration-mariadb104,\
+        modules-integration-mariadb106
+
+    #
+    # Backend MySQL
+    #
+
+    test.batch.dist.app.servers[backend-mysql]=tomcat
+
+    test.batch.names[backend-mysql]=\
+        bundle-blacklist-restart-mysql57,\
+        central-requirements,\
+        lpkg-container-mysql57,\
+        lpkg-controller-mysql57,\
+        lpkg-override-mysql57,\
+        lpkg-persistence-mysql57,\
+        lpkg-startup-mysql57,\
+        modules-integration-mysql57,\
+        release-osgi-state-exploded-test-mysql57,\
+        release-osgi-state-lpkg-change-directory-test-mysql57,\
+        release-osgi-state-lpkg-test-mysql57
+
+    #
+    # Backend Oracle
+    #
+
+    test.batch.dist.app.servers[backend-oracle]=tomcat
+
+    test.batch.names[backend-oracle]=\
+        modules-integration-oracle193
+
+    #
+    # Backend Postgres
+    #
+
+    test.batch.dist.app.servers[backend-postgresql]=tomcat
+
+    test.batch.names[backend-postgresql]=\
+        modules-integration-postgresql134,\
+        modules-integration-postgresql144,\
+        modules-integration-postgresql153,\
+        modules-integration-postgresql163
+
+    #
+    # Backend SQLServer
+    #
+
+    test.batch.dist.app.servers[backend-sqlserver]=tomcat
+
+    test.batch.names[backend-sqlserver]=\
+        modules-integration-sqlserver2017,\
+        modules-integration-sqlserver2019
 
     #
     # Blade


### PR DESCRIPTION
New Suites:
```
ci:test:backend-oracle
ci:test:backend-postgresql
ci:test:backend-sqlserver
ci:test:backend-mysql
ci:test:backend-db2
ci:test:backend-mariadb
```

Modified Suite:
`ci:test:backend-hypersonic`
This was also running some mysql batches,  I migrated those tests over to the mysql suite,but retained the other lower level test batches.

Just the single Postgres took 3 hours, the full version took around 10 hours to complete.