### PR TITLE
LPD-53149 Check basic and advanced file system store 

### DIFF
--- a/modules/apps/portal/portal-verify-test/build.gradle
+++ b/modules/apps/portal/portal-verify-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-verify-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyFileSystemStoreStructureTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyFileSystemStoreStructureTest.java
@@ -1,0 +1,410 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.PreupgradeVerifyFileSystemStoreStructure;
+import com.liferay.portal.verify.VerifyProcess;
+import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author István András Dézsi
+ */
+@RunWith(Arquillian.class)
+public class PreupgradeVerifyFileSystemStoreStructureTest
+	extends BaseVerifyProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_companyId = TestPropsValues.getCompanyId();
+
+		_repositoryId = RandomTestUtil.nextLong();
+
+		_advancedFileSystemStoreRootDir =
+			_props.get(PropsKeys.LIFERAY_HOME) +
+				"/test/store/advanced_file_system";
+
+		_advancedFileSystemStoreConfiguration =
+			_configurationAdmin.getConfiguration(
+				"com.liferay.portal.store.file.system.configuration." +
+					"AdvancedFileSystemStoreConfiguration",
+				StringPool.QUESTION);
+
+		ConfigurationTestUtil.saveConfiguration(
+			_advancedFileSystemStoreConfiguration,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"rootDir", _advancedFileSystemStoreRootDir
+			).build());
+
+		_fileSystemStoreRootDir =
+			_props.get(PropsKeys.LIFERAY_HOME) + "/test/store/file_system";
+
+		_fileSystemStoreConfiguration = _configurationAdmin.getConfiguration(
+			"com.liferay.portal.store.file.system.configuration." +
+				"FileSystemStoreConfiguration",
+			StringPool.QUESTION);
+
+		ConfigurationTestUtil.saveConfiguration(
+			_fileSystemStoreConfiguration,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"rootDir", _fileSystemStoreRootDir
+			).build());
+
+		_originalCacheEnabled = ReflectionTestUtil.getAndSetFieldValue(
+			PortalInstancePool.class, "_cacheEnabled", false);
+
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED", false);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(
+			_advancedFileSystemStoreConfiguration);
+		ConfigurationTestUtil.deleteConfiguration(
+			_fileSystemStoreConfiguration);
+
+		FileUtil.deltree(_advancedFileSystemStoreRootDir);
+		FileUtil.deltree(_fileSystemStoreRootDir);
+
+		ReflectionTestUtil.setFieldValue(
+			PortalInstancePool.class, "_cacheEnabled", _originalCacheEnabled);
+
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable.close();
+	}
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		CompanyLocalServiceUtil.forEachCompanyId(
+			companyId -> {
+				Files.createDirectories(
+					Paths.get(
+						_advancedFileSystemStoreRootDir,
+						String.valueOf(companyId)));
+				Files.createDirectories(
+					Paths.get(
+						_fileSystemStoreRootDir, String.valueOf(companyId)));
+			},
+			PortalInstancePool.getCompanyIds());
+	}
+
+	@After
+	public void tearDown() {
+		FileUtil.deltree(_advancedFileSystemStoreRootDir);
+		FileUtil.deltree(_fileSystemStoreRootDir);
+	}
+
+	@Test
+	public void testAdvancedFileSystemStoreWithLongDirectoryNameWithoutExtension()
+		throws Exception {
+
+		Path directoryWithoutExtension = Paths.get(
+			_advancedFileSystemStoreRootDir, String.valueOf(_companyId),
+			String.valueOf(_repositoryId), "100");
+
+		String expectedLogEntry =
+			"Found directory with name longer than 2 without extension in " +
+				"advanced file system pattern directory: " +
+					directoryWithoutExtension;
+
+		_assertVerify(
+			_ADVANCED_FILE_SYSTEM_STORE, directoryWithoutExtension, null, null,
+			1, expectedLogEntry);
+	}
+
+	@Test
+	public void testAdvancedFileSystemStoreWithValidStructure()
+		throws Exception {
+
+		Path validDirectory = Paths.get(
+			_advancedFileSystemStoreRootDir, String.valueOf(_companyId),
+			String.valueOf(_repositoryId), "10", "100.afsh");
+
+		_assertVerify(
+			_ADVANCED_FILE_SYSTEM_STORE, validDirectory, null, null, 0);
+	}
+
+	@Test
+	public void testFileSystemStoreWithDirectoryContainingExtension()
+		throws Exception {
+
+		Path directoryWithExtension = Paths.get(
+			_fileSystemStoreRootDir, String.valueOf(_companyId),
+			String.valueOf(_repositoryId), "100.txt");
+
+		String expectedLogEntry =
+			"Found directory with extension in basic file system pattern (no " +
+				"extensions expected): " + directoryWithExtension;
+
+		_assertVerify(
+			_FILE_SYSTEM_STORE, directoryWithExtension, null, null, 1,
+			expectedLogEntry);
+	}
+
+	@Test
+	public void testFileSystemStoreWithFileInsteadOfCompanyIdDirectory()
+		throws Exception {
+
+		Path fileSystemStoreRootPath = Paths.get(_fileSystemStoreRootDir);
+
+		Path invalidFilePath = fileSystemStoreRootPath.resolve(
+			"invalidFile.txt");
+
+		String expectedExceptionMessage =
+			invalidFilePath + " is not a directory";
+
+		_assertVerify(
+			_FILE_SYSTEM_STORE, null, invalidFilePath, expectedExceptionMessage,
+			0);
+	}
+
+	@Test
+	public void testFileSystemStoreWithFileInsteadOfFolderIdDirectory()
+		throws Exception {
+
+		Path companyIdPath = Paths.get(
+			_fileSystemStoreRootDir, String.valueOf(_companyId));
+
+		Path invalidFilePath = companyIdPath.resolve("invalidFile.txt");
+
+		String expectedLogEntry =
+			"Found file in basic file system pattern directory (only " +
+				"directories expected): " + invalidFilePath;
+
+		_assertVerify(
+			_FILE_SYSTEM_STORE, null, invalidFilePath, null, 1,
+			expectedLogEntry);
+	}
+
+	@Test
+	public void testFileSystemStoreWithFileInsteadOfNumericFileEntryNameDirectory()
+		throws Exception {
+
+		Path folderIdPath = Paths.get(
+			_fileSystemStoreRootDir, String.valueOf(_companyId),
+			String.valueOf(_repositoryId));
+
+		Path invalidFilePath = folderIdPath.resolve("invalidFile.txt");
+
+		String expectedLogEntry =
+			"Found file in basic file system pattern directory (only " +
+				"directories expected): " + invalidFilePath;
+
+		_assertVerify(
+			_FILE_SYSTEM_STORE, null, invalidFilePath, null, 1,
+			expectedLogEntry);
+	}
+
+	@Test
+	public void testFileSystemStoreWithMissingCompanyFolder() throws Exception {
+		Files.deleteIfExists(
+			Paths.get(_fileSystemStoreRootDir, String.valueOf(_companyId)));
+
+		String expectedExceptionMessage = StringBundler.concat(
+			"Missing folders for companies: [", _companyId,
+			"]. Please create the corresponding directories in ",
+			Paths.get(_fileSystemStoreRootDir));
+
+		_assertVerify(
+			_FILE_SYSTEM_STORE, null, null, expectedExceptionMessage, 0);
+	}
+
+	@Test
+	public void testFileSystemStoreWithMissingValidVersionFiles()
+		throws Exception {
+
+		Path numericFileEntryNamePath = Paths.get(
+			_fileSystemStoreRootDir, String.valueOf(_companyId),
+			String.valueOf(_repositoryId), "100");
+
+		Path invalidVersionFile = numericFileEntryNamePath.resolve(
+			"invalidVersion");
+
+		String expectedLogEntry1 =
+			"Found file that does not match version pattern (expected " +
+				"\\d+\\.\\d+.*): " + invalidVersionFile;
+
+		String expectedLogEntry2 =
+			"Directory does not contain valid version files as expected in " +
+				"basic file system pattern: " + numericFileEntryNamePath;
+
+		_assertVerify(
+			_FILE_SYSTEM_STORE, null, invalidVersionFile, null, 2,
+			expectedLogEntry1, expectedLogEntry2);
+	}
+
+	@Test
+	public void testFileSystemStoreWithValidStructure() throws Exception {
+		Path validDirectory = Paths.get(
+			_fileSystemStoreRootDir, String.valueOf(_companyId),
+			String.valueOf(_repositoryId), "100", "1.0");
+
+		_assertVerify(_FILE_SYSTEM_STORE, validDirectory, null, null, 0);
+	}
+
+	@Override
+	protected VerifyProcess getVerifyProcess() {
+		return new PreupgradeVerifyFileSystemStoreStructure();
+	}
+
+	private void _assertVerify(
+			String storeImpl, Path directoryPath, Path filePath,
+			String expectedExceptionMessage, int expectedLogEntriesCount,
+			String... expectedLogEntries)
+		throws Exception {
+
+		String originalDLStoreImpl = ReflectionTestUtil.getAndSetFieldValue(
+			PropsValues.class, "DL_STORE_IMPL", storeImpl);
+
+		LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+			PreupgradeVerifyFileSystemStoreStructure.class.getName(),
+			LoggerTestUtil.ERROR);
+
+		try {
+			if (directoryPath != null) {
+				Files.createDirectories(directoryPath);
+			}
+
+			if (filePath != null) {
+				Files.createDirectories(filePath.getParent());
+				Files.createFile(filePath);
+			}
+
+			testVerify();
+
+			_validateLogEntries(
+				logCapture, expectedLogEntriesCount, expectedLogEntries);
+
+			if (expectedLogEntries.length > 0) {
+				Assert.fail();
+			}
+		}
+		catch (Exception exception) {
+			if (expectedExceptionMessage == null) {
+				String expectedType;
+				Path rootDirPath;
+
+				if (_ADVANCED_FILE_SYSTEM_STORE.equals(storeImpl)) {
+					expectedType = "AdvancedFileSystemStore";
+					rootDirPath = Paths.get(_advancedFileSystemStoreRootDir);
+				}
+				else {
+					expectedType = "FileSystemStore";
+					rootDirPath = Paths.get(_fileSystemStoreRootDir);
+				}
+
+				expectedExceptionMessage = StringBundler.concat(
+					"File system store directory structure mismatch. Expected ",
+					expectedType, " structure but found invalid structure in: ",
+					rootDirPath);
+			}
+
+			Assert.assertEquals(
+				expectedExceptionMessage, exception.getMessage());
+
+			_validateLogEntries(
+				logCapture, expectedLogEntriesCount, expectedLogEntries);
+		}
+		finally {
+			logCapture.close();
+
+			ReflectionTestUtil.setFieldValue(
+				PropsValues.class, "DL_STORE_IMPL", originalDLStoreImpl);
+		}
+	}
+
+	private void _validateLogEntries(
+		LogCapture logCapture, int expectedLogEntriesCount,
+		String... expectedLogEntries) {
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(
+			logEntries.toString(), expectedLogEntriesCount, logEntries.size());
+
+		if (expectedLogEntriesCount > 0) {
+			for (int i = 0; i < expectedLogEntries.length; i++) {
+				Assert.assertEquals(
+					expectedLogEntries[i],
+					logEntries.get(
+						i
+					).getMessage());
+			}
+		}
+	}
+
+	private static final String _ADVANCED_FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.AdvancedFileSystemStore";
+
+	private static final String _FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.FileSystemStore";
+
+	private static Configuration _advancedFileSystemStoreConfiguration;
+	private static String _advancedFileSystemStoreRootDir;
+	private static long _companyId;
+
+	@Inject
+	private static ConfigurationAdmin _configurationAdmin;
+
+	private static Configuration _fileSystemStoreConfiguration;
+	private static String _fileSystemStoreRootDir;
+	private static boolean _originalCacheEnabled;
+
+	@Inject
+	private static Props _props;
+
+	private static long _repositoryId;
+	private static SafeCloseable
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable;
+
+}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyFileSystemStoreStructureTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyFileSystemStoreStructureTest.java
@@ -197,15 +197,27 @@ public class PreupgradeVerifyFileSystemStoreStructureTest
 
 		Path fileSystemStoreRootPath = Paths.get(_fileSystemStoreRootDir);
 
