### PR TITLE
LPD-57714 Previews are not generated when database partition is enabled

### DIFF
--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -713,7 +714,7 @@ public class BackgroundTaskLocalServiceImpl
 			backgroundTask.setUserName(user.getFullName());
 		}
 		else {
-			backgroundTask.setCompanyId(CompanyConstants.SYSTEM);
+			backgroundTask.setCompanyId(CompanyThreadLocal.getCompanyId());
 			backgroundTask.setUserName(StringPool.BLANK);
 		}
 

--- a/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
+++ b/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/service/impl/BackgroundTaskLocalServiceImpl.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.Message;
 import com.liferay.portal.kernel.messaging.MessageBus;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
@@ -12,6 +12,7 @@ import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
+import com.liferay.portal.kernel.cache.PortalCacheListener;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
@@ -52,19 +53,9 @@ public class BackgroundTaskLocalServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_backgroundTaskExecutor =
-			(BackgroundTaskExecutor)ProxyUtil.newProxyInstance(
-				BackgroundTaskExecutor.class.getClassLoader(),
-				new Class<?>[] {BackgroundTaskExecutor.class},
-				(proxy, method, argus) -> null);
-	}
-
 	@Test
 	public void testAddBackgroundTaskWithSystemDefaults()
-		throws PortalException {
-
+		throws Exception {
 		BackgroundTaskExecutor backgroundTaskExecutor =
 			(BackgroundTaskExecutor)ProxyUtil.newProxyInstance(
 				BackgroundTaskExecutor.class.getClassLoader(),
@@ -121,23 +112,15 @@ public class BackgroundTaskLocalServiceTest {
 						backgroundTask.getBackgroundTaskId());
 				});
 		}
-		catch (Exception e) {
-			e.printStackTrace();
-		}
 		finally {
 			serviceRegistration.unregister();
 		}
 	}
-
-	private static BackgroundTaskExecutor _backgroundTaskExecutor;
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
-
-	@DeleteAfterTestRun
-	private Group _group;
 
 }

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.background.task.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.background.task.model.BackgroundTask;
+import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class BackgroundTaskLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_backgroundTaskExecutor =
+			(BackgroundTaskExecutor) ProxyUtil.newProxyInstance(
+				BackgroundTaskExecutor.class.getClassLoader(),
+				new Class<?>[] {BackgroundTaskExecutor.class},
+				(proxy, method, argus) -> null);
+	}
+
+	@Test
+	public void testAddBackgroundTaskWithSystemDefaults()
+		throws PortalException {
+
+		BackgroundTaskExecutor backgroundTaskExecutor =
+			(BackgroundTaskExecutor)ProxyUtil.newProxyInstance(
+				BackgroundTaskExecutor.class.getClassLoader(),
+				new Class<?>[] {BackgroundTaskExecutor.class},
+				(proxy, method, argus) -> null);
+
+		Class<?> backgroundTaskExecutorClass =
+			backgroundTaskExecutor.getClass();
+
+		Bundle bundle = FrameworkUtil.getBundle(BackgroundTaskLocalServiceTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		ServiceRegistration<BackgroundTaskExecutor> serviceRegistration =
+			bundleContext.registerService(
+				BackgroundTaskExecutor.class, backgroundTaskExecutor,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"background.task.executor.class.name",
+					backgroundTaskExecutorClass.getName()
+				).build());
+
+		try{
+			_companyLocalService.forEachCompanyId(
+				companyId -> {
+					BackgroundTask backgroundTask =
+						_backgroundTaskLocalService.addBackgroundTask(
+							UserConstants.USER_ID_DEFAULT, CompanyConstants.SYSTEM,
+							RandomTestUtil.randomString(), null, _backgroundTaskExecutor.getClass(), null, null);
+
+					Assert.assertEquals(backgroundTask.getCompanyId(), (long)companyId);
+
+					_backgroundTaskLocalService.deleteBackgroundTask(
+						backgroundTask.getBackgroundTaskId());
+				});
+		}
+		catch(Exception e){
+			e.printStackTrace();
+		}
+		finally{
+			serviceRegistration.unregister();
+		}
+	}
+
+	@Inject
+	private BackgroundTaskLocalService _backgroundTaskLocalService;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	private static BackgroundTaskExecutor _backgroundTaskExecutor;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
@@ -1,14 +1,17 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
 package com.liferay.portal.background.task.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
