### PR TITLE
LPD-49349 database infra part of LPD-47718

### DIFF
--- a/modules/apps/portal-instances/portal-instances-web/package.json
+++ b/modules/apps/portal-instances/portal-instances-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"frontend-js-components-web": "*",
 		"frontend-js-web": "*"
 	},
 	"main": "js/index.js",

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/AddInstance.js
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/AddInstance.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fetch, getOpener, openToast} from 'frontend-js-web';
+import {openToast} from 'frontend-js-components-web';
+import {fetch, getOpener} from 'frontend-js-web';
 
 export default function ({namespace}) {
 	const form = document.getElementById(`${namespace}fm`);

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/PortalInstancesManagementToolbarPropsTransformer.js
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/PortalInstancesManagementToolbarPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	return {

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/openDeleteCompanyModal.js
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/js/openDeleteCompanyModal.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal, sub} from 'frontend-js-web';
+import {openModal} from 'frontend-js-components-web';
+import {sub} from 'frontend-js-web';
 
 export default function openDeleteAssetEntryListModal({onDelete}) {
 	openModal({

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/tsconfig.json
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "aed531f0ca45ad73ee06f3dd87e4079ab1c46684",
+	"@generated": "0a27901e7c5f14436b60ae76e2abf922ce12557a",
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT **",
 	"compilerOptions": {
 		"allowSyntheticDefaultImports": true,
@@ -12,6 +12,9 @@
 		"module": "es6",
 		"moduleResolution": "node",
 		"paths": {
+			"frontend-js-components-web": [
+				"../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/index.ts"
+			],
 			"frontend-js-web": [
 				"../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -32,6 +35,9 @@
 		"../../../../../../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../../../../../../frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/tsconfig.json"
+		},
 		{
 			"path": "../../../../../../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/tsconfig.json"
 		}


### PR DESCRIPTION
Hi team :wave: 

This PR is part of [LPD-47718](https://liferay.atlassian.net/browse/LPD-47718).

It refactors your code to import `openModal`, `openToast`, etc. from `frontend-js-components-web` instead of `frontend-js-web`.

The final goal is to remove those methods from `frontend-js-web` so that whenever that module is imported the browser doesn't need to pull React and Clay simply because those methods existed there. This will enhance the performance of sites that don't need React or Clay.

Internally, for now, we are only [re-exporting those methods](https://github.com/brianchandotcom/liferay-portal/pull/159020/commits/3c4231e573b72d8775583af87224810fe42de532) from `frontend-js-components-web`, but once all PRs like this one sent to teams are merged, we (Frontend Infra) will send another final PR to move the methods and remove them completely from `frontend-js-web`.

The code in this PR (as well as the one we will send to other teams) has been thoroughly tested in [this PR](https://github.com/liferay-frontend/liferay-portal/pull/4720#) but we want to make sure that it doesn't break anything and that's why we send it to you for review.

The expectations are that you run the tests suites you think apply and if nothing breaks you just simply forward the PR to Brian. 

Also, it would be great if any new code you write that uses those methods imports them from `frontend-js-components-web` instead of `frontend-js-web` so that we don't have to repeat this process again :grimacing: .

For reference, here is the list of moved methods:

1. openAlertModal
2. openCategorySelectionModal
3. openConfirmModal
4. openModal
5. openPortletModal
6. openPortletWindow
7. openSelectionModal
8. openSimpleInputModal
9. openTagSelectionModal
10. openToast

[LPD-47718]: https://liferay.atlassian.net/browse/LPD-47718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