-		Path invalidFilePath = fileSystemStoreRootPath.resolve(
-			"invalidFile.txt");
+		long companyId = PortalInstancePool.getCompanyIds()[0];
 
-		String expectedExceptionMessage =
-			invalidFilePath + " is not a directory";
+		Path companyIdPath = fileSystemStoreRootPath.resolve(
+			String.valueOf(companyId));
+		Path companyIdBackupPath = fileSystemStoreRootPath.resolve(
+			String.valueOf(companyId) + "_backup");
 
-		_assertVerify(
-			_FILE_SYSTEM_STORE, null, invalidFilePath, expectedExceptionMessage,
-			0);
+		try {
+			Files.move(companyIdPath, companyIdBackupPath);
+			Files.createFile(companyIdPath);
+
+			String expectedExceptionMessage =
+				companyIdPath + " is not a directory";
+
+			_assertVerify(
+				_FILE_SYSTEM_STORE, null, null, expectedExceptionMessage, 0);
+		}
+		finally {
+			Files.delete(companyIdPath);
+			Files.move(companyIdBackupPath, companyIdPath);
+		}
 	}
 
 	@Test
@@ -325,7 +337,9 @@ public class PreupgradeVerifyFileSystemStoreStructureTest
 			_validateLogEntries(
 				logCapture, expectedLogEntriesCount, expectedLogEntries);
 
