### PR TITLE
LPD-47268 Implement base upgrade process to handle duplicated records

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/util/test/DefaultDuplicateRemovalProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/util/test/DefaultDuplicateRemovalProcessTest.java
@@ -18,13 +18,13 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.util.DefaultDuplicateRemovalProcess;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
-import com.liferay.portal.upgrade.util.DefaultDuplicateRemovalProcess;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -107,12 +107,11 @@ public class DefaultDuplicateRemovalProcessTest {
 
 		DefaultDuplicateRemovalProcess upgradeProcess =
 			new DefaultDuplicateRemovalProcess(
-				"TestTable",
-				"column1, column2, column3, column4");
+				"TestTable", "column1, column2, column3, column4");
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-			"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
-			LoggerTestUtil.OFF)) {
+				"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
+				LoggerTestUtil.OFF)) {
 
 			upgradeProcess.upgrade();
 		}
@@ -120,9 +119,9 @@ public class DefaultDuplicateRemovalProcessTest {
 		_assertDuplicates(true);
 
 		try (Connection connection = DataAccess.getConnection();
-			 PreparedStatement preparedStatement = connection.prepareStatement(
-				 "SELECT primaryKeyColumn FROM TestTable");
-			 ResultSet resultSet = preparedStatement.executeQuery()) {
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"SELECT primaryKeyColumn FROM TestTable");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			Assert.assertTrue(resultSet.next());
 
@@ -138,13 +137,12 @@ public class DefaultDuplicateRemovalProcessTest {
 
 		DefaultDuplicateRemovalProcess upgradeProcess =
 			new DefaultDuplicateRemovalProcess(
-				"TestTable",
-				"column1, column2, column3, column4",
+				"TestTable", "column1, column2, column3, column4",
 				"primaryKeyColumn", "asc");
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-			"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
-			LoggerTestUtil.OFF)) {
+				"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
+				LoggerTestUtil.OFF)) {
 
 			upgradeProcess.upgrade();
 		}
