### PR TITLE
LPD-58688 throw a warning instead of preventing the upgrade

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/recorder/UpgradeRecorder.java
@@ -45,11 +45,6 @@ import org.osgi.util.tracker.ServiceTracker;
 @Component(service = UpgradeRecorder.class)
 public class UpgradeRecorder {
 
-	public static boolean isPreupgradeVerifyFailure() {
-		return _errorMessages.containsKey(
-			PreupgradeVerifyProcessSuite.class.getName());
-	}
-
 	public Map<String, Map<String, Integer>> getDataCleanUpMessages() {
 		return _dataCleanUpMessages;
 	}
@@ -94,6 +89,17 @@ public class UpgradeRecorder {
 
 	public Map<String, Map<String, Integer>> getWarningMessages() {
 		return _warningMessages;
+	}
+
+	public boolean isPreupgradeVerifyFailure() {
+		ReleaseManager releaseManager = _serviceTracker.getService();
+
+		if (releaseManager != null) {
+			return false;
+		}
+
+		return _errorMessages.containsKey(
+			PreupgradeVerifyProcessSuite.class.getName());
 	}
 
 	public void recordErrorMessage(

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseCharacterSetTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseCharacterSetTest.java
@@ -31,6 +31,7 @@ import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
 
 import java.sql.Connection;
+
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -126,7 +127,8 @@ public class PreupgradeVerifyDatabaseCharacterSetTest
 				" (testColumn VARCHAR(75) primary key) collate utf8_bin"));
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-			PreupgradeVerifyDatabaseCharacterSet.class.getName(), LoggerTestUtil.WARN)) {
+				PreupgradeVerifyDatabaseCharacterSet.class.getName(),
+				LoggerTestUtil.WARN)) {
 
 			testVerify();
 
@@ -139,7 +141,6 @@ public class PreupgradeVerifyDatabaseCharacterSetTest
 			Assert.assertEquals(
 				"Mixed character set and collation: testtable",
 				logEntry.getMessage());
-
 		}
 		finally {
 			_serviceComponentLocalService.deleteServiceComponent(

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseCharacterSetTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseCharacterSetTest.java
@@ -20,6 +20,9 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -28,6 +31,7 @@ import com.liferay.portal.verify.VerifyProcess;
 import com.liferay.portal.verify.test.util.BaseVerifyProcessTestCase;
 
 import java.sql.Connection;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -105,7 +109,7 @@ public class PreupgradeVerifyDatabaseCharacterSetTest
 			_serviceComponentLocalService.createServiceComponent(
 				RandomTestUtil.nextLong());
 
-		DBInspector dbInspector = new DBInspector(DataAccess.getConnection());
+		DBInspector dbInspector = new DBInspector(_connection);
 
 		String tableName = dbInspector.normalizeName("TestTable");
 
@@ -121,13 +125,21 @@ public class PreupgradeVerifyDatabaseCharacterSetTest
 				"create table ", tableName,
 				" (testColumn VARCHAR(75) primary key) collate utf8_bin"));
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+			PreupgradeVerifyDatabaseCharacterSet.class.getName(), LoggerTestUtil.WARN)) {
+
 			testVerify();
 
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			_verifyException(exception, "Mixed character set and collation:");
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(
+				"Mixed character set and collation: testtable",
+				logEntry.getMessage());
+
 		}
 		finally {
 			_serviceComponentLocalService.deleteServiceComponent(

--- a/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseCharacterSetTest.java
+++ b/modules/apps/portal/portal-verify-test/src/testIntegration/java/com/liferay/portal/verify/test/PreupgradeVerifyDatabaseCharacterSetTest.java
@@ -139,7 +139,7 @@ public class PreupgradeVerifyDatabaseCharacterSetTest
 			LogEntry logEntry = logEntries.get(0);
 
 			Assert.assertEquals(
-				"Mixed character set and collation: testtable",
+				"Mixed character set and collation: " + tableName,
 				logEntry.getMessage());
 		}
 		finally {

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
@@ -89,8 +89,8 @@ public class PreupgradeVerifyDatabaseCharacterSet
 							resultSet.getString("default_character_set_name"),
 							" character set and ",
 							resultSet.getString("default_collation_name"),
-							". Recommended configuration is ",
-							"utf8mb4/utf8mb4_unicode_ci."));
+							". Recommended character set is utf8mb4 and ",
+							"recommended collation is utf8mb4_unicode_ci."));
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
@@ -88,7 +88,9 @@ public class PreupgradeVerifyDatabaseCharacterSet
 							" collation, but database has ",
 							resultSet.getString("default_character_set_name"),
 							" character set and ",
-							resultSet.getString("default_collation_name")));
+							resultSet.getString("default_collation_name"),
+							". Recommended configuration is ",
+							"utf8mb4/utf8mb4_unicode_ci."));
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseCharacterSet.java
@@ -11,6 +11,8 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -76,16 +78,18 @@ public class PreupgradeVerifyDatabaseCharacterSet
 					continue;
 				}
 
-				throw new VerifyException(
-					StringBundler.concat(
-						"Mixed character set and collation: ", tableName,
-						" has ", resultSet.getString("character_set_name"),
-						" character set and ",
-						resultSet.getString("collation_name"),
-						" collation, but database has ",
-						resultSet.getString("default_character_set_name"),
-						" character set and ",
-						resultSet.getString("default_collation_name")));
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Mixed character set and collation: ", tableName,
+							" has ", resultSet.getString("character_set_name"),
+							" character set and ",
+							resultSet.getString("collation_name"),
+							" collation, but database has ",
+							resultSet.getString("default_character_set_name"),
+							" character set and ",
+							resultSet.getString("default_collation_name")));
+				}
 			}
 		}
 	}
@@ -94,5 +98,8 @@ public class PreupgradeVerifyDatabaseCharacterSet
 	protected boolean isSkipDBPartitions() {
 		return true;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PreupgradeVerifyDatabaseCharacterSet.class);
 
 }


### PR DESCRIPTION
Previous PR https://github.com/liferay-database-infra/liferay-portal/pull/2872

I have added 'character set' and 'collation' texts to the recommendation, see f294e6631c1b10ad1e5072ae0305baa4de25b070

I have also add an extra validation to the `UpgradeRecorder` because if we add a `PreupgradeVerifyProcessSuite` error trace but we don't throw a VerifyException, we can have a false positive "preupgrade verification failure" message in the report but having executed the complete upgrade.

cc @javalosjr96 