-			if (expectedLogEntries.length > 0) {
+			if ((expectedExceptionMessage != null) ||
+				(expectedLogEntries.length > 0)) {
+
 				Assert.fail();
 			}
 		}

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyFileSystemStoreWritePermissionTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyFileSystemStoreWritePermissionTest.java
@@ -1,0 +1,150 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.verify.PreupgradeVerifyFileSystemStoreWritePermission;
+import com.liferay.portal.verify.VerifyProcess;
+import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
+import com.liferay.portal.verify.util.PreupgradeFileSystemStoreVerifyUtil;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author István András Dézsi
+ */
+@RunWith(Arquillian.class)
+public class PreupgradeVerifyFileSystemStoreWritePermissionTest
+	extends BaseVerifyProcessTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_rootDir =
+			_props.get(PropsKeys.LIFERAY_HOME) + "/test/store/file_system";
+
+		_configuration = _configurationAdmin.getConfiguration(
+			"com.liferay.portal.store.file.system.configuration." +
+				"FileSystemStoreConfiguration",
+			StringPool.QUESTION);
+
+		ConfigurationTestUtil.saveConfiguration(
+			_configuration,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"rootDir", _rootDir
+			).build());
+
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED", false);
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(_configuration);
+
+		FileUtil.deltree(_rootDir);
+
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable.close();
+	}
+
+	@Test
+	public void testVerifyNonexistentRootDirectory() throws Exception {
+		Path originalPath = Paths.get(_rootDir);
+
+		Path renamedPath = Paths.get(
+			StringUtil.replace(_rootDir, "file_system", "file_system2"));
+
+		if (Files.exists(originalPath)) {
+			Files.move(originalPath, renamedPath);
+		}
+
+		LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+			PreupgradeFileSystemStoreVerifyUtil.class.getName(),
+			LoggerTestUtil.ERROR);
+
+		try {
+			testVerify();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertEquals(
+				"File system store root directory does not exist",
+				exception.getMessage());
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"File system store root directory does not exist: " +
+					originalPath,
+				logEntry.getMessage());
+		}
+		finally {
+			logCapture.close();
+
+			if (Files.exists(renamedPath)) {
+				Files.move(renamedPath, originalPath);
+			}
+		}
+	}
+
+	@Override
+	protected VerifyProcess getVerifyProcess() {
+		return new PreupgradeVerifyFileSystemStoreWritePermission();
+	}
+
+	private static Configuration _configuration;
+
+	@Inject
+	private static ConfigurationAdmin _configurationAdmin;
+
+	@Inject
+	private static Props _props;
+
+	private static String _rootDir;
+	private static SafeCloseable
+		_upgradeDatabaseDLStorageCheckDisabledSafeCloseable;
+
+}

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2395,6 +2395,11 @@ public class PropsValues {
 	public static final String UNICODE_TEXT_NORMALIZER_FORM = PropsUtil.get(
 		PropsKeys.UNICODE_TEXT_NORMALIZER_FORM);
 
+	public static final boolean UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(
+				PropsKeys.UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED));
+
 	public static final boolean UPGRADE_DATABASE_TRANSACTIONS_DISABLED =
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_DATABASE_TRANSACTIONS_DISABLED));

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 72.0.0
+version 72.1.0

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreStructure.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreStructure.java
@@ -50,8 +50,7 @@ public class PreupgradeVerifyFileSystemStoreStructure
 			PortalInstancePool.getCompanyIds());
 
 		Path fileSystemStoreRootDir =