@@ -152,9 +150,9 @@ public class DefaultDuplicateRemovalProcessTest {
 		_assertDuplicates(true);
 
 		try (Connection connection = DataAccess.getConnection();
-			 PreparedStatement preparedStatement = connection.prepareStatement(
-				 "SELECT primaryKeyColumn FROM TestTable");
-			 ResultSet resultSet = preparedStatement.executeQuery()) {
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"SELECT primaryKeyColumn FROM TestTable");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
 
 			Assert.assertTrue(resultSet.next());
 
@@ -163,19 +161,18 @@ public class DefaultDuplicateRemovalProcessTest {
 	}
 
 	private void _assertDuplicates(boolean removed) throws SQLException {
-		String countSQL = StringBundler.concat(
-			"SELECT COUNT(*) FROM TestTable GROUP BY column1, ",
-			"column2, column3, column4 ",
-			"HAVING COUNT(*) > 1");
+		String countSQL =
+			"SELECT COUNT(*) FROM TestTable GROUP BY column1, column2, " +
+				"column3, column4 HAVING COUNT(*) > 1";
 
 		if (removed) {
 			_companyLocalService.forEachCompany(
 				company -> {
 					try (Connection connection = DataAccess.getConnection();
-						 PreparedStatement preparedStatement =
-							 connection.prepareStatement(countSQL);
-						 ResultSet resultSet =
-							 preparedStatement.executeQuery()) {
+						PreparedStatement preparedStatement =
+							connection.prepareStatement(countSQL);
+						ResultSet resultSet =
+							preparedStatement.executeQuery()) {
 
 						Assert.assertFalse(resultSet.next());
 					}
@@ -185,10 +182,10 @@ public class DefaultDuplicateRemovalProcessTest {
 			_companyLocalService.forEachCompany(
 				company -> {
 					try (Connection connection = DataAccess.getConnection();
-						 PreparedStatement preparedStatement =
-							 connection.prepareStatement(countSQL);
-						 ResultSet resultSet =
-							 preparedStatement.executeQuery()) {
+						PreparedStatement preparedStatement =
+							connection.prepareStatement(countSQL);
+						ResultSet resultSet =
+							preparedStatement.executeQuery()) {
 
 						Assert.assertTrue(resultSet.next());
 
@@ -202,7 +199,7 @@ public class DefaultDuplicateRemovalProcessTest {
 	private static CompanyLocalService _companyLocalService;
 
 	private static DB _db;
-	private static long _minPrimaryKey;
 	private static long _maxPrimaryKey;
+	private static long _minPrimaryKey;
 
 }

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/util/test/DefaultDuplicateRemovalProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/util/test/DefaultDuplicateRemovalProcessTest.java
@@ -1,0 +1,208 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.util.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import com.liferay.portal.upgrade.util.DefaultDuplicateRemovalProcess;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class DefaultDuplicateRemovalProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_db = DBManagerUtil.getDB();
+
+		_maxPrimaryKey = RandomTestUtil.randomLong(9000, 10000);
+
+		_minPrimaryKey = RandomTestUtil.randomLong(10, 10);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_companyLocalService.forEachCompany(
+			company -> {
+				_db.runSQL(
+					StringBundler.concat(
+						"create table TestTable (mvccVersion LONG default 0 ",
+						"not null, uuid_ VARCHAR(75) null, primaryKeyColumn ",
+						"LONG not null primary key, column1 LONG, column2 LONG",
+						", column3 LONG, column4 LONG, companyId LONG)"));
+
+				_db.runSQL(
+					StringBundler.concat(
+						"insert into TestTable values (0, '",
+						RandomTestUtil.randomString(10), "', ", _minPrimaryKey,
+						", 1, 2, 3, 4, 1)"));
+
+				_db.runSQL(
+					StringBundler.concat(
+						"insert into TestTable values (0, '",
+						RandomTestUtil.randomString(10), "', ",
+						RandomTestUtil.randomLong(10, 8999),
+						", 1, 2, 3, 4, 1)"));
+
+				_db.runSQL(
+					StringBundler.concat(
+						"insert into TestTable values (0, '",
+						RandomTestUtil.randomString(10), "', ",
+						RandomTestUtil.randomLong(10, 8999),
+						", 1, 2, 3, 4, 1)"));
+
+				_db.runSQL(
+					StringBundler.concat(
+						"insert into TestTable values (0, '",
+						RandomTestUtil.randomString(10), "', ", _maxPrimaryKey,
+						", 1, 2, 3, 4, 1)"));
+			});
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_companyLocalService.forEachCompany(
+			company -> _db.runSQL("drop table TestTable"));
+	}
+
+	@Test
+	public void testDefaultDuplicateRemovalProcess()
+		throws SQLException, UpgradeException {
+
+		_assertDuplicates(false);
+
+		DefaultDuplicateRemovalProcess upgradeProcess =
+			new DefaultDuplicateRemovalProcess(
+				"TestTable",
+				"column1, column2, column3, column4");
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+			"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
+			LoggerTestUtil.OFF)) {
+
+			upgradeProcess.upgrade();
+		}
+
+		_assertDuplicates(true);
+
+		try (Connection connection = DataAccess.getConnection();
+			 PreparedStatement preparedStatement = connection.prepareStatement(
+				 "SELECT primaryKeyColumn FROM TestTable");
+			 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			Assert.assertTrue(resultSet.next());
+
+			Assert.assertEquals(_minPrimaryKey, resultSet.getLong(1));
+		}
+	}
+
+	@Test
+	public void testDefaultDuplicateRemovalProcessWithOrderBy()
+		throws SQLException, UpgradeException {
+
+		_assertDuplicates(false);
+
+		DefaultDuplicateRemovalProcess upgradeProcess =
+			new DefaultDuplicateRemovalProcess(
+				"TestTable",
+				"column1, column2, column3, column4",
+				"primaryKeyColumn", "asc");
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+			"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
+			LoggerTestUtil.OFF)) {
+
+			upgradeProcess.upgrade();
+		}
+
+		_assertDuplicates(true);
+
+		try (Connection connection = DataAccess.getConnection();
+			 PreparedStatement preparedStatement = connection.prepareStatement(
+				 "SELECT primaryKeyColumn FROM TestTable");
+			 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			Assert.assertTrue(resultSet.next());
+
+			Assert.assertEquals(_maxPrimaryKey, resultSet.getLong(1));
+		}
+	}
+
+	private void _assertDuplicates(boolean removed) throws SQLException {
+		String countSQL = StringBundler.concat(
+			"SELECT COUNT(*) FROM TestTable GROUP BY column1, ",
+			"column2, column3, column4 ",
+			"HAVING COUNT(*) > 1");
+
+		if (removed) {
+			_companyLocalService.forEachCompany(
+				company -> {
+					try (Connection connection = DataAccess.getConnection();
+						 PreparedStatement preparedStatement =
+							 connection.prepareStatement(countSQL);
+						 ResultSet resultSet =
+							 preparedStatement.executeQuery()) {
+
+						Assert.assertFalse(resultSet.next());
+					}
+				});
+		}
+		else {
+			_companyLocalService.forEachCompany(
+				company -> {
+					try (Connection connection = DataAccess.getConnection();
+						 PreparedStatement preparedStatement =
+							 connection.prepareStatement(countSQL);
+						 ResultSet resultSet =
+							 preparedStatement.executeQuery()) {
+
+						Assert.assertTrue(resultSet.next());
+
+						Assert.assertEquals(4, resultSet.getLong(1));
+					}
+				});
+		}
+	}
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	private static DB _db;
+	private static long _minPrimaryKey;
+	private static long _maxPrimaryKey;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/util/test/DefaultDuplicateRemovalProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/util/test/DefaultDuplicateRemovalProcessTest.java
@@ -110,7 +110,8 @@ public class DefaultDuplicateRemovalProcessTest {
 				"TestTable", "column1, column2, column3, column4");
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
+				"com.liferay.portal.kernel.upgrade.util." +
+					"BaseDuplicateRemovalProcess",
 				LoggerTestUtil.OFF)) {
 
 			upgradeProcess.upgrade();
@@ -141,7 +142,8 @@ public class DefaultDuplicateRemovalProcessTest {
 				"primaryKeyColumn", "asc");
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.kernel.upgrade.BaseDuplicateRemovalProcess",
+				"com.liferay.portal.kernel.upgrade.util." +
+					"BaseDuplicateRemovalProcess",
 				LoggerTestUtil.OFF)) {
 
 			upgradeProcess.upgrade();

--- a/portal-impl/src/com/liferay/portal/upgrade/util/DefaultDuplicateRemovalProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/DefaultDuplicateRemovalProcess.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.util;
+
+import com.liferay.portal.kernel.upgrade.util.BaseDuplicateRemovalProcess;
+
+/**
+ * @author Jorge Avalos
+ */
+public class DefaultDuplicateRemovalProcess
+	extends BaseDuplicateRemovalProcess {
+
+	public DefaultDuplicateRemovalProcess(String tableName, String columns) {
+		super(tableName, columns, null, null);
+	}
+
+	public DefaultDuplicateRemovalProcess(
+		String tableName, String columns, String orderByColumns,
+		String orderByClause) {
+
+		super(tableName, columns, orderByColumns, orderByClause);
+	}
+
+	@Override
+	protected void doUpgrade() {
+		super.doUpgrade();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.util.UpgradeModulesFactory;
 import com.liferay.portal.kernel.upgrade.util.UpgradeVersionTreeMap;
 import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.upgrade.util.DefaultDuplicateRemovalProcess;
 import com.liferay.portal.upgrade.util.PortalUpgradeProcessRegistry;
 import com.liferay.portal.upgrade.util.UpgradePartitionedControlTable;
 import com.liferay.portal.upgrade.v7_4_x.util.AssetTagGroupRelTable;
@@ -598,6 +599,18 @@ public class PortalUpgradeProcessRegistryImpl
 
 		upgradeVersionTreeMap.put(
 			new Version(31, 18, 0), AssetTagGroupRelTable.create());
+
+		upgradeVersionTreeMap.put(
+			new Version(31, 18, 1),
+			new DefaultDuplicateRemovalProcess(
+				"PortalPreferences", "ownerType, ownerId"),
+			new DefaultDuplicateRemovalProcess(
+				"PortletItem", "groupId, classNameId, portletId, name"),
+			new DefaultDuplicateRemovalProcess(
+				"SocialActivitySetting",
+				"groupId, classNameId, activityType, name, ctCollectionId"),
+			new DefaultDuplicateRemovalProcess(
+				"Ticket", "key_", "ticketId", "asc"));
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/BaseDuplicateRemovalProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/BaseDuplicateRemovalProcess.java
@@ -1,0 +1,303 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade.util;
+
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Jorge Avalos
+ */
+public class BaseDuplicateRemovalProcess extends UpgradeProcess {
+
+	public BaseDuplicateRemovalProcess(
+		String tableName, String columns, String orderByColumns,
+		String sortOrder) {
+
+		_tableName = tableName;
+		_columns = columns;
+
+		_orderByClause = _getOrderByClause(orderByColumns, sortOrder);
+	}
+
+	@Override
+	protected void doUpgrade() {
+		_removeDuplicates();
+	}
+
+	protected List<Map<String, String>> getDuplicatesSQL(
+		String[] indexDuplicateColumns) {
+
+		List<Map<String, String>> queryResult = new ArrayList<>();
+
+		String[] columns = _columns.split(", ");
+
+		StringBundler sb = new StringBundler();
+
+		sb.append("SELECT * FROM ");
+		sb.append(_tableName);
+		sb.append(" WHERE ");
+
+		for (int i = 0; i < indexDuplicateColumns.length; i++) {
+			sb.append(columns[i]);
+
+			if (indexDuplicateColumns[i] == null) {
+				sb.append(" IS NULL ");
+			}
+			else {
+				sb.append(" = '");
+				sb.append(_escape(indexDuplicateColumns[i]));
+				sb.append("' ");
+			}
+
+			if (i < (columns.length - 1)) {
+				sb.append("AND ");
+			}
+		}
+
+		if (_orderByClause != null) {
+			sb.append(_orderByClause);
+		}
+
+		String sql = sb.toString();
+
+		try (Connection connection = DataAccess.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				sql);
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			ResultSetMetaData metaData = resultSet.getMetaData();
+
+			int columnCount = metaData.getColumnCount();
+
+			String[] columnNames = new String[columnCount];
+
+			for (int i = 1; i <= columnCount; i++) {
+				String columnName = metaData.getColumnName(i);
+
+				columnNames[i - 1] = columnName;
+			}
+
+			while (resultSet.next()) {
+				Map<String, String> queryMap = new LinkedHashMap<>();
+
+				for (int i = 0; i < columnCount; i++) {
+					String value = resultSet.getString(columnNames[i]);
+
+					queryMap.put(columnNames[i], value);
+				}
+
+				queryResult.add(queryMap);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		if (_orderByClause == null) {
+			Collections.reverse(queryResult);
+		}
+
+		return queryResult;
+	}
+
+	private String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _DB_ESCAPE_STRINGS[0],
+			_DB_ESCAPE_STRINGS[1]);
+	}
+
+	private List<String[]> _getIndexDuplicatesList() {
+		List<String[]> indexesDuplicatesList = new ArrayList<>();
+
+		StringBundler sb = new StringBundler(7);
+
+		sb.append("SELECT ");
+		sb.append(_columns);
+		sb.append(" FROM ");
+		sb.append(_tableName);
+		sb.append(" GROUP BY ");
+		sb.append(_columns);
+		sb.append(" HAVING COUNT(*) > 1");
+
+		String sql = sb.toString();
+
+		try (Connection connection = DataAccess.getConnection();
+			 PreparedStatement preparedStatement =
+				 connection.prepareStatement(sql);
+
+			 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			ResultSetMetaData metaData = resultSet.getMetaData();
+
+			int columnCount = metaData.getColumnCount();
+
+			while (resultSet.next()) {
+				String[] columnResults = new String[columnCount];
+
+				for (int i = 1; i <= columnCount; i++) {
+					String value = resultSet.getString(i);
+
+					columnResults[i - 1] = value;
+				}
+
+				indexesDuplicatesList.add(columnResults);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+		}
+
+		return indexesDuplicatesList;
+	}
+
+	private String _getOrderByClause(String orderByColumns, String sortOrder) {
+		if ((orderByColumns != null) || (sortOrder != null)) {
+			StringBuilder ordeByClause = new StringBuilder();
+
+			ordeByClause.append("ORDER BY ");
+
+			String[] orderByArray = orderByColumns.split(", ");
+
+			for (int i = 0; i < orderByArray.length; i++) {
+				while (i < (orderByArray.length - 1)) {
+					ordeByClause.append(
+						orderByArray[i]
+					).append(
+						" "
+					);
+
+					ordeByClause.append(
+						sortOrder
+					).append(
+						", "
+					);
+				}
+
+				ordeByClause.append(
+					orderByArray[i]
+				).append(
+					" "
+				);
+
+				ordeByClause.append(sortOrder);
+			}
+
+			return ordeByClause.toString();
+		}
+
+		return null;
+	}
+
+	private void _logDeletedDuplicates(Map<String, String> duplicate) {
+		if (_log.isWarnEnabled()) {
+			_log.warn(
+				StringBundler.concat(
+					"Deleted duplicate entry from ", _tableName,
+					" table for index columns (", _columns, "): ",
+					duplicate.toString()));
+		}
+	}
+
+	private void _removeDuplicates() {
+		List<String[]> indexDuplicatesList = _getIndexDuplicatesList();
+
+		for (String[] indexDuplicateColumns : indexDuplicatesList) {
+			List<Map<String, String>> duplicatesList = getDuplicatesSQL(
+				indexDuplicateColumns);
+
+			int duplicateCount = duplicatesList.size();
+
+			for (Map<String, String> duplicate : duplicatesList) {
+				if (duplicateCount == 1) {
+					break;
+				}
+
+				StringBundler sb = new StringBundler();
+
+				sb.append("DELETE FROM ");
+				sb.append(_tableName);
+				sb.append(" WHERE ");
+
+				int counter = 0;
+
+				for (Map.Entry<String, String> querySet :
+						duplicate.entrySet()) {
+
+					sb.append(querySet.getKey());
+
+					if (querySet.getValue() == null) {
+						sb.append(" IS NULL ");
+					}
+					else {
+						sb.append(" = '");
+						sb.append(_escape(querySet.getValue()));
+						sb.append("' ");
+					}
+
+					if (counter < (duplicate.size() - 1)) {
+						sb.append("AND ");
+					}
+
+					counter++;
+				}
+
+				String sql = sb.toString();
+
+				try (Connection connection = DataAccess.getConnection()) {
+					PreparedStatement preparedStatement1 =
+						connection.prepareStatement(sql);
+
+					preparedStatement1.execute();
+				}
+				catch (SQLException sqlException) {
+					_log.error(
+						StringBundler.concat(
+							"Failed to remove duplicate entry: ",
+							duplicate.toString(), " in ", _tableName, " for ",
+							_columns),
+						sqlException);
+				}
+				finally {
+					_logDeletedDuplicates(duplicate);
+					duplicateCount--;
+				}
+			}
+		}
+	}
+
+	private static final String[][] _DB_ESCAPE_STRINGS = {
+		{"\\", "'"}, {"\\\\", "''"}
+	};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseDuplicateRemovalProcess.class);
+
+	private final String _columns;
+	private final String _orderByClause;
+	private final String _tableName;
+
+}


### PR DESCRIPTION
Issue:
With existing finder methods being switched to also apply a unique index, we need to accommodate for any duplicates that currently exist becuase of the lack of an index.

Solution:
Create an upgrade process where columns used by the index can be checked for any possible duplicates and remove them based on the finder method used(before the change) as well as the service.xml(for orderBy clause).
