### PR TITLE
LPD-42488 Proritize Company model in Dataguard to ensure proper company removal

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -53,7 +53,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -275,7 +275,7 @@ public class DataGuardTestRuleUtil {
 
 		StringBundler sb = new StringBundler();
 
-		Map<String, List<BaseModel<?>>> dataMap = _captureDataMap();
+		LinkedHashMap<String, List<BaseModel<?>>> dataMap = _captureDataMap();
 
 		for (Map.Entry<String, List<BaseModel<?>>> entry : dataMap.entrySet()) {
 			String className = entry.getKey();
@@ -334,13 +334,14 @@ public class DataGuardTestRuleUtil {
 			Map<String, List<BaseModel<?>>> previousDataMap)
 		throws Throwable {
 
-		Map<String, PersistedModelLocalService> persistedModelLocalServices =
-			_getPersistedModelLocalServices();
+		LinkedHashMap<String, PersistedModelLocalService>
+			persistedModelLocalServices = _getPersistedModelLocalServices();
 
 		while (true) {
 			boolean deleted = false;
 
-			Map<String, List<BaseModel<?>>> dataMap = _captureDataMap();
+			LinkedHashMap<String, List<BaseModel<?>>> dataMap =
+				_captureDataMap();
 
 			for (Map.Entry<String, List<BaseModel<?>>> entry :
 					dataMap.entrySet()) {
@@ -399,11 +400,12 @@ public class DataGuardTestRuleUtil {
 		}
 	}
 
-	private static Map<String, List<BaseModel<?>>> _captureDataMap() {
-		Map<String, PersistedModelLocalService> persistedModelLocalServices =
-			_getPersistedModelLocalServices();
+	private static LinkedHashMap<String, List<BaseModel<?>>> _captureDataMap() {
+		LinkedHashMap<String, PersistedModelLocalService>
+			persistedModelLocalServices = _getPersistedModelLocalServices();
 
-		Map<String, List<BaseModel<?>>> dataMap = new HashMap<>();
+		LinkedHashMap<String, List<BaseModel<?>>> dataMap =
+			new LinkedHashMap<>();
 
 		for (Map.Entry<String, PersistedModelLocalService> entry :
 				persistedModelLocalServices.entrySet()) {
@@ -519,32 +521,34 @@ public class DataGuardTestRuleUtil {
 		return persistedModelLocalService.getBasePersistence();
 	}
 
-	private static Map<String, PersistedModelLocalService>
+	private static LinkedHashMap<String, PersistedModelLocalService>
 		_getPersistedModelLocalServices() {
 
-		Map<String, PersistedModelLocalService>
-			scrubbedPersistedModelLocalServices = new HashMap<>();
+		LinkedHashMap<String, PersistedModelLocalService>
+			scrubbedPersistedModelLocalServices = new LinkedHashMap<>();
 
 		ServiceTrackerMap<String, PersistedModelLocalService>
 			serviceTrackerMap = ReflectionTestUtil.getFieldValue(
 				PersistedModelLocalServiceRegistryUtil.class,
 				"_serviceTrackerMap");
 
-		for (String modeClassName : _prioritizedModelClassNames) {
-			if (serviceTrackerMap.containsKey(modeClassName) &&
-				(modeClassName.indexOf(CharPool.POUND) == -1)) {
+		for (String modelClassName : _prioritizedModelClassNames) {
+			if (serviceTrackerMap.containsKey(modelClassName) &&
+				(modelClassName.indexOf(CharPool.POUND) == -1)) {
 
 				scrubbedPersistedModelLocalServices.put(
-					modeClassName, serviceTrackerMap.getService(modeClassName));
+					modelClassName,
+					serviceTrackerMap.getService(modelClassName));
 			}
 		}
 
-		for (String modeClassName : serviceTrackerMap.keySet()) {
-			if (!_blacklistedModelClassNames.contains(modeClassName) &&
-				(modeClassName.indexOf(CharPool.POUND) == -1)) {
+		for (String modelClassName : serviceTrackerMap.keySet()) {
+			if (!_blacklistedModelClassNames.contains(modelClassName) &&
+				(modelClassName.indexOf(CharPool.POUND) == -1)) {
 
 				scrubbedPersistedModelLocalServices.put(
-					modeClassName, serviceTrackerMap.getService(modeClassName));
+					modelClassName,
+					serviceTrackerMap.getService(modelClassName));
 			}
 		}
 

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -530,7 +530,7 @@ public class DataGuardTestRuleUtil {
 				PersistedModelLocalServiceRegistryUtil.class,
 				"_serviceTrackerMap");
 
-		for (String modelClassName : _prioritizedModelClassNames) {
+		for (String modelClassName : _PRIORITIZED_MODEL_CLASS_NAMES) {
 			if (serviceTrackerMap.containsKey(modelClassName) &&
 				(modelClassName.indexOf(CharPool.POUND) == -1)) {
 
@@ -656,12 +656,13 @@ public class DataGuardTestRuleUtil {
 			basePersistence, "_sessionFactory", originalSessionFactory);
 	}
 
+	private static final String[] _PRIORITIZED_MODEL_CLASS_NAMES = {
+		Company.class.getName()
+	};
+
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
-	private static final String[] _prioritizedModelClassNames = {
-		Company.class.getName()
-	};
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -53,7 +53,7 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -276,7 +276,7 @@ public class DataGuardTestRuleUtil {
 
 		StringBundler sb = new StringBundler();
 
-		LinkedHashMap<String, List<BaseModel<?>>> dataMap = _captureDataMap();
+		Map<String, List<BaseModel<?>>> dataMap = _captureDataMap();
 
 		for (Map.Entry<String, List<BaseModel<?>>> entry : dataMap.entrySet()) {
 			String className = entry.getKey();
@@ -335,14 +335,13 @@ public class DataGuardTestRuleUtil {
 			Map<String, List<BaseModel<?>>> previousDataMap)
 		throws Throwable {
 
-		LinkedHashMap<String, PersistedModelLocalService>
-			persistedModelLocalServices = _getPersistedModelLocalServices();
+		Map<String, PersistedModelLocalService> persistedModelLocalServices =
+			_getPersistedModelLocalServices();
 
 		while (true) {
 			boolean deleted = false;
 
-			LinkedHashMap<String, List<BaseModel<?>>> dataMap =
-				_captureDataMap();
+			Map<String, List<BaseModel<?>>> dataMap = _captureDataMap();
 
 			for (Map.Entry<String, List<BaseModel<?>>> entry :
 					dataMap.entrySet()) {
@@ -401,12 +400,11 @@ public class DataGuardTestRuleUtil {
 		}
 	}
 
-	private static LinkedHashMap<String, List<BaseModel<?>>> _captureDataMap() {
-		LinkedHashMap<String, PersistedModelLocalService>
-			persistedModelLocalServices = _getPersistedModelLocalServices();
+	private static Map<String, List<BaseModel<?>>> _captureDataMap() {
+		Map<String, PersistedModelLocalService> persistedModelLocalServices =
+			_getPersistedModelLocalServices();
 
-		LinkedHashMap<String, List<BaseModel<?>>> dataMap =
-			new LinkedHashMap<>();
+		Map<String, List<BaseModel<?>>> dataMap = new HashMap<>();
 
 		for (Map.Entry<String, PersistedModelLocalService> entry :
 				persistedModelLocalServices.entrySet()) {
@@ -522,11 +520,11 @@ public class DataGuardTestRuleUtil {
 		return persistedModelLocalService.getBasePersistence();
 	}
 
-	private static LinkedHashMap<String, PersistedModelLocalService>
+	private static Map<String, PersistedModelLocalService>
 		_getPersistedModelLocalServices() {
 
-		LinkedHashMap<String, PersistedModelLocalService>
-			scrubbedPersistedModelLocalServices = new LinkedHashMap<>();
+		Map<String, PersistedModelLocalService>
+			scrubbedPersistedModelLocalServices = new HashMap<>();
 
 		ServiceTrackerMap<String, PersistedModelLocalService>
 			serviceTrackerMap = ReflectionTestUtil.getFieldValue(

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -529,6 +530,15 @@ public class DataGuardTestRuleUtil {
 				PersistedModelLocalServiceRegistryUtil.class,
 				"_serviceTrackerMap");
 
+		for (String modeClassName : _prioritizedModelClassNames) {
+			if (serviceTrackerMap.containsKey(modeClassName) &&
+				(modeClassName.indexOf(CharPool.POUND) == -1)) {
+
+				scrubbedPersistedModelLocalServices.put(
+					modeClassName, serviceTrackerMap.getService(modeClassName));
+			}
+		}
+
 		for (String modeClassName : serviceTrackerMap.keySet()) {
 			if (!_blacklistedModelClassNames.contains(modeClassName) &&
 				(modeClassName.indexOf(CharPool.POUND) == -1)) {
@@ -647,6 +657,8 @@ public class DataGuardTestRuleUtil {
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
+	private static final List<String> _prioritizedModelClassNames =
+		ListUtil.fromArray("com.liferay.portal.kernel.model.Company");
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -662,8 +662,7 @@ public class DataGuardTestRuleUtil {
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
 	private static final Set<String> _prioritizedModelClassNames =
-		new LinkedHashSet<>(
-			Arrays.<String>asList("com.liferay.portal.kernel.model.Company"));
+		new LinkedHashSet<>(Set.of("com.liferay.portal.kernel.model.Company"));
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.orm.SessionWrapper;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.PersistedModel;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceConstants;
@@ -662,7 +663,7 @@ public class DataGuardTestRuleUtil {
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
 	private static final Set<String> _prioritizedModelClassNames =
-		new LinkedHashSet<>(Set.of("com.liferay.portal.kernel.model.Company"));
+		new LinkedHashSet<>(Set.of(Company.class.getName()));
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -54,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -660,8 +659,9 @@ public class DataGuardTestRuleUtil {
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
-	private static final Set<String> _prioritizedModelClassNames =
-		new LinkedHashSet<>(Set.of(Company.class.getName()));
+	private static final String[] _prioritizedModelClassNames = {
+		Company.class.getName()
+	};
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =

--- a/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/rule/DataGuardTestRuleUtil.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.test.util.ResourcePermissionTestUtil;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.SetUtil;
@@ -54,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -661,8 +661,9 @@ public class DataGuardTestRuleUtil {
 	private static final Set<String> _blacklistedModelClassNames =
 		SetUtil.fromArray(
 			"com.liferay.portal.security.audit.storage.model.AuditEvent");
-	private static final List<String> _prioritizedModelClassNames =
-		ListUtil.fromArray("com.liferay.portal.kernel.model.Company");
+	private static final Set<String> _prioritizedModelClassNames =
+		new LinkedHashSet<>(
+			Arrays.<String>asList("com.liferay.portal.kernel.model.Company"));
 	private static final ThreadLocal<Map<String, Map<Serializable, String>>>
 		_recordsThreadLocal = new ThreadLocal<>();
 	private static final TransactionConfig _transactionConfig =


### PR DESCRIPTION
Issue:
Dataguard will clear out test leftovers at random, based on the service trackers available.  
This can cause required data for other removal methods(doDeleteCompany) to null exceptions and fail to clear caches when at the end of the method.

Solution:
Prioritize certain models to remove them first.