+import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
+import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
@@ -17,7 +20,9 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -28,10 +33,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
+
+import java.util.Objects;
 
 /**
  * @author Jorge Avalos
@@ -47,7 +55,7 @@ public class BackgroundTaskLocalServiceTest {
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		_backgroundTaskExecutor =
-			(BackgroundTaskExecutor) ProxyUtil.newProxyInstance(
+			(BackgroundTaskExecutor)ProxyUtil.newProxyInstance(
 				BackgroundTaskExecutor.class.getClassLoader(),
 				new Class<?>[] {BackgroundTaskExecutor.class},
 				(proxy, method, argus) -> null);
@@ -61,7 +69,26 @@ public class BackgroundTaskLocalServiceTest {
 			(BackgroundTaskExecutor)ProxyUtil.newProxyInstance(
 				BackgroundTaskExecutor.class.getClassLoader(),
 				new Class<?>[] {BackgroundTaskExecutor.class},
-				(proxy, method, argus) -> null);
+				(proxy, method, argus) -> {
+					if (Objects.equals(method.getName(), "clone")) {
+						return proxy;
+					}
+					else if (Objects.equals(method.getName(), "execute")) {
+						return new BackgroundTaskResult(
+							BackgroundTaskConstants.STATUS_FAILED);
+					}
+					else if (Objects.equals(
+						method.getName(), "getIsolationLevel")) {
+
+						return BackgroundTaskConstants.
+							ISOLATION_LEVEL_NOT_ISOLATED;
+					}
+					else if (Objects.equals(method.getName(), "isSerial")) {
+						return false;
+					}
+
+					return null;
+				});
 
 		Class<?> backgroundTaskExecutorClass =
 			backgroundTaskExecutor.getClass();
@@ -78,35 +105,37 @@ public class BackgroundTaskLocalServiceTest {
 					backgroundTaskExecutorClass.getName()
 				).build());
 
-		try{
+		try {
 			_companyLocalService.forEachCompanyId(
 				companyId -> {
 					BackgroundTask backgroundTask =
 						_backgroundTaskLocalService.addBackgroundTask(
 							UserConstants.USER_ID_DEFAULT, CompanyConstants.SYSTEM,
-							RandomTestUtil.randomString(), null, _backgroundTaskExecutor.getClass(), null, null);
+							RandomTestUtil.randomString(), null,
+							backgroundTaskExecutor.getClass(), null, null);
 
-					Assert.assertEquals(backgroundTask.getCompanyId(), (long)companyId);
+					Assert.assertEquals(
+						backgroundTask.getCompanyId(), (long)companyId);
 
 					_backgroundTaskLocalService.deleteBackgroundTask(
 						backgroundTask.getBackgroundTaskId());
 				});
 		}
-		catch(Exception e){
+		catch (Exception e) {
 			e.printStackTrace();
 		}
-		finally{
+		finally {
 			serviceRegistration.unregister();
 		}
 	}
+
+	private static BackgroundTaskExecutor _backgroundTaskExecutor;
 
 	@Inject
 	private BackgroundTaskLocalService _backgroundTaskLocalService;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;
-
-	private static BackgroundTaskExecutor _backgroundTaskExecutor;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
+++ b/modules/apps/portal-background-task/portal-background-task-test/src/testIntegration/java/com/liferay/portal/background/task/service/test/BackgroundTaskLocalServiceTest.java
@@ -6,30 +6,24 @@
 package com.liferay.portal.background.task.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.portal.background.task.model.BackgroundTask;
 import com.liferay.portal.background.task.service.BackgroundTaskLocalService;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskExecutor;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskResult;
 import com.liferay.portal.kernel.backgroundtask.constants.BackgroundTaskConstants;
-import com.liferay.portal.kernel.cache.PortalCacheListener;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.CompanyConstants;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.ProxyFactory;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.Objects;
+
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -39,8 +33,6 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
-
-import java.util.Objects;
 
 /**
  * @author Jorge Avalos
@@ -54,8 +46,7 @@ public class BackgroundTaskLocalServiceTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testAddBackgroundTaskWithSystemDefaults()
-		throws Exception {
+	public void testAddBackgroundTaskWithSystemDefaults() throws Exception {
 		BackgroundTaskExecutor backgroundTaskExecutor =
 			(BackgroundTaskExecutor)ProxyUtil.newProxyInstance(
 				BackgroundTaskExecutor.class.getClassLoader(),
@@ -69,7 +60,7 @@ public class BackgroundTaskLocalServiceTest {
 							BackgroundTaskConstants.STATUS_FAILED);
 					}
 					else if (Objects.equals(
-						method.getName(), "getIsolationLevel")) {
+								method.getName(), "getIsolationLevel")) {
 
 						return BackgroundTaskConstants.
 							ISOLATION_LEVEL_NOT_ISOLATED;
@@ -84,7 +75,8 @@ public class BackgroundTaskLocalServiceTest {
 		Class<?> backgroundTaskExecutorClass =
 			backgroundTaskExecutor.getClass();
 
-		Bundle bundle = FrameworkUtil.getBundle(BackgroundTaskLocalServiceTest.class);
+		Bundle bundle = FrameworkUtil.getBundle(
+			BackgroundTaskLocalServiceTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -101,7 +93,8 @@ public class BackgroundTaskLocalServiceTest {
 				companyId -> {
 					BackgroundTask backgroundTask =
 						_backgroundTaskLocalService.addBackgroundTask(
-							UserConstants.USER_ID_DEFAULT, CompanyConstants.SYSTEM,
+							UserConstants.USER_ID_DEFAULT,
+							CompanyConstants.SYSTEM,
 							RandomTestUtil.randomString(), null,
 							backgroundTaskExecutor.getClass(), null, null);
 


### PR DESCRIPTION
@marianoalvarosaiz 
Can you checkout how the backgroundTaskExecutor is created,  is that the only way to avoid any errors on the listener-side?