### PR TITLE
LPD-56224 Fix unit test errors in PreupgradeVerifyProcessSuiteTest

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
@@ -34,7 +34,13 @@ public class PreupgradeVerifyProcessSuiteTest {
 			MockedConstruction<PreupgradeVerifyDatabaseCharacterSet>
 				mockedConstruction2 = _mockConstruction(
 					PreupgradeVerifyDatabaseCharacterSet.class);
-			MockedConstruction<PreupgradeVerifyProperties> mockedConstruction3 =
+			MockedConstruction<PreupgradeVerifyDatabasePrivileges>
+				mockedConstruction3 = _mockConstruction(
+					PreupgradeVerifyDatabasePrivileges.class);
+			MockedConstruction<PreupgradeVerifyDatabaseState>
+				mockedConstruction4 = _mockConstruction(
+					PreupgradeVerifyDatabaseState.class);
+			MockedConstruction<PreupgradeVerifyProperties> mockedConstruction5 =
 				_mockConstruction(PreupgradeVerifyProperties.class)) {
 
 			VerifyProcess verifyProcess = new PreupgradeVerifyProcessSuite();
@@ -48,6 +54,8 @@ public class PreupgradeVerifyProcessSuiteTest {
 				StringBundler.concat(
 					"Exception in PreupgradeVerifyCompanyUsers\n",
 					"Exception in PreupgradeVerifyDatabaseCharacterSet\n",
+					"Exception in PreupgradeVerifyDatabasePrivileges\n",
+					"Exception in PreupgradeVerifyDatabaseState\n",
 					"Exception in PreupgradeVerifyProperties"),
 				verifyException.getMessage());
 		}


### PR DESCRIPTION
This fixes the unit tests problem detected here https://liferay.slack.com/archives/G01PX1Z5H63/p1750245600523309?thread_ts=1750146406.604219&cid=G01PX1Z5H63

The problem is we have to add every new PreupgradeVerify class to this unit test.

@marianoalvarosaiz do you know if we can simplify this to avoid having to add future new PreupgradeVerify here?

Thank you
