### PR TITLE
LPD-57274 Detect partially upgraded tables

### DIFF
--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseStateTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseStateTest.java
@@ -26,6 +26,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -127,8 +128,8 @@ public class PreupgradeVerifyDatabaseStateTest
 
 			Assert.assertEquals(
 				exception.getMessage(),
-				"Stale tables from a previous upgrade detected: [" +
-					tableNames + "]");
+				"Stale tables from a previous upgrade detected: " +
+					new TreeSet<>(tableNames));
 		}
 		finally {
 			serviceComponent.setData(originalData);

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseStateTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseStateTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.verify.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.db.DBResourceUtil;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.model.ServiceComponent;
@@ -23,6 +24,8 @@ import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import java.util.Set;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -96,9 +99,62 @@ public class PreupgradeVerifyDatabaseStateTest
 		}
 	}
 
+	@Test
+	public void testVerifyPreupgradePartiallyUpgradedTable()
+		throws SQLException {
+
+		ServiceComponent serviceComponent = _getServiceComponent();
+
+		String originalData = serviceComponent.getData();
+
+		try {
+			serviceComponent.setData(RandomTestUtil.randomString());
+
+			serviceComponent =
+				_serviceComponentLocalService.updateServiceComponent(
+					serviceComponent);
+
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			DBInspector dbInspector = new DBInspector(
+				DataAccess.getConnection());
+
+			Set<String> tableNames = DBResourceUtil.parseCreateTableSQL(
+				dbInspector, originalData);
+
+			Assert.assertEquals(
+				exception.getMessage(),
+				"Stale tables from a previous upgrade detected: [" +
+					tableNames + "]");
+		}
+		finally {
+			serviceComponent.setData(originalData);
+
+			_serviceComponentLocalService.updateServiceComponent(
+				serviceComponent);
+		}
+	}
+
 	@Override
 	protected VerifyProcess getVerifyProcess() {
 		return new PreupgradeVerifyDatabaseState();
+	}
+
+	private ServiceComponent _getServiceComponent() {
+		for (ServiceComponent serviceComponent :
+				_serviceComponentLocalService.getLatestServiceComponents()) {
+
+			String buildNamespace = serviceComponent.getBuildNamespace();
+
+			if (buildNamespace.startsWith("com.liferay")) {
+				return serviceComponent;
+			}
+		}
+
+		return null;
 	}
 
 	private static final Version _TEST_SCHEMA_VERSION = new Version(0, 0, 0);

--- a/portal-impl/src/com/liferay/portal/db/DBResourceUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/DBResourceUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -119,15 +120,32 @@ public class DBResourceUtil {
 			Connection connection)
 		throws Exception {
 
+		return _getServiceComponentTableNames(
+			connection, "buildNamespace like 'com.liferay%'");
+	}
+
+	public static Set<String> getServiceComponentPortalTableNames(
+			Connection connection)
+		throws Exception {
+
+		return _getServiceComponentTableNames(
+			connection,
+			"buildNamespace = '" +
+				ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME + "'");
+	}
+
+	private static Set<String> _getServiceComponentTableNames(
+			Connection connection, String sqlCondition)
+		throws Exception {
+
 		Set<String> tableNames = new HashSet<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				StringBundler.concat(
-					"select data_ from ServiceComponent where buildNamespace ",
-					"like 'com.liferay%' and buildNumber = (select ",
-					"max(buildNumber) from ServiceComponent TEMP_TABLE where ",
-					"ServiceComponent.buildNamespace = ",
-					"TEMP_TABLE.buildNamespace)"))) {
+					"select data_ from ServiceComponent where buildNumber = ",
+					"(select max(buildNumber) from ServiceComponent ",
+					"TEMP_TABLE where ServiceComponent.buildNamespace = ",
+					"TEMP_TABLE.buildNamespace) and ", sqlCondition))) {
 
 			DBInspector dbInspector = new DBInspector(connection);
 

--- a/portal-impl/src/com/liferay/portal/db/DBResourceUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/DBResourceUtil.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -68,11 +69,7 @@ public class DBResourceUtil {
 				continue;
 			}
 
-			Matcher matcher = _createTablePattern.matcher(tableSQL);
-
-			while (matcher.find()) {
-				tableNames.add(dbInspector.normalizeName(matcher.group(1)));
-			}
+			tableNames.addAll(parseCreateTableSQL(dbInspector, tableSQL));
 		}
 
 		return tableNames;
