### PR TITLE
LPD-57274 Upgrade to fix the data_ values in ServiceComponent

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeServiceComponentTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeServiceComponentTest.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
+import com.liferay.portal.kernel.model.ServiceComponent;
+import com.liferay.portal.kernel.service.ServiceComponentLocalService;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.v7_4_x.UpgradeServiceComponent;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Díaz
+ */
+@RunWith(Arquillian.class)
+public class UpgradeServiceComponentTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	@TestInfo("LPD-57274")
+	public void testUpgrade() throws Exception {
+		ServiceComponent serviceComponent = _getServiceComponent();
+
+		String originalData = serviceComponent.getData();
+
+		serviceComponent.setData(RandomTestUtil.randomString());
+
+		serviceComponent = _serviceComponentLocalService.updateServiceComponent(
+			serviceComponent);
+
+		UpgradeProcess upgradeProcess = new UpgradeServiceComponent();
+
+		upgradeProcess.upgrade();
+
+		CacheRegistryUtil.clear();
+
+		serviceComponent = _serviceComponentLocalService.getServiceComponent(
+			serviceComponent.getServiceComponentId());
+
+		Assert.assertTrue(originalData.equals(serviceComponent.getData()));
+	}
+
+	private ServiceComponent _getServiceComponent() {
+		for (ServiceComponent serviceComponent :
+				_serviceComponentLocalService.getLatestServiceComponents()) {
+
+			String buildNamespace = serviceComponent.getBuildNamespace();
+
+			if (buildNamespace.startsWith("com.liferay")) {
+				return serviceComponent;
+			}
+		}
+
+		return null;
+	}
+
+	@Inject
+	private ServiceComponentLocalService _serviceComponentLocalService;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeServiceComponentTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeServiceComponentTest.java
@@ -58,7 +58,7 @@ public class UpgradeServiceComponentTest {
 				_serviceComponentLocalService.getServiceComponent(
 					serviceComponent.getServiceComponentId());
 
-			Assert.assertTrue(originalData.equals(serviceComponent.getData()));
+			Assert.assertEquals(originalData, serviceComponent.getData());
 		}
 		finally {
 			serviceComponent.setData(originalData);

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeServiceComponentTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeServiceComponentTest.java
@@ -41,21 +41,31 @@ public class UpgradeServiceComponentTest {
 
 		String originalData = serviceComponent.getData();
 
-		serviceComponent.setData(RandomTestUtil.randomString());
+		try {
+			serviceComponent.setData(RandomTestUtil.randomString());
 
-		serviceComponent = _serviceComponentLocalService.updateServiceComponent(
-			serviceComponent);
+			serviceComponent =
+				_serviceComponentLocalService.updateServiceComponent(
+					serviceComponent);
 
-		UpgradeProcess upgradeProcess = new UpgradeServiceComponent();
+			UpgradeProcess upgradeProcess = new UpgradeServiceComponent();
 
-		upgradeProcess.upgrade();
+			upgradeProcess.upgrade();
 
-		CacheRegistryUtil.clear();
+			CacheRegistryUtil.clear();
 
-		serviceComponent = _serviceComponentLocalService.getServiceComponent(
-			serviceComponent.getServiceComponentId());
+			serviceComponent =
+				_serviceComponentLocalService.getServiceComponent(
+					serviceComponent.getServiceComponentId());
 
-		Assert.assertTrue(originalData.equals(serviceComponent.getData()));
+			Assert.assertTrue(originalData.equals(serviceComponent.getData()));
+		}
+		finally {
+			serviceComponent.setData(originalData);
+
+			_serviceComponentLocalService.updateServiceComponent(
+				serviceComponent);
+		}
 	}
 
 	private ServiceComponent _getServiceComponent() {

--- a/portal-impl/src/com/liferay/portal/db/DBResourceUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/DBResourceUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.db;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -121,8 +122,13 @@ public class DBResourceUtil {
 		Set<String> tableNames = new HashSet<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select data_ from ServiceComponent where buildNamespace " +
-					"like 'com.liferay%'")) {
+				StringBundler.concat(
+					"select data_ from ServiceComponent where buildNamespace ",
+					"like 'com.liferay%' and buildNumber = (select ",
+					"max(buildNumber)  from ServiceComponent ",
+					"tempServiceComponent where ",
+					"ServiceComponent.buildNamespace = ",
+					"tempServiceComponent.buildNamespace)"))) {
 
 			DBInspector dbInspector = new DBInspector(connection);
 

--- a/portal-impl/src/com/liferay/portal/tools/packageinfo
+++ b/portal-impl/src/com/liferay/portal/tools/packageinfo
@@ -1,1 +1,1 @@
-version 17.0.0
+version 17.1.0

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -643,6 +643,9 @@ public class PortalUpgradeProcessRegistryImpl
 
 		upgradeVersionTreeMap.put(
 			new Version(32, 4, 1), new UpgradePortletPreferenceValueCounter());
+
+		upgradeVersionTreeMap.put(
+			new Version(32, 4, 2), new UpgradeServiceComponent());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeServiceComponent.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeServiceComponent.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.PropertiesUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
@@ -65,8 +66,8 @@ public class UpgradeServiceComponent extends UpgradeProcess {
 
 				Long buildNumber = (Long)values[1];
 
-				if (!buildNumberServiceProperties.equals(
-						buildNumber.toString())) {
+				if (!StringUtil.equals(
+						buildNumberServiceProperties, buildNumber.toString())) {
 
 					return;
 				}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeServiceComponent.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeServiceComponent.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.v7_4_x;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.db.DBResourceUtil;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PropertiesUtil;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+
+import java.io.IOException;
+
+import java.util.Properties;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * @author Jorge Díaz
+ */
+public class UpgradeServiceComponent extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		String sql = StringBundler.concat(
+			"select buildNamespace, buildNumber, data_ from ServiceComponent ",
+			"where buildNamespace like 'com.liferay%' and buildNumber = ",
+			"(select max(buildNumber) from ServiceComponent ",
+			"tempServiceComponent where ServiceComponent.buildNamespace = ",
+			"tempServiceComponent.buildNamespace)");
+
+		String updateSQL =
+			"update ServiceComponent set data_ = ? where buildNamespace = ? " +
+				"and buildNumber = ?";
+
+		processConcurrently(
+			SQLTransformer.transform(sql), updateSQL,
+			resultSet -> new Object[] {
+				resultSet.getString("buildNamespace"),
+				resultSet.getLong("buildNumber"), resultSet.getString("data_")
+			},
+			(values, preparedStatement) -> {
+				String buildNamespace = (String)values[0];
+
+				Bundle bundle = BundleUtil.getBundle(
+					SystemBundleUtil.getBundleContext(), buildNamespace);
+
+				if (bundle == null) {
+					return;
+				}
+
+				Properties properties = PropertiesUtil.load(
+					bundle.getResource("service.properties"));
+
+				String buildNumberServiceProperties = properties.getProperty(
+					"build.number");
+
+				Long buildNumber = (Long)values[1];
+
+				if (!buildNumberServiceProperties.equals(
+						buildNumber.toString())) {
+
+					return;
+				}
+
+				String bundleData = _generateXML(bundle);
+				String data = (String)values[2];
+
+				if (!data.equals(bundleData)) {
+					preparedStatement.setString(1, bundleData);
+					preparedStatement.setString(2, buildNamespace);
+					preparedStatement.setLong(3, buildNumber);
+
+					preparedStatement.addBatch();
+				}
+			},
+			null);
+	}
+
+	private String _generateXML(Bundle bundle) throws IOException {
+		Document document = SAXReaderUtil.createDocument(StringPool.UTF8);
+
+		Element dataElement = document.addElement("data");
+
+		Element tablesSQLElement = dataElement.addElement("tables-sql");
+
+		tablesSQLElement.addCDATA(DBResourceUtil.getModuleTablesSQL(bundle));
+
+		Element sequencesSQLElement = dataElement.addElement("sequences-sql");
+
+		sequencesSQLElement.addCDATA(
+			DBResourceUtil.getModuleSequencesSQL(bundle));
+
+		Element indexesSQLElement = dataElement.addElement("indexes-sql");
+
+		indexesSQLElement.addCDATA(DBResourceUtil.getModuleIndexesSQL(bundle));
+
+		return document.formattedString();
+	}
+
+}


### PR DESCRIPTION
I have created a new upgrade to fix the data_ values in ServiceComponent. As of LPS-68305 we  stop updating the service.properties in old versions, so a customer can have wrong data on it.

To solve it, I am just populating the data_ field with the correct information when it doesn't match with the data from the bundle.