-			PreupgradeFileSystemStoreVerifyUtil.getFileSystemStoreRootDir(
-				connection);
+			PreupgradeFileSystemStoreVerifyUtil.getFileSystemStoreRootDir();
 
 		try (DirectoryStream<Path> fileSystemStoreRootDirStream =
 				Files.newDirectoryStream(fileSystemStoreRootDir)) {

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreStructure.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreStructure.java
@@ -1,0 +1,346 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.util.PreupgradeFileSystemStoreVerifyUtil;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.util.Set;
+
+/**
+ * @author István András Dézsi
+ */
+public class PreupgradeVerifyFileSystemStoreStructure
+	extends PreupgradeVerifyProcess {
+
+	@Override
+	protected void doVerify() throws Exception {
+		if (PropsValues.UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED ||
+			!PreupgradeFileSystemStoreVerifyUtil.isFileSystemStore() ||
+			StartupHelperUtil.isDBNew()) {
+
+			return;
+		}
+
+		boolean advancedFileSystemStore = StringUtil.equals(
+			PropsValues.DL_STORE_IMPL, _ADVANCED_FILE_SYSTEM_STORE);
+
+		boolean fileSystemStore = StringUtil.equals(
+			PropsValues.DL_STORE_IMPL, _FILE_SYSTEM_STORE);
+
+		Set<Long> companyIdSet = SetUtil.fromArray(
+			PortalInstancePool.getCompanyIds());
+
+		Path fileSystemStoreRootDir =
+			PreupgradeFileSystemStoreVerifyUtil.getFileSystemStoreRootDir(
+				connection);
+
+		try (DirectoryStream<Path> fileSystemStoreRootDirStream =
+				Files.newDirectoryStream(fileSystemStoreRootDir)) {
+
+			for (Path companyIdDirectory : fileSystemStoreRootDirStream) {
+				String companyIdDirectoryName = companyIdDirectory.getFileName(
+				).toString();
+
+				if (StringUtil.equalsIgnoreCase(
+						companyIdDirectoryName, "README.txt")) {
+
+					continue;
+				}
+
+				if (!Files.isDirectory(companyIdDirectory)) {
+					throw new VerifyException(
+						companyIdDirectory + " is not a directory");
+				}
+
+				long companyId = GetterUtil.getLong(companyIdDirectoryName);
+
+				if (!companyIdSet.remove(companyId) ||
+					(advancedFileSystemStore &&
+					 _hasAdvancedFileSystemPattern(companyIdDirectory))) {
+
+					continue;
+				}
+
+				if (fileSystemStore &&
+					_hasBasicFileSystemPattern(companyIdDirectory)) {
+
+					continue;
+				}
+
+				String expectedType =
+					advancedFileSystemStore ? "AdvancedFileSystemStore" :
+						"FileSystemStore";
+
+				throw new VerifyException(
+					StringBundler.concat(
+						"File system store directory structure mismatch. ",
+						"Expected ", expectedType, " structure but found ",
+						"invalid structure in: ",
+						fileSystemStoreRootDir.toString()));
+			}
+		}
+
+		if (!companyIdSet.isEmpty()) {
+			throw new VerifyException(
+				StringBundler.concat(
+					"Missing folders for companies: ", companyIdSet.toString(),
+					". Please create the corresponding directories in ",
+					fileSystemStoreRootDir.toString()));
+		}
+	}
+
+	@Override
+	protected boolean isSkipDBPartitions() {
+		return true;
+	}
+
+	private boolean _hasAdvancedFileSystemPattern(Path companyIdDirectory) {
+		try (DirectoryStream<Path> companyIdDirectoryStream =
+				Files.newDirectoryStream(companyIdDirectory)) {
+
+			for (Path folderIdDirectory : companyIdDirectoryStream) {
+				String folderIdDirectoryName = folderIdDirectory.getFileName(
+				).toString();
+
+				if (StringUtil.equals(
+						folderIdDirectoryName, _ADAPTIVE_MEDIA_FOLDER_NAME)) {
+
+					continue;
+				}
+
+				if (!Files.isDirectory(folderIdDirectory)) {
+					_log.error(
+						"Found file in advanced file system pattern " +
+							"directory (only directories expected): " +
+								folderIdDirectory);
+
+					return false;
+				}
+
+				if (!_validateAdvancedFileSystemSubdirectories(
+						folderIdDirectory)) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to check advanced file system pattern in: " +
+						companyIdDirectory,
+					exception);
+			}
+
+			return false;
+		}
+	}
+
+	private boolean _hasBasicFileSystemPattern(Path companyIdDirectory) {
+		try (DirectoryStream<Path> companyIdDirectoryStream =
+				Files.newDirectoryStream(companyIdDirectory)) {
+
+			for (Path folderIdDirectory : companyIdDirectoryStream) {
+				String folderIdDirectoryName = folderIdDirectory.getFileName(
+				).toString();
+
+				if (StringUtil.equals(
+						folderIdDirectoryName, _ADAPTIVE_MEDIA_FOLDER_NAME)) {
+
+					continue;
+				}
+
+				if (!Files.isDirectory(folderIdDirectory)) {
+					_log.error(
+						"Found file in basic file system pattern directory " +
+							"(only directories expected): " +
+								folderIdDirectory);
+
+					return false;
+				}
+
+				try (DirectoryStream<Path> folderIdDirectoryStream =
+						Files.newDirectoryStream(folderIdDirectory)) {
+
+					for (Path numericFileEntryNameDirectory :
+							folderIdDirectoryStream) {
+
+						if (!Files.isDirectory(numericFileEntryNameDirectory)) {
+							_log.error(
+								"Found file in basic file system pattern " +
+									"directory (only directories expected): " +
+										numericFileEntryNameDirectory);
+
+							return false;
+						}
+
+						String numericFileEntryNameDirectoryName =
+							numericFileEntryNameDirectory.getFileName(
+							).toString();
+
+						if (numericFileEntryNameDirectoryName.contains(
+								StringPool.PERIOD)) {
+
+							_log.error(
+								StringBundler.concat(
+									"Found directory with extension in basic ",
+									"file system pattern (no extensions ",
+									"expected): ",
+									numericFileEntryNameDirectory.toString()));
+
+							return false;
+						}
+
+						if (!_hasVersionFile(numericFileEntryNameDirectory)) {
+							_log.error(
+								StringBundler.concat(
+									"Directory does not contain valid version ",
+									"files as expected in basic file system ",
+									"pattern: ",
+									numericFileEntryNameDirectory.toString()));
+
+							return false;
+						}
+					}
+				}
+			}
+
+			return true;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to check basic file system pattern in: " +
+						companyIdDirectory,
+					exception);
+			}
+
+			return false;
+		}
+	}
+
+	private boolean _hasVersionFile(Path numericFileEntryNameDirectory) {
+		try (DirectoryStream<Path> numericFileEntryNameDirectoryStream =
+				Files.newDirectoryStream(numericFileEntryNameDirectory)) {
+
+			for (Path versionNumberFile : numericFileEntryNameDirectoryStream) {
+				if (!Files.isDirectory(versionNumberFile)) {
+					String versionNumberFileName =
+						versionNumberFile.getFileName(
+						).toString();
+
+					if (!versionNumberFileName.matches("\\d+\\.\\d+.*")) {
+						_log.error(
+							"Found file that does not match version pattern " +
+								"(expected \\d+\\.\\d+.*): " +
+									versionNumberFile);
+
+						return false;
+					}
+				}
+			}
+
+			return true;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to check for version file in: " +
+						numericFileEntryNameDirectory,
+					exception);
+			}
+
+			return false;
+		}
+	}
+
+	private boolean _validateAdvancedFileSystemSubdirectories(
+		Path folderIdDirectory) {
+
+		try (DirectoryStream<Path> folderIdDirectoryStream =
+				Files.newDirectoryStream(folderIdDirectory)) {
+
+			for (Path numericFileEntryNameDirectory : folderIdDirectoryStream) {
+				if (!Files.isDirectory(numericFileEntryNameDirectory)) {
+					_log.error(
+						"Found file in advanced file system pattern " +
+							"directory (only directories expected): " +
+								numericFileEntryNameDirectory);
+
+					return false;
+				}
+
+				String numericFileEntryNameDirectoryName =
+					numericFileEntryNameDirectory.getFileName(
+					).toString();
+
+				if (numericFileEntryNameDirectoryName.equals("DLFE")) {
+					if (!_validateAdvancedFileSystemSubdirectories(
+							numericFileEntryNameDirectory)) {
+
+						return false;
+					}
+				}
+				else if ((numericFileEntryNameDirectoryName.length() > 2) &&
+						 Validator.isNull(
+							 FileUtil.getExtension(
+								 numericFileEntryNameDirectoryName))) {
+
+					_log.error(
+						StringBundler.concat(
+							"Found directory with name longer than 2 without ",
+							"extension in advanced file system pattern ",
+							"directory: ",
+							numericFileEntryNameDirectory.toString()));
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to validate subdirectories in: " +
+						folderIdDirectory,
+					exception);
+			}
+
+			return false;
+		}
+	}
+
+	private static final String _ADAPTIVE_MEDIA_FOLDER_NAME = "0";
+
+	private static final String _ADVANCED_FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.AdvancedFileSystemStore";
+
+	private static final String _FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.FileSystemStore";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PreupgradeVerifyFileSystemStoreStructure.class);
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreStructure.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreStructure.java
@@ -59,9 +59,9 @@ public class PreupgradeVerifyFileSystemStoreStructure
 				String companyIdDirectoryName = companyIdDirectory.getFileName(
 				).toString();
 