@@ -95,19 +92,12 @@ public class DBResourceUtil {
 			return _portalTableNames;
 		}
 
-		Set<String> tableNames = new HashSet<>();
+		DBInspector dbInspector = new DBInspector(connection);
 
-		Matcher matcher = _createTablePattern.matcher(getPortalTablesSQL());
+		_portalTableNames = parseCreateTableSQL(
+			dbInspector, getPortalTablesSQL());
 
-		while (matcher.find()) {
-			DBInspector dbInspector = new DBInspector(connection);
-
-			tableNames.add(dbInspector.normalizeName(matcher.group(1)));
-		}
-
-		_portalTableNames = tableNames;
-
-		return tableNames;
+		return _portalTableNames;
 	}
 
 	public static String getPortalTablesSQL() {
@@ -134,6 +124,21 @@ public class DBResourceUtil {
 				ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME + "'");
 	}
 
+	public static Set<String> parseCreateTableSQL(
+			DBInspector dbInspector, String createTableSQL)
+		throws SQLException {
+
+		Set<String> tableNames = new HashSet<>();
+
+		Matcher matcher = _createTablePattern.matcher(createTableSQL);
+
+		while (matcher.find()) {
+			tableNames.add(dbInspector.normalizeName(matcher.group(1)));
+		}
+
+		return tableNames;
+	}
+
 	private static Set<String> _getServiceComponentTableNames(
 			Connection connection, String sqlCondition)
 		throws Exception {
@@ -151,13 +156,9 @@ public class DBResourceUtil {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
-					Matcher matcher = _createTablePattern.matcher(
-						resultSet.getString(1));
-
-					while (matcher.find()) {
-						tableNames.add(
-							dbInspector.normalizeName(matcher.group(1)));
-					}
+					tableNames.addAll(
+						parseCreateTableSQL(
+							dbInspector, resultSet.getString(1)));
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/events/StartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/StartupAction.java
@@ -122,6 +122,8 @@ public class StartupAction extends SimpleAction {
 		StartupHelperUtil.initResourceActions();
 
 		if (StartupHelperUtil.isDBNew()) {
+			DBUpgrader.updatePortalServiceComponent();
+
 			DLFileEntryTypeLocalServiceUtil.getBasicDocumentDLFileEntryType();
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/service/impl/ServiceComponentLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ServiceComponentLocalServiceImpl.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
+import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.model.ServiceComponent;
 import com.liferay.portal.kernel.service.configuration.ServiceComponentConfiguration;
 import com.liferay.portal.kernel.service.configuration.servlet.ServletServiceContextComponentConfiguration;
@@ -141,7 +142,10 @@ public class ServiceComponentLocalServiceImpl
 						" has build number ", previousBuildNumber,
 						" which is newer than ", buildNumber));
 			}
-			else {
+			else if (!StringUtil.equals(
+						buildNamespace,
+						ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME)) {
+
 				return serviceComponent;
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -30,6 +31,8 @@ import com.liferay.portal.kernel.module.util.ServiceLatch;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceComponentLocalServiceUtil;
+import com.liferay.portal.kernel.service.configuration.ServiceComponentConfiguration;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -50,7 +53,10 @@ import com.liferay.portal.verify.VerifyException;
 import com.liferay.portal.verify.VerifyProcessSuite;
 import com.liferay.util.dao.orm.CustomSQLUtil;
 
+import java.io.InputStream;
+
 import java.sql.Connection;
+import java.sql.SQLException;
 
 import java.util.Collection;
 
@@ -226,6 +232,67 @@ public class DBUpgrader {
 		}
 	}
 
+	public static void updatePortalServiceComponent()
+		throws PortalException, SQLException {
+
+		ServiceComponentConfiguration portalServiceComponentConfiguration =
+			new ServiceComponentConfiguration() {
+
+				@Override
+				public InputStream getHibernateInputStream() {
+					return null;
+				}
+
+				@Override
+				public InputStream getModelHintsExtInputStream() {
+					return null;
+				}
+
+				@Override
+				public InputStream getModelHintsInputStream() {
+					return null;
+				}
+
+				@Override
+				public String getServletContextName() {
+					return ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME;
+				}
+
+				@Override
+				public InputStream getSQLIndexesInputStream() {
+					return _classLoader.getResourceAsStream(
+						"com/liferay/portal/tools/sql/dependencies" +
+							"/indexes.sql");
+				}
+
+				@Override
+				public InputStream getSQLSequencesInputStream() {
+					return _classLoader.getResourceAsStream(
+						"com/liferay/portal/tools/sql/dependencies" +
+							"/sequences.sql");
+				}
+
+				@Override
+				public InputStream getSQLTablesInputStream() {
+					return _classLoader.getResourceAsStream(
+						"com/liferay/portal/tools/sql/dependencies" +
+							"/portal-tables.sql");
+				}
+
+				private final ClassLoader _classLoader =
+					ServiceComponentConfiguration.class.getClassLoader();
+
+			};
+
+		ServiceComponentLocalServiceUtil.initServiceComponent(
+			portalServiceComponentConfiguration,
+			DBUpgrader.class.getClassLoader(),
+			ReleaseConstants.DEFAULT_SERVLET_CONTEXT_NAME,
+			ReleaseInfo.getBuildNumber(),
+			ReleaseInfo.getBuildDate(
+			).getTime());
+	}
+
 	public static void upgradeModules(Runnable upgradeModulesCallbackRunnable) {
 		_registerModuleServiceLifecycle(
 			moduleServiceLifecyclePortalInitialized);
@@ -336,6 +403,10 @@ public class DBUpgrader {
 			IndexUpdaterUtil.updatePortalIndexes();
 
 			try (Connection connection = DataAccess.getConnection()) {
+				if (PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
+					updatePortalServiceComponent();
+				}
+
 				PortalUpgradeProcess.updateBuildInfo(connection);
 			}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
@@ -42,8 +42,10 @@ public class PreupgradeVerifyDatabaseCharacterSet
 		Set<String> tableNames =
 			DBResourceUtil.getServiceComponentModuleTableNames(connection);
 
-		tableNames.addAll(DBResourceUtil.getPortalTableNames(connection));
+		tableNames.addAll(
+			DBResourceUtil.getServiceComponentPortalTableNames(connection));
 		tableNames.addAll(DBResourceUtil.getModuleTableNames(connection));
+		tableNames.addAll(DBResourceUtil.getPortalTableNames(connection));
 
 		String sql = StringBundler.concat(
 			"select distinct character_set_name, collation_name, table_name, ",

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -71,9 +71,8 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 
 		if (!previousUpgradeStaleTables.isEmpty()) {
 			throw new Exception(
-				"Stale tables from a previous upgrade detected:\n" +
-					previousUpgradeStaleTables +
-						"\nPlease remove these tables to continue the upgrade");
+				"Stale tables from a previous upgrade detected: " +
+					previousUpgradeStaleTables);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -26,10 +26,15 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 			return;
 		}
 
-		Set<String> serviceComponentModuleTableNames =
+		Set<String> serviceComponentPortalTableNames =
+			DBResourceUtil.getServiceComponentPortalTableNames(connection);
+
+		Set<String> serviceComponentTableNames =
 			DBResourceUtil.getServiceComponentModuleTableNames(connection);
 
-		if (serviceComponentModuleTableNames.isEmpty()) {
+		serviceComponentTableNames.addAll(serviceComponentPortalTableNames);
+
+		if (serviceComponentTableNames.isEmpty()) {
 			return;
 		}
 
@@ -38,9 +43,9 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 		Set<String> databaseTables = new HashSet<>(
 			dbInspector.getTableNames(null));
 
-		if (!databaseTables.containsAll(serviceComponentModuleTableNames)) {
+		if (!databaseTables.containsAll(serviceComponentTableNames)) {
 			Set<String> missingTables = new HashSet<>(
-				serviceComponentModuleTableNames);
+				serviceComponentTableNames);
 
 			missingTables.removeAll(databaseTables);
 
@@ -48,10 +53,17 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 				"Missing tables detected: " + missingTables);
 		}
 
+		if (serviceComponentPortalTableNames.isEmpty()) {
+			return;
+		}
+
 		Set<String> targetVersionNewTables = DBResourceUtil.getModuleTableNames(
 			connection);
 
-		targetVersionNewTables.removeAll(serviceComponentModuleTableNames);
+		targetVersionNewTables.addAll(
+			DBResourceUtil.getPortalTableNames(connection));
+
+		targetVersionNewTables.removeAll(serviceComponentTableNames);
 
 		Set<String> previousUpgradeStaleTables = new HashSet<>(databaseTables);
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -48,14 +48,14 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 				"Missing tables detected: " + missingTables);
 		}
 
-		Set<String> targetVersionTables = DBResourceUtil.getTargetVersionTables(
+		Set<String> targetVersionNewTables = DBResourceUtil.getModuleTableNames(
 			connection);
 
-		targetVersionTables.removeAll(preupgradedServiceTables);
+		targetVersionNewTables.removeAll(serviceComponentModuleTableNames);
 
 		Set<String> previousUpgradeStaleTables = new HashSet<>(databaseTables);
 
-		previousUpgradeStaleTables.retainAll(targetVersionTables);
+		previousUpgradeStaleTables.retainAll(targetVersionNewTables);
 
 		if (!previousUpgradeStaleTables.isEmpty()) {
 			throw new Exception(

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -8,6 +8,7 @@ package com.liferay.portal.verify;
 import com.liferay.portal.db.DBResourceUtil;
 import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 
 import java.util.HashSet;
@@ -22,7 +23,9 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 	@Override
 	protected void doVerify() throws Exception {
 		if (StartupHelperUtil.isDBNew() ||
-			PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
+			PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
+			(PortalUpgradeProcess.getCurrentState(connection) !=
+				ReleaseConstants.STATE_GOOD)) {
 
 			return;
 		}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -12,6 +12,7 @@ import com.liferay.portal.upgrade.PortalUpgradeProcess;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * @author Jorge Avalos
@@ -50,7 +51,7 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 			missingTables.removeAll(databaseTables);
 
 			throw new VerifyException(
-				"Missing tables detected: " + missingTables);
+				"Missing tables detected: " + new TreeSet<>(missingTables));
 		}
 
 		if (serviceComponentPortalTableNames.isEmpty()) {
@@ -70,9 +71,9 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 		previousUpgradeStaleTables.retainAll(targetVersionNewTables);
 
 		if (!previousUpgradeStaleTables.isEmpty()) {
-			throw new Exception(
+			throw new VerifyException(
 				"Stale tables from a previous upgrade detected: " +
-					previousUpgradeStaleTables);
+					new TreeSet<>(previousUpgradeStaleTables));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -47,6 +47,22 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 			throw new VerifyException(
 				"Missing tables detected: " + missingTables);
 		}
+
+		Set<String> targetVersionTables = DBResourceUtil.getTargetVersionTables(
+			connection);
+
+		targetVersionTables.removeAll(preupgradedServiceTables);
+
+		Set<String> previousUpgradeStaleTables = new HashSet<>(databaseTables);
+
+		previousUpgradeStaleTables.retainAll(targetVersionTables);
+
+		if (!previousUpgradeStaleTables.isEmpty()) {
+			throw new Exception(
+				"Stale tables from a previous upgrade detected:\n" +
+					previousUpgradeStaleTables +
+						"\nPlease remove these tables to continue the upgrade");
+		}
 	}
 
 }


### PR DESCRIPTION
(same PR than https://github.com/liferay-database-infra/liferay-portal/pull/2837 but solves some SF problems due to last hour changes)

This PR modified the PreupgradeVerifyDatabaseCharacterSet checks to also verify partially upgraded tables from previous upgrade attempts (that weren't deleted when restoring the database)

To get these tables, we are getting the tables from the new Liferay version (from the sql files of Liferay source) and we compare them with the tables from the previous Liferay version from ServiceComponent. The tables that are not present in ServiceComponent, are the ones created during the upgrade, so they shouldn't exist.

In order to be able to check also the tables from the portal core, we are adding/updating a new 'portal' record to the ServiceComponent table.
In https://github.com/brianchandotcom/liferay-portal/pull/162528 we have also fixed a problem that caused ServiceComponent to not being updated, so to avoid problems if the upgrade starts in a old version, we are only to validate this if the portal record is present, this confirm us everything was fixed and we can execute the validations without the risk of false positives.