### PR TITLE
LPD-48789 porlet preferences with values that are considered null are not accounted for

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BasePortletPreferencesUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BasePortletPreferencesUpgradeProcess.java
@@ -722,7 +722,9 @@ public abstract class BasePortletPreferencesUpgradeProcess
 						String largeValue = null;
 						String smallValue = null;
 
-						if (value.length() > smallValueMaxLength) {
+						if ((value != null) &&
+							(value.length() > smallValueMaxLength)) {
+
 							largeValue = value;
 						}
 						else {
@@ -745,7 +747,9 @@ public abstract class BasePortletPreferencesUpgradeProcess
 					String largeValue = null;
 					String smallValue = null;
 
-					if (value.length() > smallValueMaxLength) {
+					if ((value != null) &&
+						(value.length() > smallValueMaxLength)) {
+
 						largeValue = value;
 					}
 					else {


### PR DESCRIPTION
Issue:
Some portletpreferences have values that correspond to null entries, which end up throwing an NPE when determine if it's a small or large value.

Solution:
Check for nulls.


