### PR TITLE
LRCI-5628 Revert

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1017,8 +1017,6 @@ app.server.type=@{app.server.type}]]></echo>
 
 			<antcall inheritAll="false" target="compile" />
 
-			<antcall inheritAll="false" target="install-portal-snapshots" />
-
 			<if>
 				<and>
 					<equals arg1="@{app.server.type}" arg2="tomcat" />
@@ -1180,6 +1178,8 @@ app.server.type=@{app.server.type}]]></echo>
 					</then>
 				</elseif>
 			</if>
+
+			<antcall inheritAll="false" target="install-portal-snapshots" />
 
 			<echo if:set="env.JENKINS_HOME">ANT_OPTS=${env.ANT_OPTS}</echo>
 


### PR DESCRIPTION
After e3330653372a8ec7da6899f1c2ff84947bbb0f73 the DB Partition suite started to fail, see https://testray.liferay.com/#/project/35392/routines/990902/build/220757560

The reason why it is failing is because the service implementation of SystemBundleProvider is missing. For tests the one used is: TestSystemBundleProvider that is in portal-test.

If you check the logs a working [test](https://ffb559c1f7ee26c5cd32648bad0206714daeb2cba5ef48c01cbb31d-apidata.googleusercontent.com/download/storage/v1/b/testray-results/o/2025-05%2Ftest-1-32%2Ftest-portal-testsuite-upstream(master)%2F4862%2Funit%2F0%2F0%2Fjenkins-console.txt.gz?jk=AVJhS7ugcmcy3pNu6nlI9KppkKVPq-yKMJ4heKX0VItWz9gPCG8tUx-Nx9KiJ83oTcmv6MmTDd9Hiihc5cXMXkFfjVhSRmSOih_y4YXlIwG__R3XOsY-wkcld2MYuB1oFYzgyL6ha9JqGDHsUSu9SkHVNloBRBPgQGFePD4MwxY8wIWRMzrgTfTcEy2Q0eoGK6fa50M5b6pwYmlkjOMyj1andRYEMrVLoqYb_YthP9JDfKKsaEqJetQ94zl_wgzKTMrn3BHJyoiM9n6AB3fLGaXLTY7FZKoCz7eYi-lU09Sp-xDcNfaS8UqtfVcmQFFx1JIIuX7v_OkxLiiV4c3gbYdza8ZGqrKcpi7hSwlqpPN1nDbtT2_efa2UKOlTnukLxKlTAvFVUwZPn-AlDFXxrKBbDaebYVsZT2LZ_h2leWD_QQILxmdERdi4FeveKzxxYwP3TXMzyo0wvr1ZcX1M9kK_T-VhyElTlmR2wXphOYF9o88-7xVxd6lwISDkWseA8E3id608J9mVuSg8WDBRdr41Hs3nZOTompmJ-LRe20odomdqRLOGKioq-ktcn4ZJBwRdTdRJg0KPdM7t0yCkas-Gd9z97y0YQad7gyXIwCemIZfbNSdHzezNZ-PgnZPeCTXKLgIPvrS-ElJ6mls98-JRnHYmPksdqgo2u0k2cTl8RBB4K-f_gzXyA37urW5qpPVBk2icukcvGv3lrMZJBGzgr-0-2W3ufOHeD_NgxV4YbaVGEiKaDlydtTfKDqOuFyUcZG1nExyA7d16JT0EEcYmzpe-GJUzD5UZrNrFbPcY_eTZR5kIA90eqQz7XUaSRbstv7Qh_Onily5XIMy0TrRt8RtecVflElIxpMWN21rpnnxOdlvLq_N8nHuHeW0iB4SX1LjaHWq6B1olgDpBacP-LuPVlpCS7Ma7lPhgnisdKtqtiq2fhEW3InvW5Uc_yPEdFDEYKJOzHAGmrxohA-vZtPBcYD2iTcPwUKimDyPWUbbuS6M3Lr2CBYRo3vAs1Gb1J7BDRz9VTXqb6TpMUH54KWJnqwLi5dI3ecleKLIFuiY_xU9CzTbJK-0XaCUIje8V6GGTu93iB2oaEoBRod7EoIw6Gf48AJjvNh3la6G6IVh95aO73bVjC6rQfC5pko0oEOchkgY1ARRaO1p0VPXaEfmiYqY_P7AFYOFwh9PiSwdHP2b_nBQqvw7ZwgxGRsbk8UbzVt9pW8JrYIVGXn_OZuZ9R2uwYu9b5f8z8vrpFd_WKB3wGQrT2MuP-hPGjvZJuE8&isca=1),  you'll see: 

```
compile:
     [copy] Copying 58 files to /opt/dev/projects/github/liferay-portal/portal-test/classes
```

But if you take a look to the [Jenkins console](https://ff6249b46bf0270fe866bc4b38ff95969da461f238aaca8ac8216fd-apidata.googleusercontent.com/download/storage/v1/b/testray-results/o/2025-05%2Ftest-1-30%2Ftest-portal-testsuite-upstream(master)%2F3988%2Funit%2F0%2F0%2Fjenkins-console.txt.gz?jk=AVJhS7tb2mtgMU1LrSusxrZqd4XCM9NtgdMRz8jymAX1fcvWuKm5AlYOezIoKoMJc3yzHcILqH1lGPOvMGKxmRuhyXhFrZMUYbHMbC1HDPLHyJgMCKjPhj0fn992V5wBal5LTdDUkFO7_xbaxFqY3mLyGHErt-e0jZx90mIDII2M-1-BF9MQrJ0MoUJwPiMdnFNtUmhAzXGNGcTTyvCHAKoxqaj9T4Xd8CHGOzpJxKI2acls_jFd4u76CKz_jd6evKiHzVjPV5nIDFAoY36LMdRoZMsCc6ckw1BXXo9-aJZ8u9YmWbTqxp1A-ahDtzPI9xHsVYq97gq1Z3DuAyLQk-q-bhxuDuRfYyEiigxNkgnDj8jGrFcN_lI4BPDQAufqAP9G7s-MCKPYCH3FXocD4FO-gqaFcsGkG0E-l7gT6-HvmBFK3JQOOqVuMqEY3F6cAhwupt2fprsdhlLrVxHugAed4zC9ibv7NYzR8n8FVSqb2xOlCkRl13BbGbZxmMQwPF1Psdg6UvhDkbKVZWEbq0sbdes5aBz5j0XunAkmhz38Bi_YKMB0mgHQH3arBf6Gsgx6UEIdbhO0Id19nEDU7IfX2lfexPNuf1HQUepuELXXI3XQLWjD7Ne3-AaVyL1eQNUuGjdwoNKF8l2YN9tv43_3aOK62lkKDL5qN4qjRqG5qZm6gbjwcbkvHXy85_MjGO2iryDYr5aUfffXlgVLVZ8v_eX1wLbnyqJ63wtvj_da7ayL77qvnD1Rs4dCTbCaZODi-EQA0Ijao_6yUHHrPE2ihc5Vv0fo9sVCQ5jFVwOjpAXs7vGRfO7Qcr_9e34BNRm6GbfT_0WcWHq94v0aWKqsK5Nvbjxaf2GmzrlJ88QuKtG5R78OnKkLxQdQQkcTN6lUmDZKiPMh5a_yHbIF_HvYN-zuo9vz3_oERJSBRA0Z2Jj8XYAcjTes8awow1f1pVYSIpxqC26KRUL1P9uqKTYnYiNl7hnRJ4UlbxYDbQBn5swF7hHgV-UTma6Y_AwC5DkQXqE9Gea1YpwYqH_XYwjVUSBTL_SAnWHBc0xp9qHhgC6_tCDwaIKi4hzmHuRE79Rnz2aIapppbqSMsEFIbDOO_HGs0257WKuJEe03_BF_7X1Gni1nBXGeqeFA1uUxPB2QTEdOuuZdr0_DvBuCrLJlBcDX4Ut9kctEA7-2EhMPKzw3fRwZtTxeE9D9kuXk0JlVmddkIWhm2ILnF2C_IoZhUVjASs7tikACRVlxXFQtGaT3lMjDEJhFIkPw0rAOt8XKQrtO&isca=1) after the changes portal-test classes are not compiled.

Reverting the commit fixes the issue.