-				if (StringUtil.equalsIgnoreCase(
-						companyIdDirectoryName, "README.txt")) {
+				long companyId = GetterUtil.getLong(companyIdDirectoryName);
 
+				if (!companyIdSet.remove(companyId)) {
 					continue;
 				}
 
@@ -70,11 +70,8 @@ public class PreupgradeVerifyFileSystemStoreStructure
 						companyIdDirectory + " is not a directory");
 				}
 
-				long companyId = GetterUtil.getLong(companyIdDirectoryName);
-
-				if (!companyIdSet.remove(companyId) ||
-					(advancedFileSystemStore &&
-					 _hasAdvancedFileSystemPattern(companyIdDirectory))) {
+				if (advancedFileSystemStore &&
+					_hasAdvancedFileSystemPattern(companyIdDirectory)) {
 
 					continue;
 				}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreWritePermission.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreWritePermission.java
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.portal.verify.util.PreupgradeFileSystemStoreVerifyUtil;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * @author István András Dézsi
+ */
+public class PreupgradeVerifyFileSystemStoreWritePermission
+	extends PreupgradeVerifyProcess {
+
+	@Override
+	protected void doVerify() throws Exception {
+		if (PropsValues.UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED ||
+			!PreupgradeFileSystemStoreVerifyUtil.isFileSystemStore()) {
+
+			return;
+		}
+
+		Path fileSystemStoreRootDir =
+			PreupgradeFileSystemStoreVerifyUtil.getFileSystemStoreRootDir(
+				connection);
+
+		if (fileSystemStoreRootDir == null) {
+			throw new VerifyException(
+				"File system store root directory does not exist");
+		}
+
+		if (!Files.isDirectory(fileSystemStoreRootDir)) {
+			throw new VerifyException(
+				"File system store path is not a directory: " +
+					fileSystemStoreRootDir.toString());
+		}
+
+		Path testFile = fileSystemStoreRootDir.resolve(
+			StringBundler.concat(
+				"liferay_upgrade_test_",
+				String.valueOf(System.currentTimeMillis()), ".tmp"));
+
+		try {
+			Files.createFile(testFile);
+			Files.delete(testFile);
+		}
+		catch (Exception exception) {
+			throw new VerifyException(
+				StringBundler.concat(
+					"Cannot write to file system store directory: ",
+					fileSystemStoreRootDir.toString(), ". ",
+					exception.getClass(
+					).getName(),
+					": ", exception.getMessage()));
+		}
+	}
+
+	@Override
+	protected boolean isSkipDBPartitions() {
+		return true;
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreWritePermission.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyFileSystemStoreWritePermission.java
@@ -27,8 +27,7 @@ public class PreupgradeVerifyFileSystemStoreWritePermission
 		}
 
 		Path fileSystemStoreRootDir =
-			PreupgradeFileSystemStoreVerifyUtil.getFileSystemStoreRootDir(
-				connection);
+			PreupgradeFileSystemStoreVerifyUtil.getFileSystemStoreRootDir();
 
 		if (fileSystemStoreRootDir == null) {
 			throw new VerifyException(

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyProcessSuite.java
@@ -25,6 +25,8 @@ public class PreupgradeVerifyProcessSuite extends PreupgradeVerifyProcess {
 		_verify(new PreupgradeVerifyDatabaseCharacterSet());
 		_verify(new PreupgradeVerifyDatabasePrivileges());
 		_verify(new PreupgradeVerifyDatabaseState());
+		_verify(new PreupgradeVerifyFileSystemStoreStructure());
+		_verify(new PreupgradeVerifyFileSystemStoreWritePermission());
 		_verify(new PreupgradeVerifyProperties());
 
 		if (ListUtil.isNotEmpty(_exceptionMessages)) {

--- a/portal-impl/src/com/liferay/portal/verify/util/PreupgradeFileSystemStoreVerifyUtil.java
+++ b/portal-impl/src/com/liferay/portal/verify/util/PreupgradeFileSystemStoreVerifyUtil.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.verify.util;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+/**
+ * @author István András Dézsi
+ */
+public class PreupgradeFileSystemStoreVerifyUtil {
+
+	public static String getDictionaryString(
+			Connection connection, String configurationPid)
+		throws SQLException {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select dictionary from Configuration_ where configurationId " +
+					"= ?")) {
+
+			preparedStatement.setString(1, configurationPid);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				if (resultSet.next()) {
+					return resultSet.getString(1);
+				}
+			}
+		}
+
+		return StringPool.BLANK;
+	}
+
+	public static Path getFileSystemStoreRootDir(Connection connection) {
+		String fileSystemStoreRootDirPath = getFileSystemStoreRootDirPath(
+			connection);
+
+		if (fileSystemStoreRootDirPath == null) {
+			return null;
+		}
+
+		Path fileSystemStoreRootDir = Paths.get(fileSystemStoreRootDirPath);
+
+		if (!Files.exists(fileSystemStoreRootDir)) {
+			_log.error(
+				"File system store root directory does not exist: " +
+					fileSystemStoreRootDir);
+
+			return null;
+		}
+
+		if (!fileSystemStoreRootDir.isAbsolute()) {
+			fileSystemStoreRootDir = Paths.get(
+				PropsValues.LIFERAY_HOME, fileSystemStoreRootDirPath);
+		}
+
+		return fileSystemStoreRootDir;
+	}
+
+	public static String getFileSystemStoreRootDirPath(Connection connection) {
+		String configurationPid = null;
+
+		if (StringUtil.equals(
+				PropsValues.DL_STORE_IMPL, _ADVANCED_FILE_SYSTEM_STORE)) {
+
+			configurationPid = _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE;
+		}
+		else if (StringUtil.equals(
+					PropsValues.DL_STORE_IMPL, _FILE_SYSTEM_STORE)) {
+
+			configurationPid = _CONFIGURATION_PID_FILE_SYSTEM_STORE;
+		}
+		else {
+			return null;
+		}
+
+		String rootDir = null;
+
+		try {
+			Dictionary<String, String> dictionary = parseDictionaryString(
+				getDictionaryString(connection, configurationPid));
+
+			rootDir = dictionary.get("rootDir");
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to get file system store root directory path",
+				exception);
+
+			return null;
+		}
+
+		if (Validator.isNull(rootDir)) {
+			rootDir = PropsValues.LIFERAY_HOME + "/data/document_library";
+		}
+
+		return rootDir;
+	}
+
+	public static boolean isFileSystemStore() {
+		if (StringUtil.equals(
+				PropsValues.DL_STORE_IMPL, _ADVANCED_FILE_SYSTEM_STORE) ||
+			StringUtil.equals(PropsValues.DL_STORE_IMPL, _FILE_SYSTEM_STORE)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public static Dictionary<String, String> parseDictionaryString(
+		String dictionaryString) {
+
+		Dictionary<String, String> dictionary = new Hashtable<>();
+
+		if (Validator.isNull(dictionaryString)) {
+			return dictionary;
+		}
+
+		for (String line : dictionaryString.split("\n")) {
+			line = line.trim();
+
+			if (line.isEmpty() || line.startsWith(":")) {
+				continue;
+			}
+
+			int equalsIndex = line.indexOf('=');
+
+			if (equalsIndex <= 0) {
+				continue;
+			}
+
+			String key = line.substring(0, equalsIndex);
+
+			String value = line.substring(equalsIndex + 1);
+
+			if (value.startsWith("\"") && value.endsWith("\"") &&
+				(value.length() > 1)) {
+
+				value = value.substring(1, value.length() - 1);
+			}
+
+			dictionary.put(key, value);
+		}
+
+		return dictionary;
+	}
+
+	private static final String _ADVANCED_FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.AdvancedFileSystemStore";
+
+	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.configuration." +
+			"AdvancedFileSystemStoreConfiguration";
+
+	private static final String _CONFIGURATION_PID_FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.configuration." +
+			"FileSystemStoreConfiguration";
+
+	private static final String _FILE_SYSTEM_STORE =
+		"com.liferay.portal.store.file.system.FileSystemStore";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PreupgradeFileSystemStoreVerifyUtil.class);
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/util/PreupgradeFileSystemStoreVerifyUtil.java
+++ b/portal-impl/src/com/liferay/portal/verify/util/PreupgradeFileSystemStoreVerifyUtil.java
@@ -5,114 +5,61 @@
 
 package com.liferay.portal.verify.util;
 
-import com.liferay.petra.string.StringPool;
+import com.liferay.document.library.kernel.store.Store;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsValues;
 
-import java.nio.file.Files;
+import java.io.File;
+
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.util.Collection;
 
-import java.util.Dictionary;
-import java.util.Hashtable;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
 
 /**
  * @author István András Dézsi
  */
 public class PreupgradeFileSystemStoreVerifyUtil {
 
-	public static String getDictionaryString(
-			Connection connection, String configurationPid)
-		throws SQLException {
+	public static Path getFileSystemStoreRootDir() {
+		File rootDir = null;
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select dictionary from Configuration_ where configurationId " +
-					"= ?")) {
-
-			preparedStatement.setString(1, configurationPid);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				if (resultSet.next()) {
-					return resultSet.getString(1);
-				}
-			}
-		}
-
-		return StringPool.BLANK;
-	}
-
-	public static Path getFileSystemStoreRootDir(Connection connection) {
-		String fileSystemStoreRootDirPath = getFileSystemStoreRootDirPath(
-			connection);
-
-		if (fileSystemStoreRootDirPath == null) {
-			return null;
-		}
-
-		Path fileSystemStoreRootDir = Paths.get(fileSystemStoreRootDirPath);
-
-		if (!Files.exists(fileSystemStoreRootDir)) {
-			_log.error(
-				"File system store root directory does not exist: " +
-					fileSystemStoreRootDir);
-
-			return null;
-		}
-
-		if (!fileSystemStoreRootDir.isAbsolute()) {
-			fileSystemStoreRootDir = Paths.get(
-				PropsValues.LIFERAY_HOME, fileSystemStoreRootDirPath);
-		}
-
-		return fileSystemStoreRootDir;
-	}
-
-	public static String getFileSystemStoreRootDirPath(Connection connection) {
-		String configurationPid = null;
-
-		if (StringUtil.equals(
-				PropsValues.DL_STORE_IMPL, _ADVANCED_FILE_SYSTEM_STORE)) {
-
-			configurationPid = _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE;
-		}
-		else if (StringUtil.equals(
-					PropsValues.DL_STORE_IMPL, _FILE_SYSTEM_STORE)) {
-
-			configurationPid = _CONFIGURATION_PID_FILE_SYSTEM_STORE;
-		}
-		else {
-			return null;
-		}
-
-		String rootDir = null;
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
 
 		try {
-			Dictionary<String, String> dictionary = parseDictionaryString(
-				getDictionaryString(connection, configurationPid));
+			Collection<ServiceReference<Store>> serviceReferences =
+				bundleContext.getServiceReferences(
+					Store.class,
+					"(store.type=" + PropsValues.DL_STORE_IMPL + ")");
 
-			rootDir = dictionary.get("rootDir");
+			for (ServiceReference<Store> serviceReference : serviceReferences) {
+				rootDir = (File)serviceReference.getProperty("rootDir");
+
+				break;
+			}
 		}
 		catch (Exception exception) {
 			_log.error(
-				"Unable to get file system store root directory path",
-				exception);
+				"Error getting file system store root directory", exception);
+		}
 
+		if (rootDir == null) {
 			return null;
 		}
 
-		if (Validator.isNull(rootDir)) {
-			rootDir = PropsValues.LIFERAY_HOME + "/data/document_library";
+		if (rootDir.exists()) {
+			return rootDir.toPath();
 		}
 
-		return rootDir;
+		_log.error(
+			"File system store root directory does not exist: " + rootDir);
+
+		return null;
 	}
 
 	public static boolean isFileSystemStore() {
@@ -126,54 +73,8 @@ public class PreupgradeFileSystemStoreVerifyUtil {
 		return false;
 	}
 
-	public static Dictionary<String, String> parseDictionaryString(
-		String dictionaryString) {
-
-		Dictionary<String, String> dictionary = new Hashtable<>();
-
-		if (Validator.isNull(dictionaryString)) {
-			return dictionary;
-		}
-
-		for (String line : dictionaryString.split("\n")) {
-			line = line.trim();
-
-			if (line.isEmpty() || line.startsWith(":")) {
-				continue;
-			}
-
-			int equalsIndex = line.indexOf('=');
-
-			if (equalsIndex <= 0) {
-				continue;
-			}
-
-			String key = line.substring(0, equalsIndex);
-
-			String value = line.substring(equalsIndex + 1);
-
-			if (value.startsWith("\"") && value.endsWith("\"") &&
-				(value.length() > 1)) {
-
-				value = value.substring(1, value.length() - 1);
-			}
-
-			dictionary.put(key, value);
-		}
-
-		return dictionary;
-	}
-
 	private static final String _ADVANCED_FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.AdvancedFileSystemStore";
-
-	private static final String _CONFIGURATION_PID_ADVANCED_FILE_SYSTEM_STORE =
-		"com.liferay.portal.store.file.system.configuration." +
-			"AdvancedFileSystemStoreConfiguration";
-
-	private static final String _CONFIGURATION_PID_FILE_SYSTEM_STORE =
-		"com.liferay.portal.store.file.system.configuration." +
-			"FileSystemStoreConfiguration";
 
 	private static final String _FILE_SYSTEM_STORE =
 		"com.liferay.portal.store.file.system.FileSystemStore";

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -153,6 +153,16 @@
     upgrade.database.auto.run=false
 
     #
+    # Set this to true to disable the document library storage file system
+    # verification before database upgrades. This check verifies that the
+    # expected file system store structure is present and has write permissions
+    # before making any database changes.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_DL_PERIOD_STORAGE_PERIOD_CHECK_PERIOD_DISABLED
+    #
+    upgrade.database.dl.storage.check.disabled=false
+
+    #
     # Set this to true to disable database transaction management during
     # upgrades. This forces autocommit, which will speed up the upgrade process.
     #

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2736,6 +2736,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_DATABASE_AUTO_RUN =
 		"upgrade.database.auto.run";
 
+	public static final String UPGRADE_DATABASE_DL_STORAGE_CHECK_DISABLED =
+		"upgrade.database.dl.storage.check.disabled";
+
 	public static final String UPGRADE_DATABASE_TRANSACTIONS_DISABLED =
 		"upgrade.database.transactions.disabled";
 


### PR DESCRIPTION
Hi @IstvanD 

I am adding some changes in top of your PRs https://github.com/liferay-database-infra/liferay-portal/pull/2847

- 6dcee55bb745b60fe24c997c9a99ce19ac86d762 Getting the rootDir of the FileSystemStore from the Store service reference, with this change we can remove the query to Configuration_ table and parsing it.
- 71a1da1e6ea1ce805d37493d15f4909b70a3db50 Simplify the validation, instead of cheching the README.txt, just check the folders that belong to companies
- 7d20f829ee07da8a3147cd380e4422847f90cb47 Test improve: move the company folder instead of creating a file with other name (related to my previous change)

