### PR TITLE
LPD-53153 Add new Upgrade Report output for upgrade validation failure

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -45,6 +45,11 @@ import org.osgi.util.tracker.ServiceTracker;
 @Component(service = UpgradeRecorder.class)
 public class UpgradeRecorder {
 
+	public static boolean isPreupgradeVerifyFailure() {
+		return _errorMessages.containsKey(
+			PreupgradeVerifyProcessSuite.class.getName());
+	}
+
 	public Map<String, Map<String, Integer>> getDataCleanUpMessages() {
 		return _dataCleanUpMessages;
 	}
@@ -164,9 +169,7 @@ public class UpgradeRecorder {
 			if (_type.equals("no upgrade") && _result.equals("success")) {
 				_log.info("No pending upgrades to run");
 			}
-			else if (!_errorMessages.containsKey(
-						PreupgradeVerifyProcessSuite.class.getName())) {
-
+			else if (!isPreupgradeVerifyFailure()) {
 				_log.info(
 					StringBundler.concat(
 						StringUtil.upperCaseFirstLetter(_type),
@@ -198,6 +201,10 @@ public class UpgradeRecorder {
 
 	private String _calculateResult() {
 		if (_verifyProcessError) {
+			if (isPreupgradeVerifyFailure()) {
+				return "preupgrade validation failure";
+			}
+
 			return "failure";
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -165,13 +165,9 @@ public class UpgradeRecorder {
 				_log.info("No pending upgrades to run");
 			}
 			else {
-				if (_errorMessages.containsKey(
-					PreupgradeVerifyProcessSuite.class.getName())) {
-					_log.info(
-						"A preupgrade verification process has failed. " +
-						"Please fix the reported issues and re-run the upgrade.");
-				}
-				else{
+				if (!_errorMessages.containsKey(
+						PreupgradeVerifyProcessSuite.class.getName())) {
+
 					_log.info(
 						StringBundler.concat(
 							StringUtil.upperCaseFirstLetter(_type),
@@ -179,11 +175,10 @@ public class UpgradeRecorder {
 
 					if (!_result.equals("failure") &&
 						!_errorMessages.isEmpty()) {
+
 						_log.info("Unrelated errors occur during the upgrade");
 					}
 				}
-
-
 			}
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -164,20 +164,16 @@ public class UpgradeRecorder {
 			if (_type.equals("no upgrade") && _result.equals("success")) {
 				_log.info("No pending upgrades to run");
 			}
-			else {
-				if (!_errorMessages.containsKey(
+			else if (!_errorMessages.containsKey(
 						PreupgradeVerifyProcessSuite.class.getName())) {
 
-					_log.info(
-						StringBundler.concat(
-							StringUtil.upperCaseFirstLetter(_type),
-							" upgrade finished with result ", _result));
+				_log.info(
+					StringBundler.concat(
+						StringUtil.upperCaseFirstLetter(_type),
+						" upgrade finished with result ", _result));
 
-					if (!_result.equals("failure") &&
-						!_errorMessages.isEmpty()) {
-
-						_log.info("Unrelated errors occur during the upgrade");
-					}
+				if (!_result.equals("failure") && !_errorMessages.isEmpty()) {
+					_log.info("Unrelated errors occur during the upgrade");
 				}
 			}
 		}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.PreupgradeVerifyProcessSuite;
 import com.liferay.portal.verify.VerifyException;
 
 import java.sql.Connection;
@@ -164,14 +165,25 @@ public class UpgradeRecorder {
 				_log.info("No pending upgrades to run");
 			}
 			else {
-				_log.info(
-					StringBundler.concat(
-						StringUtil.upperCaseFirstLetter(_type),
-						" upgrade finished with result ", _result));
-
-				if (!_result.equals("failure") && !_errorMessages.isEmpty()) {
-					_log.info("Unrelated errors occur during the upgrade");
+				if (_errorMessages.containsKey(
+					PreupgradeVerifyProcessSuite.class.getName())) {
+					_log.info(
+						"A preupgrade verification process has failed. " +
+						"Please fix the reported issues and re-run the upgrade.");
 				}
+				else{
+					_log.info(
+						StringBundler.concat(
+							StringUtil.upperCaseFirstLetter(_type),
+							" upgrade finished with result ", _result));
+
+					if (!_result.equals("failure") &&
+						!_errorMessages.isEmpty()) {
+						_log.info("Unrelated errors occur during the upgrade");
+					}
+				}
+
+
 			}
 		}
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -225,6 +225,10 @@ public class UpgradeReport {
 				ReleaseManager releaseManager = _releaseManagerSnapshot.get();
 
 				if (releaseManager == null) {
+					if (upgradeRecorder.isPreupgradeVerifyFailure()) {
+						return "No changes have been made to the system";
+					}
+
 					return "Upgrade failed to complete";
 				}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -333,8 +333,9 @@ public class DBUpgrader {
 					StringBundler.concat(
 						"Stopping the server because a preupgrade ",
 						"verification process has failed. No changes have ",
-						"been made. Please fix the reported issues and re-run ",
-						"the upgrade: ", verifyException.getMessage()));
+						"been made to the system. Please fix the reported ",
+						"issues and re-run the upgrade: ",
+						verifyException.getMessage()));
 
 				StartupHelperUtil.setUpgrading(false);
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -331,12 +331,7 @@ public class DBUpgrader {
 			catch (VerifyException verifyException) {
 				StartupHelperUtil.setUpgrading(false);
 
-				_log.error(
-					StringBundler.concat(
-						"A preupgrade verification process has failed. No ",
-						"changes have been made.  Please fix the reported ",
-						"issues and re-run the upgrade: ",
-						verifyException.getMessage()));
+				_log.error(verifyException);
 
 				System.exit(1);
 			}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -331,6 +331,13 @@ public class DBUpgrader {
 			catch (VerifyException verifyException) {
 				StartupHelperUtil.setUpgrading(false);
 
+				_log.error(
+					StringBundler.concat(
+						"A preupgrade verification process has failed. No ",
+						"changes have been made.  Please fix the reported ",
+						"issues and re-run the upgrade: ",
+						verifyException.getMessage()));
+
 				System.exit(1);
 			}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -331,10 +331,10 @@ public class DBUpgrader {
 			catch (VerifyException verifyException) {
 				_log.error(
 					StringBundler.concat(
-						"A preupgrade verification process has failed. No ",
-						"changes have been made. Please fix the reported ",
-						"issues and re-run the upgrade: ",
-						verifyException.getMessage()));
+						"Stopping the server because a preupgrade ",
+						"verification process has failed. No changes have ",
+						"been made. Please fix the reported issues and re-run ",
+						"the upgrade: ", verifyException.getMessage()));
 
 				StartupHelperUtil.setUpgrading(false);
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -331,7 +331,7 @@ public class DBUpgrader {
 			catch (VerifyException verifyException) {
 				StartupHelperUtil.setUpgrading(false);
 
-				_log.error(verifyException);
+				_log.error(verifyException.getMessage());
 
 				System.exit(1);
 			}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -329,10 +329,6 @@ public class DBUpgrader {
 				preupgradeVerifyProcessSuite.verify();
 			}
 			catch (VerifyException verifyException) {
-				_log.error(
-					"Stopping the server because the preupgrade verification " +
-						"process failed: " + verifyException.getMessage());
-
 				StartupHelperUtil.setUpgrading(false);
 
 				System.exit(1);

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -329,9 +329,9 @@ public class DBUpgrader {
 				preupgradeVerifyProcessSuite.verify();
 			}
 			catch (VerifyException verifyException) {
-				StartupHelperUtil.setUpgrading(false);
+				_log.error(verifyException);
 
-				_log.error(verifyException.getMessage());
+				StartupHelperUtil.setUpgrading(false);
 
 				System.exit(1);
 			}

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -329,7 +329,12 @@ public class DBUpgrader {
 				preupgradeVerifyProcessSuite.verify();
 			}
 			catch (VerifyException verifyException) {
-				_log.error(verifyException);
+				_log.error(
+					StringBundler.concat(
+						"A preupgrade verification process has failed. No ",
+						"changes have been made. Please fix the reported ",
+						"issues and re-run the upgrade: ",
+						verifyException.getMessage()));
 
 				StartupHelperUtil.setUpgrading(false);
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -44,9 +44,7 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 			verify(verifyProcess);
 		}
 		catch (VerifyException verifyException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(verifyException);
-			}
+			_log.error(verifyException);
 
 			_exceptionMessages.add(verifyException.getMessage());
 		}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.verify;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -29,8 +30,12 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {
 			throw new VerifyException(
-				StringUtil.merge(
-					_exceptionMessages, StringPool.COMMA_AND_SPACE));
+				StringBundler.concat(
+					"A preupgrade verification process has failed. No changes ",
+					"have been made.  Please fix the reported issues and re-",
+					"run the upgrade: ",
+					StringUtil.merge(
+						_exceptionMessages, StringPool.COMMA_AND_SPACE)));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.verify;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -30,12 +29,8 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {
 			throw new VerifyException(
-				StringBundler.concat(
-					"A preupgrade verification process has failed. No changes ",
-					"have been made. Please fix the reported issues and re-",
-					"run the upgrade: ",
-					StringUtil.merge(
-						_exceptionMessages, StringPool.COMMA_AND_SPACE)));
+				StringUtil.merge(
+					_exceptionMessages, StringPool.COMMA_AND_SPACE));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -32,7 +32,7 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 			throw new VerifyException(
 				StringBundler.concat(
 					"A preupgrade verification process has failed. No changes ",
-					"have been made.  Please fix the reported issues and re-",
+					"have been made. Please fix the reported issues and re-",
 					"run the upgrade: ",
 					StringUtil.merge(
 						_exceptionMessages, StringPool.COMMA_AND_SPACE)));

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -29,7 +29,8 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {
 			throw new VerifyException(
-				StringUtil.merge(_exceptionMessages, StringPool.NEW_LINE));
+				StringUtil.merge(
+					_exceptionMessages, StringPool.COMMA_AND_SPACE));
 		}
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
@@ -52,11 +52,11 @@ public class PreupgradeVerifyProcessSuiteTest {
 		catch (VerifyException verifyException) {
 			Assert.assertEquals(
 				StringBundler.concat(
-					"Exception in PreupgradeVerifyCompanyUsers\n",
-					"Exception in PreupgradeVerifyDatabaseCharacterSet\n",
-					"Exception in PreupgradeVerifyDatabasePrivileges\n",
-					"Exception in PreupgradeVerifyDatabaseState\n",
-					"Exception in PreupgradeVerifyProperties"),
+					"Exception in PreupgradeVerifyCompanyUsers, Exception in ",
+					"PreupgradeVerifyDatabaseCharacterSet, Exception in ",
+					"PreupgradeVerifyDatabasePrivileges, Exception in ",
+					"PreupgradeVerifyDatabaseState, Exception in ",
+					"PreupgradeVerifyProperties"),
 				verifyException.getMessage());
 		}
 	}

--- a/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/verify/PreupgradeVerifyProcessSuiteTest.java
@@ -34,7 +34,13 @@ public class PreupgradeVerifyProcessSuiteTest {
 			MockedConstruction<PreupgradeVerifyDatabaseCharacterSet>
 				mockedConstruction2 = _mockConstruction(
 					PreupgradeVerifyDatabaseCharacterSet.class);
-			MockedConstruction<PreupgradeVerifyProperties> mockedConstruction3 =
+			MockedConstruction<PreupgradeVerifyDatabasePrivileges>
+				mockedConstruction3 = _mockConstruction(
+					PreupgradeVerifyDatabasePrivileges.class);
+			MockedConstruction<PreupgradeVerifyDatabaseState>
+				mockedConstruction4 = _mockConstruction(
+					PreupgradeVerifyDatabaseState.class);
+			MockedConstruction<PreupgradeVerifyProperties> mockedConstruction5 =
 				_mockConstruction(PreupgradeVerifyProperties.class)) {
 
 			VerifyProcess verifyProcess = new PreupgradeVerifyProcessSuite();
@@ -48,6 +54,8 @@ public class PreupgradeVerifyProcessSuiteTest {
 				StringBundler.concat(
 					"Exception in PreupgradeVerifyCompanyUsers\n",
 					"Exception in PreupgradeVerifyDatabaseCharacterSet\n",
+					"Exception in PreupgradeVerifyDatabasePrivileges\n",
+					"Exception in PreupgradeVerifyDatabaseState\n",
 					"Exception in PreupgradeVerifyProperties"),
 				verifyException.getMessage());
 		}


### PR DESCRIPTION
Hi @javalosjr96 

Your original PR is ok, but after testing it with a DB with errors, I have added some changes to it:

- d7359943499b53e9513779ee36d86cefbbfd9e83 move the message to the DBUpgrade class
- 150c8ed6853fe699504efa335849e3dfc108f960 and 5b8243d62f4f1189d30ab79023dedf97b56dc82b add some changes to the text that I think we should maintain
- 80d4699eed13a999e1e563c7295c22fcfc41c2d6 add the preupgrade information to the `upgrade_report.txt` file:

```
$ cat /home/jorge/bundles_builds/portal-master/reports/upgrade_report.txt
Execution date: Thu, Jun 19, 2025 11:05:59 UTC

Execution time: 0 seconds

Result: preupgrade validation failure

Status: No changes have been made to the system

Type: major
```