### PR TITLE
LPD-53153

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -165,13 +165,9 @@ public class UpgradeRecorder {
 				_log.info("No pending upgrades to run");
 			}
 			else {
-				if (_errorMessages.containsKey(
-					PreupgradeVerifyProcessSuite.class.getName())) {
-					_log.info(
-						"A preupgrade verification process has failed. " +
-						"Please fix the reported issues and re-run the upgrade.");
-				}
-				else{
+				if (!_errorMessages.containsKey(
+						PreupgradeVerifyProcessSuite.class.getName())) {
+
 					_log.info(
 						StringBundler.concat(
 							StringUtil.upperCaseFirstLetter(_type),
@@ -179,11 +175,10 @@ public class UpgradeRecorder {
 
 					if (!_result.equals("failure") &&
 						!_errorMessages.isEmpty()) {
+
 						_log.info("Unrelated errors occur during the upgrade");
 					}
 				}
-
-
 			}
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.PreupgradeVerifyProcessSuite;
 import com.liferay.portal.verify.VerifyException;
 
 import java.sql.Connection;
@@ -164,14 +165,25 @@ public class UpgradeRecorder {
 				_log.info("No pending upgrades to run");
 			}
 			else {
-				_log.info(
-					StringBundler.concat(
-						StringUtil.upperCaseFirstLetter(_type),
-						" upgrade finished with result ", _result));
-
-				if (!_result.equals("failure") && !_errorMessages.isEmpty()) {
-					_log.info("Unrelated errors occur during the upgrade");
+				if (_errorMessages.containsKey(
+					PreupgradeVerifyProcessSuite.class.getName())) {
+					_log.info(
+						"A preupgrade verification process has failed. " +
+						"Please fix the reported issues and re-run the upgrade.");
 				}
+				else{
+					_log.info(
+						StringBundler.concat(
+							StringUtil.upperCaseFirstLetter(_type),
+							" upgrade finished with result ", _result));
+
+					if (!_result.equals("failure") &&
+						!_errorMessages.isEmpty()) {
+						_log.info("Unrelated errors occur during the upgrade");
+					}
+				}
+
+
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -331,12 +331,7 @@ public class DBUpgrader {
 			catch (VerifyException verifyException) {
 				StartupHelperUtil.setUpgrading(false);
 
-				_log.error(
-					StringBundler.concat(
-						"A preupgrade verification process has failed. No ",
-						"changes have been made.  Please fix the reported ",
-						"issues and re-run the upgrade: ",
-						verifyException.getMessage()));
+				_log.error(verifyException);
 
 				System.exit(1);
 			}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -331,6 +331,13 @@ public class DBUpgrader {
 			catch (VerifyException verifyException) {
 				StartupHelperUtil.setUpgrading(false);
 
+				_log.error(
+					StringBundler.concat(
+						"A preupgrade verification process has failed. No ",
+						"changes have been made.  Please fix the reported ",
+						"issues and re-run the upgrade: ",
+						verifyException.getMessage()));
+
 				System.exit(1);
 			}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -331,7 +331,7 @@ public class DBUpgrader {
 			catch (VerifyException verifyException) {
 				StartupHelperUtil.setUpgrading(false);
 
-				_log.error(verifyException);
+				_log.error(verifyException.getMessage());
 
 				System.exit(1);
 			}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -329,10 +329,6 @@ public class DBUpgrader {
 				preupgradeVerifyProcessSuite.verify();
 			}
 			catch (VerifyException verifyException) {
-				_log.error(
-					"Stopping the server because the preupgrade verification " +
-						"process failed: " + verifyException.getMessage());
-
 				StartupHelperUtil.setUpgrading(false);
 
 				System.exit(1);

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -329,9 +329,9 @@ public class DBUpgrader {
 				preupgradeVerifyProcessSuite.verify();
 			}
 			catch (VerifyException verifyException) {
-				StartupHelperUtil.setUpgrading(false);
+				_log.error(verifyException);
 
-				_log.error(verifyException.getMessage());
+				StartupHelperUtil.setUpgrading(false);
 
 				System.exit(1);
 			}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -44,9 +44,7 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 			verify(verifyProcess);
 		}
 		catch (VerifyException verifyException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(verifyException);
-			}
+			_log.error(verifyException);
 
 			_exceptionMessages.add(verifyException.getMessage());
 		}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.verify;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -29,8 +30,12 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {
 			throw new VerifyException(
-				StringUtil.merge(
-					_exceptionMessages, StringPool.COMMA_AND_SPACE));
+				StringBundler.concat(
+					"A preupgrade verification process has failed. No changes ",
+					"have been made.  Please fix the reported issues and re-",
+					"run the upgrade: ",
+					StringUtil.merge(
+						_exceptionMessages, StringPool.COMMA_AND_SPACE)));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -32,7 +32,7 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 			throw new VerifyException(
 				StringBundler.concat(
 					"A preupgrade verification process has failed. No changes ",
-					"have been made.  Please fix the reported issues and re-",
+					"have been made. Please fix the reported issues and re-",
 					"run the upgrade: ",
 					StringUtil.merge(
 						_exceptionMessages, StringPool.COMMA_AND_SPACE)));

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -29,7 +29,8 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {
 			throw new VerifyException(
-				StringUtil.merge(_exceptionMessages, StringPool.NEW_LINE));
+				StringUtil.merge(
+					_exceptionMessages, StringPool.COMMA_AND_SPACE));
 		}
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
@@ -52,11 +52,11 @@ public class PreupgradeVerifyProcessSuiteTest {
 		catch (VerifyException verifyException) {
 			Assert.assertEquals(
 				StringBundler.concat(
-					"Exception in PreupgradeVerifyCompanyUsers\n",
-					"Exception in PreupgradeVerifyDatabaseCharacterSet\n",
-					"Exception in PreupgradeVerifyDatabasePrivileges\n",
-					"Exception in PreupgradeVerifyDatabaseState\n",
-					"Exception in PreupgradeVerifyProperties"),
+					"Exception in PreupgradeVerifyCompanyUsers, Exception in ",
+					"PreupgradeVerifyDatabaseCharacterSet, Exception in ",
+					"PreupgradeVerifyDatabasePrivileges, Exception in ",
+					"PreupgradeVerifyDatabaseState, Exception in ",
+					"PreupgradeVerifyProperties"),
 				verifyException.getMessage());
 		}
 	}

--- a/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
@@ -34,7 +34,13 @@ public class PreupgradeVerifyProcessSuiteTest {
 			MockedConstruction<PreupgradeVerifyDatabaseCharacterSet>
 				mockedConstruction2 = _mockConstruction(
 					PreupgradeVerifyDatabaseCharacterSet.class);
-			MockedConstruction<PreupgradeVerifyProperties> mockedConstruction3 =
+			MockedConstruction<PreupgradeVerifyDatabasePrivileges>
+				mockedConstruction3 = _mockConstruction(
+					PreupgradeVerifyDatabasePrivileges.class);
+			MockedConstruction<PreupgradeVerifyDatabaseState>
+				mockedConstruction4 = _mockConstruction(
+					PreupgradeVerifyDatabaseState.class);
+			MockedConstruction<PreupgradeVerifyProperties> mockedConstruction5 =
 				_mockConstruction(PreupgradeVerifyProperties.class)) {
 
 			VerifyProcess verifyProcess = new PreupgradeVerifyProcessSuite();
@@ -48,6 +54,8 @@ public class PreupgradeVerifyProcessSuiteTest {
 				StringBundler.concat(
 					"Exception in PreupgradeVerifyCompanyUsers\n",
 					"Exception in PreupgradeVerifyDatabaseCharacterSet\n",
+					"Exception in PreupgradeVerifyDatabasePrivileges\n",
+					"Exception in PreupgradeVerifyDatabaseState\n",
 					"Exception in PreupgradeVerifyProperties"),
 				verifyException.getMessage());
 		}

--- a/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
@@ -51,10 +51,11 @@ public class PreupgradeVerifyProcessSuiteTest {
 		}
 		catch (VerifyException verifyException) {
 			Assert.assertEquals(
-				StringBundler.concat("A preupgrade verification process has failed. No changes ",
-					"have been made.  Please fix the reported issues and re-",
-					"run the upgrade: ",
-					"Exception in PreupgradeVerifyCompanyUsers, Exception in ",
+				StringBundler.concat(
+					"A preupgrade verification process has failed. No changes ",
+					"have been made. Please fix the reported issues and re-",
+					"run the upgrade: Exception in ",
+					"PreupgradeVerifyCompanyUsers, Exception in ",
 					"PreupgradeVerifyDatabaseCharacterSet, Exception in ",
 					"PreupgradeVerifyDatabasePrivileges, Exception in ",
 					"PreupgradeVerifyDatabaseState, Exception in ",

--- a/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
@@ -51,7 +51,9 @@ public class PreupgradeVerifyProcessSuiteTest {
 		}
 		catch (VerifyException verifyException) {
 			Assert.assertEquals(
-				StringBundler.concat(
+				StringBundler.concat("A preupgrade verification process has failed. No changes ",
+					"have been made.  Please fix the reported issues and re-",
+					"run the upgrade: ",
 					"Exception in PreupgradeVerifyCompanyUsers, Exception in ",
 					"PreupgradeVerifyDatabaseCharacterSet, Exception in ",
 					"PreupgradeVerifyDatabasePrivileges, Exception in ",


### PR DESCRIPTION
@jorgediaz-lr 

Because of the system.exit,  we can't test DBUpgrader explicitly.  I moved the "No Changes Made" Message into the suite.  It also ensures that the last message in the terminal output is the preupgrade failure.  