### PR TITLE
LPD-56186 Add PreupgradeVerifyDatabasePermissions

### DIFF
--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -23,6 +23,8 @@ import com.liferay.portal.verify.PreupgradeVerifyDatabasePrivileges;
 import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
 
+import java.sql.Connection;
+
 import javax.sql.DataSource;
 
 import org.junit.After;
@@ -34,9 +36,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.sql.Connection;
-import java.sql.SQLException;
 
 /**
  * @author Jorge Avalos
@@ -64,7 +63,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
 			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.POSTGRESQL) || (_db.getDBType() == DBType.SQLSERVER));
+			(_db.getDBType() == DBType.POSTGRESQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		_createTestUser();
 
@@ -77,17 +77,20 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void tearDown() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL) || (_db.getDBType() == DBType.SQLSERVER));
-
-		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.POSTGRESQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		InfrastructureUtil.setDataSource(_dataSource);
 
 		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
+			DBInspector dbInspector = new DBInspector(
+				DataAccess.getConnection());
+
 			_db.runSQL(
 				StringBundler.concat(
-					"revoke all privileges on schema ",
-					dbInspector.getSchema(), " from test"));
+					"revoke all privileges on schema ", dbInspector.getSchema(),
+					" from test"));
 		}
 
 		if (_testUserDataSource != null) {
@@ -105,7 +108,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyAlterTablePrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL));
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("alter");
 
@@ -128,7 +132,9 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyCreateTablePrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL)  || (_db.getDBType() == DBType.SQLSERVER));
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.POSTGRESQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("create");
 
@@ -140,13 +146,13 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			if(DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
+			if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
 				_verifyException(exception, "ERROR: permission denied'");
 			}
 			else {
-				_verifyException(exception, "CREATE command denied to user 'test'");
+				_verifyException(
+					exception, "CREATE command denied to user 'test'");
 			}
-
 		}
 	}
 
@@ -154,7 +160,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyDeleteRowPrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL));
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("delete");
 
@@ -177,7 +184,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyInsertRowPrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.SQLSERVER));
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("insert");
 
@@ -200,7 +208,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifySelectRowPrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.SQLSERVER));
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("select");
 
@@ -223,7 +232,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyUpdateRowPrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.SQLSERVER));
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("update");
 
@@ -267,26 +277,25 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
-			StringBundler.concat(
-				"create user [test] for login [test] with ",
-				"default_schema = ", dbInspector.getSchema()));
+			"create user [test] for login [test] with default_schema = " +
+				dbInspector.getSchema());
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant create,alter,index,select,insert,delete,update,drop on " +
-			"*.* to 'test'@'%'");
+			"grant alter, create,delete, drop, index, insert, select, update " +
+				"on *.* to 'test'@'%'");
 
 		dbTypeToSQLMap.add(
 			DBType.POSTGRESQL,
 			StringBundler.concat(
-				"grant usage, create on schema ",
-				dbInspector.getSchema(), " to test"));
+				"grant usage, create on schema ", dbInspector.getSchema(),
+				" to test"));
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
 			"grant alter, delete, insert, select, update  on schema::dbo to " +
-			"test");
+				"test");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
@@ -299,13 +308,14 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 				"revoke ", privilege, " on *.* from 'test'@'%'"));
 
 		dbTypeToSQLMap.add(
-				DBType.POSTGRESQL,
-				StringBundler.concat(
-					"revoke ", privilege, " on schema ",
-					dbInspector.getSchema(), " from test"));
+			DBType.POSTGRESQL,
+			StringBundler.concat(
+				"revoke ", privilege, " on schema ", dbInspector.getSchema(),
+				" from test"));
 
-		if(privilege.equals("create")) {
-			dbTypeToSQLMap.add(DBType.SQLSERVER, "revoke create table from test");
+		if (privilege.equals("create")) {
+			dbTypeToSQLMap.add(
+				DBType.SQLSERVER, "revoke create table from test");
 		}
 		else {
 			dbTypeToSQLMap.add(
@@ -315,7 +325,6 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
-
 	}
 
 	private void _verifyException(Exception exception, String expectedMessage) {
@@ -323,6 +332,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		Assert.assertTrue(message.contains(expectedMessage));
 	}
+
 	private static Connection _connection;
 	private static DataSource _dataSource;
 	private static DB _db;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -9,11 +9,8 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
-import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
-import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.jdbc.DataSourceFactoryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
@@ -22,8 +19,6 @@ import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.verify.PreupgradeVerifyDatabasePrivileges;
 import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
-
-import java.sql.Connection;
 
 import javax.sql.DataSource;
 
@@ -50,7 +45,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		new LiferayIntegrationTestRule();
 
 	@BeforeClass
-	public static void setUpClass(){
+	public static void setUpClass() {
 		_db = DBManagerUtil.getDB();
 
 		_dataSource = InfrastructureUtil.getDataSource();
@@ -215,14 +210,17 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	private void _createTestUser() throws Exception {
 		_db.runSQL("create user 'test'@'%' identified BY 'liferay'");
-		_db.runSQL("grant create,alter,index,select,insert,delete,update,drop on *.* to 'test'@'%'");
+		_db.runSQL(
+			"grant create,alter,index,select,insert,delete,update,drop on " +
+				"*.* to 'test'@'%'");
 	}
 
 	private void _revokePrivileges(String privilege) throws Exception {
-		_db.runSQL(StringBundler.concat("revoke ", privilege, " on *.* from 'test'@'%'"));
+		_db.runSQL(
+			StringBundler.concat(
+				"revoke ", privilege, " on *.* from 'test'@'%'"));
 	}
 
-	private static Connection _connection;
 	private static DataSource _dataSource;
 	private static DB _db;
 	private static DataSource _testUserDataSource;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -302,8 +302,9 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
-			"grant alter, delete, insert, select, update  on schema::dbo to " +
-				"test");
+			StringBundler.concat(
+				"grant alter, delete, insert, select, update  on schema::",
+				dbInspector.getSchema(), " to test"));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
@@ -329,7 +330,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			dbTypeToSQLMap.add(
 				DBType.SQLSERVER,
 				StringBundler.concat(
-					"revoke ", privilege, " on schema::dbo from test"));
+					"revoke ", privilege, " on schema::",
+					dbInspector.getSchema(), " from test"));
 		}
 
 		_db.runSQL(_connection, dbTypeToSQLMap);

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -59,7 +59,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void setUp() throws Exception {
 		_createTestUser();
 
-		_badUserDataSource = DataSourceFactoryUtil.initDataSource(
+		_testUserDataSource = DataSourceFactoryUtil.initDataSource(
 			PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME,
 			PropsValues.JDBC_DEFAULT_URL, "testUser", "liferay",
 			StringPool.BLANK);
@@ -69,8 +69,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void tearDown() throws Exception {
 		InfrastructureUtil.setDataSource(_dataSource);
 
-		if (_badUserDataSource != null) {
-			DataSourceFactoryUtil.destroyDataSource(_badUserDataSource);
+		if (_testUserDataSource != null) {
+			DataSourceFactoryUtil.destroyDataSource(_testUserDataSource);
 		}
 
 		_db.runSQL("drop user testUser");
@@ -78,10 +78,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyAlterTablePrivilege() throws Exception {
-		_revokePrivileges("ALTER");
-		_revokePrivileges("INDEX");
+		_revokePrivileges("alter");
+		_revokePrivileges("index");
 
-		InfrastructureUtil.setDataSource(_badUserDataSource);
+		InfrastructureUtil.setDataSource(_testUserDataSource);
 
 		try {
 			testVerify();
@@ -102,9 +102,9 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyCreateTablePrivilege() throws Exception {
-		_revokePrivileges("CREATE");
+		_revokePrivileges("create");
 
-		InfrastructureUtil.setDataSource(_badUserDataSource);
+		InfrastructureUtil.setDataSource(_testUserDataSource);
 
 		try {
 			testVerify();
@@ -124,7 +124,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyDeleteRowPrivilege() throws Exception {
 		_revokePrivileges("delete");
 
-		InfrastructureUtil.setDataSource(_badUserDataSource);
+		InfrastructureUtil.setDataSource(_testUserDataSource);
 
 		try {
 			testVerify();
@@ -147,7 +147,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyInsertTablePrivilege() throws Exception {
 		_revokePrivileges("insert");
 
-		InfrastructureUtil.setDataSource(_badUserDataSource);
+		InfrastructureUtil.setDataSource(_testUserDataSource);
 
 		try {
 			testVerify();
@@ -170,7 +170,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyUpdateRowPrivilege() throws Exception {
 		_revokePrivileges("update");
 
-		InfrastructureUtil.setDataSource(_badUserDataSource);
+		InfrastructureUtil.setDataSource(_testUserDataSource);
 
 		try {
 			testVerify();
@@ -196,47 +196,47 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	private void _createTestUser() throws Exception {
 		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-			"CREATE USER 'testUser'@'%' IDENTIFIED BY 'liferay';");
+			"create user 'testUser'@'%' identified by 'liferay';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT SELECT ON *.* TO 'testUser'@'%';");
+			"grant select on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT CREATE ON *.* TO 'testUser'@'%';");
+			"grant create on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT ALTER ON *.* TO 'testUser'@'%';");
+			"grant alter on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT INDEX ON *.* TO 'testUser'@'%';");
+			"grant index on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT INSERT ON *.* TO 'testUser'@'%';");
+			"grant insert on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT DELETE ON *.* TO 'testUser'@'%';");
+			"grant delete on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT UPDATE ON *.* TO 'testUser'@'%';");
+			"grant update on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"GRANT DROP ON *.* TO 'testUser'@'%';");
+			"grant drop on *.* to 'testUser'@'%';");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
@@ -244,12 +244,12 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	private void _revokePrivileges(String privilege) throws Exception {
 		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
 			StringBundler.concat(
-				"REVOKE ", privilege, " ON *.* FROM 'testUser'@'%';"));
+				"revoke ", privilege, " on *.* from 'testUser'@'%';"));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
 
-	private static DataSource _badUserDataSource;
+	private static DataSource _testUserDataSource;
 	private static Connection _connection;
 	private static DataSource _dataSource;
 	private static DB _db;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -67,10 +67,6 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 
 		_createTestUser();
-
-		_testUserDataSource = DataSourceFactoryUtil.initDataSource(
-			PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME,
-			PropsValues.JDBC_DEFAULT_URL, "test", "test", StringPool.BLANK);
 	}
 
 	@After
@@ -113,7 +109,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_revokePrivileges("alter");
 
-		InfrastructureUtil.setDataSource(_testUserDataSource);
+		_initTestDatasource();
 
 		try {
 			testVerify();
@@ -143,7 +139,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_revokePrivileges("create");
 
-		InfrastructureUtil.setDataSource(_testUserDataSource);
+		_initTestDatasource();
 
 		try {
 			testVerify();
@@ -169,7 +165,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_revokePrivileges("delete");
 
-		InfrastructureUtil.setDataSource(_testUserDataSource);
+		_initTestDatasource();
 
 		try {
 			testVerify();
@@ -193,7 +189,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_revokePrivileges("insert");
 
-		InfrastructureUtil.setDataSource(_testUserDataSource);
+		_initTestDatasource();
 
 		try {
 			testVerify();
@@ -217,7 +213,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_revokePrivileges("select");
 
-		InfrastructureUtil.setDataSource(_testUserDataSource);
+		_initTestDatasource();
 
 		try {
 			testVerify();
@@ -241,7 +237,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_revokePrivileges("update");
 
-		InfrastructureUtil.setDataSource(_testUserDataSource);
+		_initTestDatasource();
 
 		try {
 			testVerify();
@@ -307,6 +303,14 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 				dbInspector.getSchema(), " to test"));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
+	}
+
+	private void _initTestDatasource() throws Exception {
+		_testUserDataSource = DataSourceFactoryUtil.initDataSource(
+			PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME,
+			PropsValues.JDBC_DEFAULT_URL, "test", "test", StringPool.BLANK);
+
+		InfrastructureUtil.setDataSource(_testUserDataSource);
 	}
 
 	private void _revokePrivileges(String privilege) throws Exception {

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
  * @author Jorge Avalos
@@ -50,10 +51,12 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		new LiferayIntegrationTestRule();
 
 	@BeforeClass
-	public static void setUpClass() {
-		_db = DBManagerUtil.getDB();
+	public static void setUpClass() throws Exception {
+		_connection = DataAccess.getConnection();
 
 		_dataSource = InfrastructureUtil.getDataSource();
+
+		_db = DBManagerUtil.getDB();
 	}
 
 	@Before
@@ -61,7 +64,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
 			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.POSTGRESQL));
+			(_db.getDBType() == DBType.POSTGRESQL) || (_db.getDBType() == DBType.SQLSERVER));
 
 		_createTestUser();
 
@@ -74,7 +77,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void tearDown() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL));
+			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL) || (_db.getDBType() == DBType.SQLSERVER));
 
 		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
 
@@ -125,7 +128,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyCreateTablePrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL));
+			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL)  || (_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("create");
 
@@ -171,10 +174,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	}
 
 	@Test
-	public void testVerifyInsertTablePrivilege() throws Exception {
+	public void testVerifyInsertRowPrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL));
+			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("insert");
 
@@ -194,10 +197,33 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	}
 
 	@Test
+	public void testVerifySelectRowPrivilege() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.SQLSERVER));
+
+		_revokePrivileges("select");
+
+		InfrastructureUtil.setDataSource(_testUserDataSource);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			_verifyException(exception, "SELECT command denied to user 'test'");
+		}
+		finally {
+			InfrastructureUtil.setDataSource(_dataSource);
+		}
+	}
+
+	@Test
 	public void testVerifyUpdateRowPrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL));
+			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.SQLSERVER));
 
 		_revokePrivileges("update");
 
@@ -278,10 +304,17 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 					"revoke ", privilege, " on schema ",
 					dbInspector.getSchema(), " from test"));
 
-		dbTypeToSQLMap.add(
-			DBType.SQLSERVER,
-			StringBundler.concat(
-				"revoke ", privilege, " on schema::dbo from test"));
+		if(privilege.equals("create")) {
+			dbTypeToSQLMap.add(DBType.SQLSERVER, "revoke create table from test");
+		}
+		else {
+			dbTypeToSQLMap.add(
+				DBType.SQLSERVER,
+				StringBundler.concat(
+					"revoke ", privilege, " on schema::dbo from test"));
+		}
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
 
 	}
 

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -29,7 +29,6 @@ import javax.sql.DataSource;
 
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -64,13 +63,14 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_testUserDataSource = DataSourceFactoryUtil.initDataSource(
 			PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME,
-			PropsValues.JDBC_DEFAULT_URL, "testUser", "liferay",
-			StringPool.BLANK);
+			PropsValues.JDBC_DEFAULT_URL, "test", "liferay", StringPool.BLANK);
 	}
 
 	@After
 	public void tearDown() throws Exception {
 		InfrastructureUtil.setDataSource(_dataSource);
+
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
 
 		if (_testUserDataSource != null) {
 			DataSourceFactoryUtil.destroyDataSource(_testUserDataSource);
@@ -78,23 +78,25 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
 			_db.runSQL(
-				"revoke all privileges on all tables in schema public from " +
-					"testuser");
+				StringBundler.concat(
+					"revoke all privileges on all tables in schema ",
+					dbInspector.getSchema(), " from test"));
+
+			_db.runSQL(
+				StringBundler.concat(
+					"revoke all privileges ON DATABASE ",
+					dbInspector.getCatalog(), " from test"));
 		}
 
-		_db.runSQL("drop user testUser");
+		_db.runSQL("drop user test");
 
 		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
-			_db.runSQL("drop login testUser");
+			_db.runSQL("drop login test");
 		}
 	}
 
 	@Test
 	public void testVerifyAlterTablePrivilege() throws Exception {
-		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.MARIADB));
-
 		_revokePrivileges("alter");
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
@@ -109,7 +111,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			).getMessage();
 
 			Assert.assertTrue(
-				cause.contains("ALTER command denied to user 'testUser'"));
+				cause.contains("ALTER command denied to user 'test'"));
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -119,10 +121,6 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	@Test
 	public void testVerifyCreateTablePrivilege() throws Exception {
 		_revokePrivileges("create");
-
-		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.MARIADB));
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
 
@@ -136,7 +134,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			).getMessage();
 
 			Assert.assertTrue(
-				cause.contains("CREATE command denied to user 'testUser'"));
+				cause.contains("CREATE command denied to user 'test'"));
 		}
 	}
 
@@ -156,7 +154,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			).getMessage();
 
 			Assert.assertTrue(
-				cause.contains("DELETE command denied to user 'testUser'"));
+				cause.contains("DELETE command denied to user 'test'"));
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -179,7 +177,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			).getMessage();
 
 			Assert.assertTrue(
-				cause.contains("INSERT command denied to user 'testUser'"));
+				cause.contains("INSERT command denied to user 'test'"));
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -202,7 +200,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			).getMessage();
 
 			Assert.assertTrue(
-				cause.contains("UPDATE command denied to user 'testUser'"));
+				cause.contains("UPDATE command denied to user 'test'"));
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -220,41 +218,54 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
 			_db.runSQL(
 				StringBundler.concat(
-					"create login [testUser] with password = 'liferay', ",
+					"create login [test] with password = 'liferay', ",
 					"default_database = [", dbInspector.getCatalog(),
-					"], check_policy = off; use lportal;"));
+					"], check_policy = off"));
 		}
 
 		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-			"create user 'testUser'@'%' identified BY 'liferay'");
+			"create user 'test'@'%' identified BY 'liferay'");
 
 		dbTypeToSQLMap.add(
-			DBType.POSTGRESQL, "create user testUser with password 'liferay'");
+			DBType.POSTGRESQL,
+			"create user test with ENCRYPTED PASSWORD 'liferay'");
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
 			StringBundler.concat(
-				"create user [testUser] for login [testUser] with ",
+				"create user [test] for login [test] with ",
 				"default_schema = ", dbInspector.getSchema()));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
 			"grant create,alter,index,select,insert,delete,update,drop on " +
-				"*.* to 'testUser'@'%'");
+				"*.* to 'test'@'%'");
 
 		dbTypeToSQLMap.add(
 			DBType.POSTGRESQL,
 			StringBundler.concat(
-				"grant select, insert, delete, update on all tables in schema",
-				dbInspector.getSchema(), " to testUser"));
+				"grant select, insert, delete, update on all tables in schema ",
+				dbInspector.getSchema(), " to test"));
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
 			"grant select,insert,alter, update, delete on schema::dbo to " +
-				"testUser");
+				"test");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
+			_db.runSQL(
+				StringBundler.concat(
+					"grant create on database ", dbInspector.getCatalog(),
+					" to test"));
+
+			_db.runSQL(
+				StringBundler.concat(
+					"SET search_path TO ", dbInspector.getCatalog(),
+					", public;"));
+		}
 	}
 
 	private void _revokePrivileges(String privilege) throws Exception {
@@ -262,27 +273,27 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
 			StringBundler.concat(
-				"revoke ", privilege, " on *.* from 'testUser'@'%'"));
+				"revoke ", privilege, " on *.* from 'test'@'%'"));
 
 		if (privilege.equals("create")) {
 			dbTypeToSQLMap.add(
 				DBType.POSTGRESQL,
 				StringBundler.concat(
 					"revoke create on schema ", dbInspector.getSchema(),
-					" from testUser"));
+					" from test"));
 		}
 		else {
 			dbTypeToSQLMap.add(
 				DBType.POSTGRESQL,
 				StringBundler.concat(
 					"revoke ", privilege, " on all tables in schema ",
-					dbInspector.getSchema(), " from testUser"));
+					dbInspector.getSchema(), " from test"));
 		}
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
 			StringBundler.concat(
-				"revoke ", privilege, " on schema::dbo from testUser"));
+				"revoke ", privilege, " on schema::dbo from test"));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -29,6 +29,7 @@ import javax.sql.DataSource;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -77,6 +78,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyAlterTablePrivilege() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.MARIADB));
+
 		_revokePrivileges("alter");
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
@@ -100,6 +105,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyCreateTablePrivilege() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.MARIADB));
+
 		_revokePrivileges("create");
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
@@ -120,6 +129,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyDeleteRowPrivilege() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.MARIADB));
+
 		_revokePrivileges("delete");
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
@@ -143,6 +156,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyInsertTablePrivilege() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.MARIADB));
+
 		_revokePrivileges("insert");
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
@@ -166,6 +183,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyUpdateRowPrivilege() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.MARIADB));
+
 		_revokePrivileges("update");
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -60,11 +60,11 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Before
 	public void setUp() throws Exception {
-		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.POSTGRESQL) ||
-			(_db.getDBType() == DBType.SQLSERVER));
+		if ((_db.getDBType() == DBType.DB2) ||
+			(_db.getDBType() == DBType.ORACLE)) {
+
+			return;
+		}
 
 		_createTestUser();
 
@@ -75,15 +75,15 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@After
 	public void tearDown() throws Exception {
-		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.POSTGRESQL) ||
-			(_db.getDBType() == DBType.SQLSERVER));
+		if ((_db.getDBType() == DBType.DB2) ||
+			(_db.getDBType() == DBType.ORACLE)) {
+
+			return;
+		}
 
 		InfrastructureUtil.setDataSource(_dataSource);
 
-		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
+		if (_db.getDBType() == DBType.POSTGRESQL) {
 			DBInspector dbInspector = new DBInspector(
 				DataAccess.getConnection());
 
@@ -99,7 +99,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_db.runSQL("drop user test");
 
-		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+		if (_db.getDBType() == DBType.SQLSERVER) {
 			_db.runSQL("drop login test");
 		}
 	}
@@ -121,7 +121,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+			if (_db.getDBType() == DBType.SQLSERVER) {
 				_verifyException(exception, "does not exist");
 			}
 			else {
@@ -151,8 +151,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
-				_verifyException(exception, "ERROR: permission denied'");
+			if (_db.getDBType() == DBType.POSTGRESQL) {
+				_verifyException(exception, "ERROR: permission denied");
 			}
 			else {
 				_verifyException(exception, "CREATE");
@@ -264,7 +264,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	private void _createTestUser() throws Exception {
 		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
 
-		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+		if (_db.getDBType() == DBType.SQLSERVER) {
 			_db.runSQL(
 				StringBundler.concat(
 					"create login [test] with password = 'test', ",
@@ -296,7 +296,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 				"grant usage, create on schema ", dbInspector.getSchema(),
 				" to test"));
 
-		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+		if (_db.getDBType() == DBType.SQLSERVER) {
 			_db.runSQL("grant create table to test");
 		}
 

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -29,9 +29,11 @@ import javax.sql.DataSource;
 
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,11 +77,25 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			DataSourceFactoryUtil.destroyDataSource(_testUserDataSource);
 		}
 
+		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
+			_db.runSQL(
+				"revoke all privileges on all tables in schema public from "+
+				"testuser");
+		}
+
 		_db.runSQL("drop user testUser");
+
+		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+			_db.runSQL("drop login testUser");
+		}
 	}
 
 	@Test
 	public void testVerifyAlterTablePrivilege() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.MARIADB));
+
 		_revokePrivileges("alter");
 		_revokePrivileges("index");
 
@@ -104,7 +120,9 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyCreateTablePrivilege() throws Exception {
-		_revokePrivileges("create");
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.MARIADB));
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
 
@@ -122,6 +140,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 	}
 
+	@Ignore
 	@Test
 	public void testVerifyDeleteRowPrivilege() throws Exception {
 		_revokePrivileges("delete");
@@ -145,6 +164,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 	}
 
+	@Ignore
 	@Test
 	public void testVerifyInsertTablePrivilege() throws Exception {
 		_revokePrivileges("insert");
@@ -168,6 +188,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 	}
 
+	@Ignore
 	@Test
 	public void testVerifyUpdateRowPrivilege() throws Exception {
 		_revokePrivileges("update");
@@ -208,34 +229,34 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 
 		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-			"create user 'testUser'@'%' identified BY 'liferay';");
+			"create user 'testUser'@'%' identified BY 'liferay'");
 
 		dbTypeToSQLMap.add(
-			DBType.POSTGRESQL, "create user testUser with password 'liferay';");
+			DBType.POSTGRESQL, "create user testUser with password 'liferay'");
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
 			StringBundler.concat(
 				"create user [testUser] for login [testUser] with ",
-				"default_schema = ", dbInspector.getSchema(), ";"));
+				"default_schema = ", dbInspector.getSchema()));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
 			"grant create,alter,index,select,insert,delete,update,drop on " +
-				"*.* to 'testUser'@'%';");
+				"*.* to 'testUser'@'%'");
 
 		dbTypeToSQLMap.add(
 			DBType.POSTGRESQL,
 			StringBundler.concat(
-				"grant create,alter,index,select,insert,delete,update,",
-				"drop on all tables in schema ", dbInspector.getSchema(),
-				" to testUser;"));
+				"grant select, insert, delete, update ",
+				"on all tables in schema ", dbInspector.getSchema(),
+				" to testUser"));
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
 			"grant select,insert,alter, update, delete on schema::dbo to " +
-				"testUser;");
+				"testUser");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
@@ -245,19 +266,27 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
 			StringBundler.concat(
-				"revoke ", privilege, " on *.* from 'testUser'@'%';"));
+				"revoke ", privilege, " on *.* from 'testUser'@'%'"));
 
-		dbTypeToSQLMap.add(
-			DBType.POSTGRESQL,
-			StringBundler.concat(
-				"revoke ", privilege, " on all tables in schema ",
-				dbInspector.getSchema(), " from testUser;"));
+		if (privilege.equals("create")) {
+			dbTypeToSQLMap.add(
+				DBType.POSTGRESQL,
+				StringBundler.concat(
+					"revoke create on schema ", dbInspector.getSchema(),
+					" from testUser"));
+		}
+		else {
+			dbTypeToSQLMap.add(
+				DBType.POSTGRESQL,
+				StringBundler.concat(
+					"revoke ", privilege, " on all tables in schema ",
+					dbInspector.getSchema(), " from testUser"));
+		}
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,
 			StringBundler.concat(
-				"revoke ", privilege, " on schema::", dbInspector.getSchema(),
-				" from testUser;"));
+				"revoke ", privilege, " on schema::dbo from testUser"));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -57,7 +57,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		_testUserDataSource = DataSourceFactoryUtil.initDataSource(
 			PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME,
-			PropsValues.JDBC_DEFAULT_URL, "test", "liferay", StringPool.BLANK);
+			PropsValues.JDBC_DEFAULT_URL, "test", "test", StringPool.BLANK);
 	}
 
 	@After
@@ -87,11 +87,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause(
-			).getMessage();
-
-			Assert.assertTrue(
-				cause.contains("ALTER command denied to user 'test'"));
+			_verifyException(exception, "ALTER command denied to user 'test'");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -114,11 +110,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause(
-			).getMessage();
-
-			Assert.assertTrue(
-				cause.contains("CREATE command denied to user 'test'"));
+			_verifyException(exception, "CREATE command denied to user 'test'");
 		}
 	}
 
@@ -138,11 +130,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause(
-			).getMessage();
-
-			Assert.assertTrue(
-				cause.contains("DELETE command denied to user 'test'"));
+			_verifyException(exception, "DELETE command denied to user 'test'");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -165,11 +153,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause(
-			).getMessage();
-
-			Assert.assertTrue(
-				cause.contains("INSERT command denied to user 'test'"));
+			_verifyException(exception, "INSERT command denied to user 'test'");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -192,11 +176,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause(
-			).getMessage();
-
-			Assert.assertTrue(
-				cause.contains("UPDATE command denied to user 'test'"));
+			_verifyException(exception, "UPDATE command denied to user 'test'");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -209,16 +189,22 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	}
 
 	private void _createTestUser() throws Exception {
-		_db.runSQL("create user 'test'@'%' identified BY 'liferay'");
+		_db.runSQL("create user 'test'@'%' identified BY 'test'");
 		_db.runSQL(
-			"grant create,alter,index,select,insert,delete,update,drop on " +
-				"*.* to 'test'@'%'");
+			"grant alter, create, delete, drop, index, insert, select, " +
+				"update on *.* to 'test'@'%'");
 	}
 
 	private void _revokePrivileges(String privilege) throws Exception {
 		_db.runSQL(
 			StringBundler.concat(
 				"revoke ", privilege, " on *.* from 'test'@'%'"));
+	}
+
+	private void _verifyException(Exception exception, String expectedMessage) {
+		String message = exception.getMessage();
+
+		Assert.assertTrue(message.contains(expectedMessage));
 	}
 
 	private static DataSource _dataSource;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -121,7 +121,12 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			_verifyException(exception, "ALTER command denied to user 'test'");
+			if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+				_verifyException(exception, "does not exist");
+			}
+			else {
+				_verifyException(exception, "ALTER");
+			}
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -150,8 +155,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 				_verifyException(exception, "ERROR: permission denied'");
 			}
 			else {
-				_verifyException(
-					exception, "CREATE command denied to user 'test'");
+				_verifyException(exception, "CREATE");
 			}
 		}
 	}
@@ -173,7 +177,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			_verifyException(exception, "DELETE command denied to user 'test'");
+			_verifyException(exception, "DELETE");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -197,7 +201,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			_verifyException(exception, "INSERT command denied to user 'test'");
+			_verifyException(exception, "INSERT");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -221,7 +225,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			_verifyException(exception, "SELECT command denied to user 'test'");
+			_verifyException(exception, "SELECT");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -245,7 +249,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			_verifyException(exception, "UPDATE command denied to user 'test'");
+			_verifyException(exception, "UPDATE");
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
@@ -283,14 +287,18 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		_db.runSQL(_connection, dbTypeToSQLMap);
 
 		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant alter, create,delete, drop, index, insert, select, update " +
-				"on *.* to 'test'@'%'");
+			"grant alter, create, delete, drop, index, insert, select, " +
+				"update on *.* to 'test'@'%'");
 
 		dbTypeToSQLMap.add(
 			DBType.POSTGRESQL,
 			StringBundler.concat(
 				"grant usage, create on schema ", dbInspector.getSchema(),
 				" to test"));
+
+		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+			_db.runSQL("grant create table to test");
+		}
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -49,12 +49,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		new LiferayIntegrationTestRule();
 
 	@BeforeClass
-	public static void setUpClass() throws Exception {
+	public static void setUpClass(){
 		_db = DBManagerUtil.getDB();
 
 		_dataSource = InfrastructureUtil.getDataSource();
-
-		_connection = DataAccess.getConnection();
 	}
 
 	@Before
@@ -70,29 +68,11 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void tearDown() throws Exception {
 		InfrastructureUtil.setDataSource(_dataSource);
 
-		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
-
 		if (_testUserDataSource != null) {
 			DataSourceFactoryUtil.destroyDataSource(_testUserDataSource);
 		}
 
-		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
-			_db.runSQL(
-				StringBundler.concat(
-					"revoke all privileges on all tables in schema ",
-					dbInspector.getSchema(), " from test"));
-
-			_db.runSQL(
-				StringBundler.concat(
-					"revoke all privileges ON DATABASE ",
-					dbInspector.getCatalog(), " from test"));
-		}
-
 		_db.runSQL("drop user test");
-
-		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
-			_db.runSQL("drop login test");
-		}
 	}
 
 	@Test
@@ -213,89 +193,12 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	}
 
 	private void _createTestUser() throws Exception {
-		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
-
-		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
-			_db.runSQL(
-				StringBundler.concat(
-					"create login [test] with password = 'liferay', ",
-					"default_database = [", dbInspector.getCatalog(),
-					"], check_policy = off"));
-		}
-
-		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-			"create user 'test'@'%' identified BY 'liferay'");
-
-		dbTypeToSQLMap.add(
-			DBType.POSTGRESQL,
-			"create user test with ENCRYPTED PASSWORD 'liferay'");
-
-		dbTypeToSQLMap.add(
-			DBType.SQLSERVER,
-			StringBundler.concat(
-				"create user [test] for login [test] with ",
-				"default_schema = ", dbInspector.getSchema()));
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant create,alter,index,select,insert,delete,update,drop on " +
-				"*.* to 'test'@'%'");
-
-		dbTypeToSQLMap.add(
-			DBType.POSTGRESQL,
-			StringBundler.concat(
-				"grant select, insert, delete, update on all tables in schema ",
-				dbInspector.getSchema(), " to test"));
-
-		dbTypeToSQLMap.add(
-			DBType.SQLSERVER,
-			"grant select,insert,alter, update, delete on schema::dbo to " +
-				"test");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
-			_db.runSQL(
-				StringBundler.concat(
-					"grant create on database ", dbInspector.getCatalog(),
-					" to test"));
-
-			_db.runSQL(
-				StringBundler.concat(
-					"SET search_path TO ", dbInspector.getCatalog(),
-					", public;"));
-		}
+		_db.runSQL("create user 'test'@'%' identified BY 'liferay'");
+		_db.runSQL("grant create,alter,index,select,insert,delete,update,drop on *.* to 'test'@'%'");
 	}
 
 	private void _revokePrivileges(String privilege) throws Exception {
-		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
-
-		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-			StringBundler.concat(
-				"revoke ", privilege, " on *.* from 'test'@'%'"));
-
-		if (privilege.equals("create")) {
-			dbTypeToSQLMap.add(
-				DBType.POSTGRESQL,
-				StringBundler.concat(
-					"revoke create on schema ", dbInspector.getSchema(),
-					" from test"));
-		}
-		else {
-			dbTypeToSQLMap.add(
-				DBType.POSTGRESQL,
-				StringBundler.concat(
-					"revoke ", privilege, " on all tables in schema ",
-					dbInspector.getSchema(), " from test"));
-		}
-
-		dbTypeToSQLMap.add(
-			DBType.SQLSERVER,
-			StringBundler.concat(
-				"revoke ", privilege, " on schema::dbo from test"));
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
+		_db.runSQL(StringBundler.concat("revoke ", privilege, " on *.* from 'test'@'%'"));
 	}
 
 	private static Connection _connection;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -79,8 +79,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
 			_db.runSQL(
-				"revoke all privileges on all tables in schema public from "+
-				"testuser");
+				"revoke all privileges on all tables in schema public from " +
+					"testuser");
 		}
 
 		_db.runSQL("drop user testUser");
@@ -249,9 +249,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		dbTypeToSQLMap.add(
 			DBType.POSTGRESQL,
 			StringBundler.concat(
-				"grant select, insert, delete, update ",
-				"on all tables in schema ", dbInspector.getSchema(),
-				" to testUser"));
+				"grant select, insert, delete, update on all tables in schema",
+				dbInspector.getSchema(), " to testUser"));
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -9,8 +9,11 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.jdbc.DataSourceFactoryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
@@ -31,6 +34,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.sql.Connection;
 
 /**
  * @author Jorge Avalos
@@ -55,7 +60,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void setUp() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL));
+			(_db.getDBType() == DBType.MYSQL) ||
+			(_db.getDBType() == DBType.POSTGRESQL));
 
 		_createTestUser();
 
@@ -68,15 +74,28 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void tearDown() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL));
+			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL));
+
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
 
 		InfrastructureUtil.setDataSource(_dataSource);
+
+		if (DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
+			_db.runSQL(
+				StringBundler.concat(
+					"revoke all privileges on schema ",
+					dbInspector.getSchema(), " from test"));
+		}
 
 		if (_testUserDataSource != null) {
 			DataSourceFactoryUtil.destroyDataSource(_testUserDataSource);
 		}
 
 		_db.runSQL("drop user test");
+
+		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+			_db.runSQL("drop login test");
+		}
 	}
 
 	@Test
@@ -106,7 +125,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	public void testVerifyCreateTablePrivilege() throws Exception {
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MARIADB) ||
-			(_db.getDBType() == DBType.MYSQL));
+			(_db.getDBType() == DBType.MYSQL) || (_db.getDBType() == DBType.POSTGRESQL));
 
 		_revokePrivileges("create");
 
@@ -118,7 +137,13 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			_verifyException(exception, "CREATE command denied to user 'test'");
+			if(DBManagerUtil.getDBType() == DBType.POSTGRESQL) {
+				_verifyException(exception, "ERROR: permission denied'");
+			}
+			else {
+				_verifyException(exception, "CREATE command denied to user 'test'");
+			}
+
 		}
 	}
 
@@ -197,16 +222,67 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	}
 
 	private void _createTestUser() throws Exception {
-		_db.runSQL("create user 'test'@'%' identified BY 'test'");
-		_db.runSQL(
-			"grant alter, create, delete, drop, index, insert, select, " +
-				"update on *.* to 'test'@'%'");
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+
+		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+			_db.runSQL(
+				StringBundler.concat(
+					"create login [test] with password = 'test', ",
+					"default_database = [", dbInspector.getCatalog(),
+					"], check_policy = off"));
+		}
+
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
+			"create user 'test'@'%' identified BY 'test'");
+
+		dbTypeToSQLMap.add(
+			DBType.POSTGRESQL,
+			"create user test with ENCRYPTED PASSWORD 'test'");
+
+		dbTypeToSQLMap.add(
+			DBType.SQLSERVER,
+			StringBundler.concat(
+				"create user [test] for login [test] with ",
+				"default_schema = ", dbInspector.getSchema()));
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"grant create,alter,index,select,insert,delete,update,drop on " +
+			"*.* to 'test'@'%'");
+
+		dbTypeToSQLMap.add(
+			DBType.POSTGRESQL,
+			StringBundler.concat(
+				"grant usage, create on schema ",
+				dbInspector.getSchema(), " to test"));
+
+		dbTypeToSQLMap.add(
+			DBType.SQLSERVER,
+			"grant alter, delete, insert, select, update  on schema::dbo to " +
+			"test");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
 
 	private void _revokePrivileges(String privilege) throws Exception {
-		_db.runSQL(
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
 			StringBundler.concat(
 				"revoke ", privilege, " on *.* from 'test'@'%'"));
+
+		dbTypeToSQLMap.add(
+				DBType.POSTGRESQL,
+				StringBundler.concat(
+					"revoke ", privilege, " on schema ",
+					dbInspector.getSchema(), " from test"));
+
+		dbTypeToSQLMap.add(
+			DBType.SQLSERVER,
+			StringBundler.concat(
+				"revoke ", privilege, " on schema::dbo from test"));
+
 	}
 
 	private void _verifyException(Exception exception, String expectedMessage) {
@@ -214,7 +290,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		Assert.assertTrue(message.contains(expectedMessage));
 	}
-
+	private static Connection _connection;
 	private static DataSource _dataSource;
 	private static DB _db;
 	private static DataSource _testUserDataSource;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -273,7 +273,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 		dbTypeToSQLMap.add(
 			DBType.POSTGRESQL,
-			"create user test with ENCRYPTED PASSWORD 'test'");
+			"create user test with encrypted password 'test' noinherit");
 
 		dbTypeToSQLMap.add(
 			DBType.SQLSERVER,

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -196,53 +196,75 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		return new PreupgradeVerifyDatabasePrivileges();
 	}
 
-	private static void _createTestUser() throws Exception {
+	private void _createTestUser() throws Exception {
 		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
 
 		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
-			_db.runSQL(StringBundler.concat("create login [testUser] with password = 'liferay', default_database = [",dbInspector.getCatalog(),"], check_policy = off; use lportal;"));
-		}
-			DBTypeToSQLMap dbTypeToSQLMap = new
-				DBTypeToSQLMap(
-				"create user 'testUser'@'%' identified BY 'liferay';");
-
-			dbTypeToSQLMap.add(
-				DBType.POSTGRESQL,
-				"create user testUser with password 'liferay';");
-
-			dbTypeToSQLMap.add(DBType.SQLSERVER,StringBundler.concat("create user [testUser] for login [testUser] with default_schema = ", dbInspector.getSchema(),";"));
-			_db.runSQL(_connection, dbTypeToSQLMap);
-
-			dbTypeToSQLMap = new
-				DBTypeToSQLMap(
-				"grant create,alter,index,select,insert,delete,update,drop on *.* to 'testUser'@'%';");
-
-			dbTypeToSQLMap.add(
-				DBType.POSTGRESQL,
-				StringBundler.concat("grant create,alter,index,select,insert,delete,update,drop on all tables in schema ", dbInspector.getSchema()," to testUser;"));
-
-			dbTypeToSQLMap.add(DBType.SQLSERVER,"grant select,insert,alter, update, delete on schema::dbo to testUser;");
-
-			_db.runSQL(_connection, dbTypeToSQLMap);
+			_db.runSQL(
+				StringBundler.concat(
+					"create login [testUser] with password = 'liferay', ",
+					"default_database = [", dbInspector.getCatalog(),
+					"], check_policy = off; use lportal;"));
 		}
 
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
+			"create user 'testUser'@'%' identified BY 'liferay';");
 
-	private static void _revokePrivileges(String privilege) throws Exception {
-		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+		dbTypeToSQLMap.add(
+			DBType.POSTGRESQL, "create user testUser with password 'liferay';");
 
-		DBTypeToSQLMap dbTypeToSQLMap = new
-			DBTypeToSQLMap(StringBundler.concat("revoke ",privilege," on *.* from 'testUser'@'%';"));
+		dbTypeToSQLMap.add(
+			DBType.SQLSERVER,
+			StringBundler.concat(
+				"create user [testUser] for login [testUser] with ",
+				"default_schema = ", dbInspector.getSchema(), ";"));
 
-		dbTypeToSQLMap.add(DBType.POSTGRESQL,StringBundler.concat("revoke ",privilege," on all tables in schema ", dbInspector.getSchema(), " from testUser;"));
+		_db.runSQL(_connection, dbTypeToSQLMap);
 
-		dbTypeToSQLMap.add(DBType.SQLSERVER,StringBundler.concat("revoke ",privilege," on schema::", dbInspector.getSchema(), " from testUser;"));
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"grant create,alter,index,select,insert,delete,update,drop on " +
+				"*.* to 'testUser'@'%';");
+
+		dbTypeToSQLMap.add(
+			DBType.POSTGRESQL,
+			StringBundler.concat(
+				"grant create,alter,index,select,insert,delete,update,",
+				"drop on all tables in schema ", dbInspector.getSchema(),
+				" to testUser;"));
+
+		dbTypeToSQLMap.add(
+			DBType.SQLSERVER,
+			"grant select,insert,alter, update, delete on schema::dbo to " +
+				"testUser;");
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
 
-	private static DataSource _testUserDataSource;
+	private void _revokePrivileges(String privilege) throws Exception {
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
+			StringBundler.concat(
+				"revoke ", privilege, " on *.* from 'testUser'@'%';"));
+
+		dbTypeToSQLMap.add(
+			DBType.POSTGRESQL,
+			StringBundler.concat(
+				"revoke ", privilege, " on all tables in schema ",
+				dbInspector.getSchema(), " from testUser;"));
+
+		dbTypeToSQLMap.add(
+			DBType.SQLSERVER,
+			StringBundler.concat(
+				"revoke ", privilege, " on schema::", dbInspector.getSchema(),
+				" from testUser;"));
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+	}
+
 	private static Connection _connection;
 	private static DataSource _dataSource;
 	private static DB _db;
+	private static DataSource _testUserDataSource;
 
 }

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -1,0 +1,261 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.jdbc.DataSourceFactoryUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.PreupgradeVerifyDatabasePrivileges;
+import com.liferay.portal.verify.VerifyProcess;
+import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
+
+import java.sql.Connection;
+
+import javax.sql.DataSource;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class PreupgradeVerifyDatabasePrivilegesTest
+	extends BaseVerifyProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_db = DBManagerUtil.getDB();
+
+		_dataSource = InfrastructureUtil.getDataSource();
+
+		_connection = DataAccess.getConnection();
+
+	}
+
+	@Before
+	public void setUp() throws Exception {
+
+		_createTestUser();
+
+		_badUserDataSource = DataSourceFactoryUtil.initDataSource(
+			PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME,
+			PropsValues.JDBC_DEFAULT_URL, "testUser", "liferay",
+			StringPool.BLANK);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		InfrastructureUtil.setDataSource(_dataSource);
+
+		if (_badUserDataSource != null) {
+			DataSourceFactoryUtil.destroyDataSource(_badUserDataSource);
+		}
+
+		_db.runSQL("drop user testUser");
+
+	}
+
+	@Test
+	public void testVerifyCreateTablePrivilege() throws Exception {
+		revokePrivileges("CREATE");;
+
+		InfrastructureUtil.setDataSource(
+			_badUserDataSource);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			String cause = exception.getCause().getMessage();
+
+			Assert.assertTrue(
+				cause.contains("CREATE command denied to user 'testUser'"));
+		}
+	}
+
+	@Test
+	public void testVerifyAlterTablePrivilege() throws Exception {
+		revokePrivileges("ALTER");
+		revokePrivileges("INDEX");
+
+		InfrastructureUtil.setDataSource(
+			_badUserDataSource);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			String cause = exception.getCause().getMessage();
+
+			Assert.assertTrue(
+				cause.contains("ALTER command denied to user 'testUser'"));
+		}
+		finally {
+			InfrastructureUtil.setDataSource(_dataSource);
+
+		}
+	}
+
+	@Test
+	public void testVerifyInsertTablePrivilege() throws Exception {
+		revokePrivileges("insert");
+
+		InfrastructureUtil.setDataSource(
+			_badUserDataSource);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			String cause = exception.getCause().getMessage();
+
+			Assert.assertTrue(
+				cause.contains("INSERT command denied to user 'testUser'"));
+		}
+		finally {
+			InfrastructureUtil.setDataSource(_dataSource);
+		}
+	}
+
+	@Test
+	public void testVerifyUpdateRowPrivilege() throws Exception {
+		revokePrivileges("update");
+
+		InfrastructureUtil.setDataSource(
+			_badUserDataSource);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			String cause = exception.getCause().getMessage();
+
+			Assert.assertTrue(
+				cause.contains("UPDATE command denied to user 'testUser'"));
+		}
+		finally {
+			InfrastructureUtil.setDataSource(_dataSource);
+		}
+	}
+
+	@Test
+	public void testVerifyDeleteRowPrivilege() throws Exception {
+		revokePrivileges("delete");
+
+		InfrastructureUtil.setDataSource(
+			_badUserDataSource);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			String cause = exception.getCause().getMessage();
+
+			Assert.assertTrue(
+				cause.contains("DELETE command denied to user 'testUser'"));
+		}
+		finally {
+			InfrastructureUtil.setDataSource(_dataSource);
+		}
+	}
+
+
+	private static void _createTestUser() throws Exception {
+		DBTypeToSQLMap dbTypeToSQLMap = new
+			DBTypeToSQLMap("CREATE USER 'testUser'@'%' IDENTIFIED BY 'liferay';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT SELECT ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT CREATE ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT ALTER ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT INDEX ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT INSERT ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT DELETE ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT UPDATE ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new
+			DBTypeToSQLMap("GRANT DROP ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+	}
+
+	private static void revokePrivileges(String privilege) throws Exception {
+		DBTypeToSQLMap dbTypeToSQLMap = new
+			DBTypeToSQLMap(StringBundler.concat("REVOKE ",privilege," ON *.* FROM 'testUser'@'%';"));
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+	}
+
+	@Override
+	protected VerifyProcess getVerifyProcess() {
+		return new PreupgradeVerifyDatabasePrivileges();
+	}
+
+	private static DataSource _badUserDataSource;
+	private static Connection _connection;
+	private static DataSource _dataSource;
+	private static DB _db;
+
+}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
@@ -196,8 +197,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	}
 
 	private static void _createTestUser() throws Exception {
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+
 		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
-			_db.runSQL("create login [testUser] with password = 'liferay', default_database = [lportal], check_policy = off; use lportal;");
+			_db.runSQL(StringBundler.concat("create login [testUser] with password = 'liferay', default_database = [",dbInspector.getCatalog(),"], check_policy = off; use lportal;"));
 		}
 			DBTypeToSQLMap dbTypeToSQLMap = new
 				DBTypeToSQLMap(
@@ -207,7 +210,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 				DBType.POSTGRESQL,
 				"create user testUser with password 'liferay';");
 
-			dbTypeToSQLMap.add(DBType.SQLSERVER,"create user [testUser] for login [testUser] with default_schema = lportal;");
+			dbTypeToSQLMap.add(DBType.SQLSERVER,StringBundler.concat("create user [testUser] for login [testUser] with default_schema = ", dbInspector.getSchema(),";"));
 			_db.runSQL(_connection, dbTypeToSQLMap);
 
 			dbTypeToSQLMap = new
@@ -216,7 +219,7 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 			dbTypeToSQLMap.add(
 				DBType.POSTGRESQL,
-				"grant create,alter,index,select,insert,delete,update,drop on all tables in schema public to testUser;");
+				StringBundler.concat("grant create,alter,index,select,insert,delete,update,drop on all tables in schema ", dbInspector.getSchema()," to testUser;"));
 
 			dbTypeToSQLMap.add(DBType.SQLSERVER,"grant select,insert,alter, update, delete on schema::dbo to testUser;");
 
@@ -225,12 +228,14 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 
 	private static void _revokePrivileges(String privilege) throws Exception {
+		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+
 		DBTypeToSQLMap dbTypeToSQLMap = new
 			DBTypeToSQLMap(StringBundler.concat("revoke ",privilege," on *.* from 'testUser'@'%';"));
 
-		dbTypeToSQLMap.add(DBType.POSTGRESQL,StringBundler.concat("revoke ",privilege," on all tables in schema public from testUser;"));
+		dbTypeToSQLMap.add(DBType.POSTGRESQL,StringBundler.concat("revoke ",privilege," on all tables in schema ", dbInspector.getSchema(), " from testUser;"));
 
-		dbTypeToSQLMap.add(DBType.SQLSERVER,StringBundler.concat("revoke ",privilege," on schema::lportal from testUser;"));
+		dbTypeToSQLMap.add(DBType.SQLSERVER,StringBundler.concat("revoke ",privilege," on schema::", dbInspector.getSchema(), " from testUser;"));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -33,7 +33,6 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -53,12 +53,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		_dataSource = InfrastructureUtil.getDataSource();
 
 		_connection = DataAccess.getConnection();
-
 	}
 
 	@Before
 	public void setUp() throws Exception {
-
 		_createTestUser();
 
 		_badUserDataSource = DataSourceFactoryUtil.initDataSource(
@@ -76,15 +74,14 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 
 		_db.runSQL("drop user testUser");
-
 	}
 
 	@Test
-	public void testVerifyCreateTablePrivilege() throws Exception {
-		revokePrivileges("CREATE");;
+	public void testVerifyAlterTablePrivilege() throws Exception {
+		_revokePrivileges("ALTER");
+		_revokePrivileges("INDEX");
 
-		InfrastructureUtil.setDataSource(
-			_badUserDataSource);
+		InfrastructureUtil.setDataSource(_badUserDataSource);
 
 		try {
 			testVerify();
@@ -92,7 +89,31 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause().getMessage();
+			String cause = exception.getCause(
+			).getMessage();
+
+			Assert.assertTrue(
+				cause.contains("ALTER command denied to user 'testUser'"));
+		}
+		finally {
+			InfrastructureUtil.setDataSource(_dataSource);
+		}
+	}
+
+	@Test
+	public void testVerifyCreateTablePrivilege() throws Exception {
+		_revokePrivileges("CREATE");
+
+		InfrastructureUtil.setDataSource(_badUserDataSource);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			String cause = exception.getCause(
+			).getMessage();
 
 			Assert.assertTrue(
 				cause.contains("CREATE command denied to user 'testUser'"));
@@ -100,12 +121,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	}
 
 	@Test
-	public void testVerifyAlterTablePrivilege() throws Exception {
-		revokePrivileges("ALTER");
-		revokePrivileges("INDEX");
+	public void testVerifyDeleteRowPrivilege() throws Exception {
+		_revokePrivileges("delete");
 
-		InfrastructureUtil.setDataSource(
-			_badUserDataSource);
+		InfrastructureUtil.setDataSource(_badUserDataSource);
 
 		try {
 			testVerify();
@@ -113,23 +132,22 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause().getMessage();
+			String cause = exception.getCause(
+			).getMessage();
 
 			Assert.assertTrue(
-				cause.contains("ALTER command denied to user 'testUser'"));
+				cause.contains("DELETE command denied to user 'testUser'"));
 		}
 		finally {
 			InfrastructureUtil.setDataSource(_dataSource);
-
 		}
 	}
 
 	@Test
 	public void testVerifyInsertTablePrivilege() throws Exception {
-		revokePrivileges("insert");
+		_revokePrivileges("insert");
 
-		InfrastructureUtil.setDataSource(
-			_badUserDataSource);
+		InfrastructureUtil.setDataSource(_badUserDataSource);
 
 		try {
 			testVerify();
@@ -137,7 +155,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause().getMessage();
+			String cause = exception.getCause(
+			).getMessage();
 
 			Assert.assertTrue(
 				cause.contains("INSERT command denied to user 'testUser'"));
@@ -149,10 +168,9 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyUpdateRowPrivilege() throws Exception {
-		revokePrivileges("update");
+		_revokePrivileges("update");
 
-		InfrastructureUtil.setDataSource(
-			_badUserDataSource);
+		InfrastructureUtil.setDataSource(_badUserDataSource);
 
 		try {
 			testVerify();
@@ -160,7 +178,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			Assert.fail();
 		}
 		catch (Exception exception) {
-			String cause = exception.getCause().getMessage();
+			String cause = exception.getCause(
+			).getMessage();
 
 			Assert.assertTrue(
 				cause.contains("UPDATE command denied to user 'testUser'"));
@@ -170,87 +189,64 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 	}
 
-	@Test
-	public void testVerifyDeleteRowPrivilege() throws Exception {
-		revokePrivileges("delete");
-
-		InfrastructureUtil.setDataSource(
-			_badUserDataSource);
-
-		try {
-			testVerify();
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			String cause = exception.getCause().getMessage();
-
-			Assert.assertTrue(
-				cause.contains("DELETE command denied to user 'testUser'"));
-		}
-		finally {
-			InfrastructureUtil.setDataSource(_dataSource);
-		}
-	}
-
-
-	private static void _createTestUser() throws Exception {
-		DBTypeToSQLMap dbTypeToSQLMap = new
-			DBTypeToSQLMap("CREATE USER 'testUser'@'%' IDENTIFIED BY 'liferay';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT SELECT ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT CREATE ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT ALTER ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT INDEX ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT INSERT ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT DELETE ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT UPDATE ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new
-			DBTypeToSQLMap("GRANT DROP ON *.* TO 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-	}
-
-	private static void revokePrivileges(String privilege) throws Exception {
-		DBTypeToSQLMap dbTypeToSQLMap = new
-			DBTypeToSQLMap(StringBundler.concat("REVOKE ",privilege," ON *.* FROM 'testUser'@'%';"));
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-	}
-
 	@Override
 	protected VerifyProcess getVerifyProcess() {
 		return new PreupgradeVerifyDatabasePrivileges();
+	}
+
+	private void _createTestUser() throws Exception {
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
+			"CREATE USER 'testUser'@'%' IDENTIFIED BY 'liferay';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT SELECT ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT CREATE ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT ALTER ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT INDEX ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT INSERT ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT DELETE ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT UPDATE ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+
+		dbTypeToSQLMap = new DBTypeToSQLMap(
+			"GRANT DROP ON *.* TO 'testUser'@'%';");
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
+	}
+
+	private void _revokePrivileges(String privilege) throws Exception {
+		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
+			StringBundler.concat(
+				"REVOKE ", privilege, " ON *.* FROM 'testUser'@'%';"));
+
+		_db.runSQL(_connection, dbTypeToSQLMap);
 	}
 
 	private static DataSource _badUserDataSource;

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -53,6 +53,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Before
 	public void setUp() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL));
+
 		_createTestUser();
 
 		_testUserDataSource = DataSourceFactoryUtil.initDataSource(
@@ -62,6 +66,10 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@After
 	public void tearDown() throws Exception {
+		Assume.assumeTrue(
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL));
+
 		InfrastructureUtil.setDataSource(_dataSource);
 
 		if (_testUserDataSource != null) {
@@ -74,8 +82,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	@Test
 	public void testVerifyAlterTablePrivilege() throws Exception {
 		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.MARIADB));
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL));
 
 		_revokePrivileges("alter");
 
@@ -97,8 +105,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	@Test
 	public void testVerifyCreateTablePrivilege() throws Exception {
 		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.MARIADB));
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL));
 
 		_revokePrivileges("create");
 
@@ -117,8 +125,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	@Test
 	public void testVerifyDeleteRowPrivilege() throws Exception {
 		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.MARIADB));
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL));
 
 		_revokePrivileges("delete");
 
@@ -140,8 +148,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	@Test
 	public void testVerifyInsertTablePrivilege() throws Exception {
 		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.MARIADB));
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL));
 
 		_revokePrivileges("insert");
 
@@ -163,8 +171,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	@Test
 	public void testVerifyUpdateRowPrivilege() throws Exception {
 		Assume.assumeTrue(
-			(_db.getDBType() == DBType.MYSQL) ||
-			(_db.getDBType() == DBType.MARIADB));
+			(_db.getDBType() == DBType.MARIADB) ||
+			(_db.getDBType() == DBType.MYSQL));
 
 		_revokePrivileges("update");
 

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -97,7 +97,6 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 			(_db.getDBType() == DBType.MARIADB));
 
 		_revokePrivileges("alter");
-		_revokePrivileges("index");
 
 		InfrastructureUtil.setDataSource(_testUserDataSource);
 
@@ -120,6 +119,8 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 
 	@Test
 	public void testVerifyCreateTablePrivilege() throws Exception {
+		_revokePrivileges("create");
+
 		Assume.assumeTrue(
 			(_db.getDBType() == DBType.MYSQL) ||
 			(_db.getDBType() == DBType.MARIADB));
@@ -140,7 +141,6 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testVerifyDeleteRowPrivilege() throws Exception {
 		_revokePrivileges("delete");
@@ -164,7 +164,6 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testVerifyInsertTablePrivilege() throws Exception {
 		_revokePrivileges("insert");
@@ -188,7 +187,6 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testVerifyUpdateRowPrivilege() throws Exception {
 		_revokePrivileges("update");

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.DBTypeToSQLMap;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dao.jdbc.DataSourceFactoryUtil;
@@ -194,57 +195,42 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 		return new PreupgradeVerifyDatabasePrivileges();
 	}
 
-	private void _createTestUser() throws Exception {
-		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-			"create user 'testUser'@'%' identified by 'liferay';");
+	private static void _createTestUser() throws Exception {
+		if (DBManagerUtil.getDBType() == DBType.SQLSERVER) {
+			_db.runSQL("create login [testUser] with password = 'liferay', default_database = [lportal], check_policy = off; use lportal;");
+		}
+			DBTypeToSQLMap dbTypeToSQLMap = new
+				DBTypeToSQLMap(
+				"create user 'testUser'@'%' identified BY 'liferay';");
 
-		_db.runSQL(_connection, dbTypeToSQLMap);
+			dbTypeToSQLMap.add(
+				DBType.POSTGRESQL,
+				"create user testUser with password 'liferay';");
 
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant select on *.* to 'testUser'@'%';");
+			dbTypeToSQLMap.add(DBType.SQLSERVER,"create user [testUser] for login [testUser] with default_schema = lportal;");
+			_db.runSQL(_connection, dbTypeToSQLMap);
 
-		_db.runSQL(_connection, dbTypeToSQLMap);
+			dbTypeToSQLMap = new
+				DBTypeToSQLMap(
+				"grant create,alter,index,select,insert,delete,update,drop on *.* to 'testUser'@'%';");
 
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant create on *.* to 'testUser'@'%';");
+			dbTypeToSQLMap.add(
+				DBType.POSTGRESQL,
+				"grant create,alter,index,select,insert,delete,update,drop on all tables in schema public to testUser;");
 
-		_db.runSQL(_connection, dbTypeToSQLMap);
+			dbTypeToSQLMap.add(DBType.SQLSERVER,"grant select,insert,alter, update, delete on schema::dbo to testUser;");
 
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant alter on *.* to 'testUser'@'%';");
+			_db.runSQL(_connection, dbTypeToSQLMap);
+		}
 
-		_db.runSQL(_connection, dbTypeToSQLMap);
 
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant index on *.* to 'testUser'@'%';");
+	private static void _revokePrivileges(String privilege) throws Exception {
+		DBTypeToSQLMap dbTypeToSQLMap = new
+			DBTypeToSQLMap(StringBundler.concat("revoke ",privilege," on *.* from 'testUser'@'%';"));
 
-		_db.runSQL(_connection, dbTypeToSQLMap);
+		dbTypeToSQLMap.add(DBType.POSTGRESQL,StringBundler.concat("revoke ",privilege," on all tables in schema public from testUser;"));
 
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant insert on *.* to 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant delete on *.* to 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant update on *.* to 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-
-		dbTypeToSQLMap = new DBTypeToSQLMap(
-			"grant drop on *.* to 'testUser'@'%';");
-
-		_db.runSQL(_connection, dbTypeToSQLMap);
-	}
-
-	private void _revokePrivileges(String privilege) throws Exception {
-		DBTypeToSQLMap dbTypeToSQLMap = new DBTypeToSQLMap(
-			StringBundler.concat(
-				"revoke ", privilege, " on *.* from 'testUser'@'%';"));
+		dbTypeToSQLMap.add(DBType.SQLSERVER,StringBundler.concat("revoke ",privilege," on schema::lportal from testUser;"));
 
 		_db.runSQL(_connection, dbTypeToSQLMap);
 	}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabasePrivilegesTest.java
@@ -260,6 +260,11 @@ public class PreupgradeVerifyDatabasePrivilegesTest
 	private void _createTestUser() throws Exception {
 		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
 
+		if(_db.getDBType() == DBType.POSTGRESQL) {
+			_db.runSQL(StringBundler.concat("revoke create on schema ", dbInspector.getSchema(),
+				" from public"));
+		}
+
 		if (_db.getDBType() == DBType.SQLSERVER) {
 			_db.runSQL(
 				StringBundler.concat(

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -70,7 +70,7 @@ public class PreupgradeVerifyDatabasePrivileges
 		}
 		catch (Exception exception) {
 			throw new VerifyException(
-				"User is missing database privileges", exception);
+				"Database user is missing privileges", exception);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -28,50 +28,49 @@ public class PreupgradeVerifyDatabasePrivileges
 
 		try {
 			if (dbInspector.hasTable(tempTableName)) {
-				db.runSQL("DROP TABLE " + tempTableName);
+				db.runSQL("drop table " + tempTableName);
 			}
 
 			db.runSQL(
 				StringBundler.concat(
-					"CREATE TABLE ", tempTableName, " (column1 LONG NOT NULL, ",
-					"column2 LONG, PRIMARY KEY (column1))"));
+					"create table ", tempTableName, " (column1 long not null, ",
+					"column2 long, primary key (column1))"));
 
 			db.updateIndexes(
 				connection, tempTableName,
 				StringBundler.concat(
-					"create index IX_TEMP on ", tempTableName, " (column2)"),
+					"create index ix_temp on ", tempTableName, " (column2)"),
 				true);
 
-			alterTableAddColumn(tempTableName, "column3", "LONG");
+			alterTableAddColumn(tempTableName, "column3", "long");
 
 			db.runSQL(
 				StringBundler.concat(
-					"INSERT INTO ", tempTableName,
-					" (column1, column2, column3) VALUES (1,1,1)"));
+					"insert into ", tempTableName,
+					" (column1, column2, column3) values (1,1,1)"));
 
 			db.runSQL(
 				StringBundler.concat(
-					"UPDATE ", tempTableName,
-					" SET column2 = 2 WHERE column1 = 1"));
+					"update ", tempTableName,
+					" set column2 = 2 where column1 = 1"));
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				StringBundler.concat(
-					"SELECT 1 FROM ", tempTableName, " WHERE column1 = 1"));
+					"select 1 from ", tempTableName, " where column1 = 1"));
 
 			preparedStatement.executeQuery();
 
 			db.runSQL(
 				StringBundler.concat(
-					"DELETE FROM ", tempTableName, " WHERE column1 = 1"));
+					"delete from ", tempTableName, " where column1 = 1"));
+
+			if (dbInspector.hasTable(tempTableName)) {
+				db.runSQL("drop table " + tempTableName);
+			}
 		}
 		catch (Exception exception) {
 			throw new VerifyException(
 				"User is missing database privileges", exception);
-		}
-		finally {
-			if (dbInspector.hasTable(tempTableName)) {
-				db.runSQL("DROP TABLE " + tempTableName);
-			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+
+import java.sql.PreparedStatement;
+
+/**
+ * @author Jorge Avalos
+ */
+public class PreupgradeVerifyDatabasePrivileges
+	extends PreupgradeVerifyProcess {
+
+	@Override
+	protected void doVerify() throws Exception {
+		String tempTableName = "temp_permission_check";
+
+		DB db = DBManagerUtil.getDB();
+
+		DBInspector dbInspector = new DBInspector(connection);
+
+		try {
+			if (dbInspector.hasTable(tempTableName)) {
+				db.runSQL("DROP TABLE " + tempTableName);
+			}
+
+			db.runSQL(
+				StringBundler.concat(
+					"CREATE TABLE ", tempTableName, " (column1 LONG NOT NULL, ",
+					"PRIMARY KEY (column1))"));
+
+			alterTableAddColumn(tempTableName, "column2", "LONG");
+
+			db.updateIndexes(
+				connection, tempTableName,
+				StringBundler.concat(
+					"create index IX_TEMP on ", tempTableName, " (column2)"),
+				true);
+
+			db.runSQL(
+				StringBundler.concat(
+					"INSERT INTO ", tempTableName,
+					" (column1, column2) VALUES (1,1)"));
+
+			db.runSQL(
+				StringBundler.concat(
+					"UPDATE ", tempTableName,
+					" SET column2 = 2 WHERE column1 = 1"));
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"SELECT 1 FROM ", tempTableName, " WHERE column1 = 1"));
+
+			preparedStatement.executeQuery();
+
+			db.runSQL(
+				StringBundler.concat(
+					"DELETE FROM ", tempTableName, " WHERE column1 = 1"));
+		}
+		catch (Exception exception) {
+			throw new VerifyException(
+				"User is missing database privileges", exception);
+		}
+		finally {
+			if (dbInspector.hasTable(tempTableName)) {
+				db.runSQL("DROP TABLE " + tempTableName);
+			}
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -33,8 +33,9 @@ public class PreupgradeVerifyDatabasePrivileges
 
 			db.runSQL(
 				StringBundler.concat(
-					"create table ", tempTableName, " (column1 long not null, ",
-					"column2 long, primary key (column1))"));
+					"create table ", tempTableName,
+					"(column1 LONG not null primary key, ",
+					"column2 VARCHAR(75))"));
 
 			db.updateIndexes(
 				connection, tempTableName,

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -26,17 +26,15 @@ public class PreupgradeVerifyDatabasePrivileges
 
 		DBInspector dbInspector = new DBInspector(connection);
 
-		if (dbInspector.hasTable(tempTableName)) {
-			db.runSQL("DROP TABLE " + tempTableName);
-		}
-
 		try {
+			if (dbInspector.hasTable(tempTableName)) {
+				db.runSQL("DROP TABLE " + tempTableName);
+			}
+
 			db.runSQL(
 				StringBundler.concat(
 					"CREATE TABLE ", tempTableName, " (column1 LONG NOT NULL, ",
-					"PRIMARY KEY (column1))"));
-
-			alterTableAddColumn(tempTableName, "column2", "LONG");
+					"column2 LONG, PRIMARY KEY (column1))"));
 
 			db.updateIndexes(
 				connection, tempTableName,
@@ -44,10 +42,12 @@ public class PreupgradeVerifyDatabasePrivileges
 					"create index IX_TEMP on ", tempTableName, " (column2)"),
 				true);
 
