### PR TITLE
LPD-40151 follow-up: portal-tools-db-upgrade-client tests belong to 'Database Upgrade Tool'

### DIFF
--- a/modules/util/portal-tools-db-upgrade-client/test.properties
+++ b/modules/util/portal-tools-db-upgrade-client/test.properties
@@ -27,4 +27,4 @@
 ## Testray
 ##
 
-    testray.main.component.name=Dev Tools
+    testray.main.component.name=Database Upgrade Tool


### PR DESCRIPTION
The PR https://github.com/brianchandotcom/liferay-portal/pull/155521 of LPD-40151 added the missing `testray.main.component.name` property to several **test.properties**

In `modules/util/portal-tools-db-upgrade-client/test.properties` this property was set to 'Dev Tools', but this module belongs to 'Database Upgrade Tool' 

Detected by @achaparro 