+			alterTableAddColumn(tempTableName, "column3", "LONG");
+
 			db.runSQL(
 				StringBundler.concat(
 					"INSERT INTO ", tempTableName,
-					" (column1, column2) VALUES (1,1)"));
+					" (column1, column2, column3) VALUES (1,1,1)"));
 
 			db.runSQL(
 				StringBundler.concat(

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -26,11 +26,11 @@ public class PreupgradeVerifyDatabasePrivileges
 
 		DBInspector dbInspector = new DBInspector(connection);
 
-		try {
-			if (dbInspector.hasTable(tempTableName)) {
-				db.runSQL("DROP TABLE " + tempTableName);
-			}
+		if (dbInspector.hasTable(tempTableName)) {
+			db.runSQL("DROP TABLE " + tempTableName);
+		}
 
+		try {
 			db.runSQL(
 				StringBundler.concat(
 					"CREATE TABLE ", tempTableName, " (column1 LONG NOT NULL, ",

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.verify;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
@@ -20,58 +19,48 @@ public class PreupgradeVerifyDatabasePrivileges
 
 	@Override
 	protected void doVerify() throws Exception {
-		String tempTableName = "temp_permission_check";
-
 		DB db = DBManagerUtil.getDB();
 
 		DBInspector dbInspector = new DBInspector(connection);
 
 		try {
-			if (dbInspector.hasTable(tempTableName)) {
-				db.runSQL("drop table " + tempTableName);
+			if (dbInspector.hasTable("temp_permission_check")) {
+				db.runSQL("drop table temp_permission_check");
 			}
 
 			db.runSQL(
-				StringBundler.concat(
-					"create table ", tempTableName,
-					"(column1 LONG not null primary key, ",
-					"column2 VARCHAR(75))"));
+				"create table temp_permission_check (column1 int not null)");
 
 			db.updateIndexes(
-				connection, tempTableName,
-				StringBundler.concat(
-					"create index ix_temp on ", tempTableName, " (column2)"),
+				connection, "temp_permission_check",
+				"create index ix_temp on temp_permission_check (column1)",
 				true);
 
-			alterTableAddColumn(tempTableName, "column3", "long");
+			alterTableAddColumn("temp_permission_check", "column2", "int");
 
 			db.runSQL(
-				StringBundler.concat(
-					"insert into ", tempTableName,
-					" (column1, column2, column3) values (1,1,1)"));
+				"insert into temp_permission_check(column1, column2) values " +
+					"(1,1)");
 
 			db.runSQL(
-				StringBundler.concat(
-					"update ", tempTableName,
-					" set column2 = 2 where column1 = 1"));
+				"update temp_permission_check set column2 = 2 where column1 " +
+					"= 1");
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"select 1 from ", tempTableName, " where column1 = 1"));
+				"select 1 from temp_permission_check where column1 = 1");
 
 			preparedStatement.executeQuery();
 
-			db.runSQL(
-				StringBundler.concat(
-					"delete from ", tempTableName, " where column1 = 1"));
+			db.runSQL("delete from temp_permission_check where column1 = 1");
 
-			if (dbInspector.hasTable(tempTableName)) {
-				db.runSQL("drop table " + tempTableName);
+			if (dbInspector.hasTable("tempTableName")) {
+				db.runSQL("drop table temp_permission_check");
 			}
 		}
 		catch (Exception exception) {
 			throw new VerifyException(
-				"Database user is missing privileges", exception);
+				"Database user is missing privileges: " +
+					exception.getMessage());
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabasePrivileges.java
@@ -53,9 +53,7 @@ public class PreupgradeVerifyDatabasePrivileges
 
 			db.runSQL("delete from temp_permission_check where column1 = 1");
 
-			if (dbInspector.hasTable("tempTableName")) {
-				db.runSQL("drop table temp_permission_check");
-			}
+			db.runSQL("drop table temp_permission_check");
 		}
 		catch (Exception exception) {
 			throw new VerifyException(

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -23,6 +23,7 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 	public void doVerify() throws Exception {
 		_verify(new PreupgradeVerifyCompanyUsers());
 		_verify(new PreupgradeVerifyDatabaseCharacterSet());
+		_verify(new PreupgradeVerifyDatabasePrivileges());
 		_verify(new PreupgradeVerifyDatabaseState());
 		_verify(new PreupgradeVerifyProperties());
 


### PR DESCRIPTION
@jorgediaz-lr 
The tests for postgres and mssql became complicated.

For Postgres and MSSQL, alot of privileges overlap making it difficult to test specific privileges as the verify process would fail at the start.

Besides the base verify tests,  the other tests only run on mysql/mariadb.