### PR TITLE
LPD-59412 Ensure PortletTracker considers portlet target company before any attempt to access underlying data structures

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-portlet-tracker/src/main/java/com/liferay/portal/osgi/web/portlet/tracker/internal/osgi/util/tracker/PortletTracker.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletInstanceFactory;
 import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
@@ -153,63 +154,74 @@ public class PortletTracker
 			return null;
 		}
 
-		com.liferay.portal.kernel.model.Portlet portletModel =
-			_portletLocalService.getPortletById(portletId);
+		Long companyId = (Long)serviceReference.getProperty(
+			"com.liferay.portlet.company");
 
-		if (portletModel != null) {
-			_log.error("Portlet id " + portletId + " is already in use");
-
-			_bundleContext.ungetService(serviceReference);
-
-			return null;
+		if (companyId == null) {
+			companyId = CompanyThreadLocal.getNonsystemCompanyId();
 		}
 
-		if (_log.isInfoEnabled()) {
-			_log.info("Adding " + serviceReference);
-		}
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
-		String finalPortletName = portletName;
-		String finalPortletId = portletId;
+			com.liferay.portal.kernel.model.Portlet portletModel =
+				_portletLocalService.getPortletById(portletId);
 
-		FutureTask<com.liferay.portal.kernel.model.Portlet> futureTask =
-			new FutureTask<>(
-				new CompanyInheritableThreadLocalCallable<>(
-					() -> {
-						com.liferay.portal.kernel.model.Portlet
-							addedPortletModel = _addingPortlet(
-								serviceReference, portlet, finalPortletName,
-								finalPortletId);
+			if (portletModel != null) {
+				_log.error("Portlet id " + portletId + " is already in use");
 
-						if (addedPortletModel == null) {
-							_bundleContext.ungetService(serviceReference);
-						}
+				_bundleContext.ungetService(serviceReference);
 
-						return addedPortletModel;
-					}));
-
-		if (_parallel &&
-			GetterUtil.getBoolean(
-				serviceReference.getProperty(
-					"com.liferay.portlet.deploy.parallel"),
-				true)) {
-
-			ExecutorService executorService =
-				SystemExecutorServiceUtil.getExecutorService();
-
-			executorService.submit(futureTask);
-		}
-		else {
-			futureTask.run();
-		}
-
-		return () -> {
-			try {
-				return futureTask.get();
+				return null;
 			}
-			catch (Exception exception) {
-				return ReflectionUtil.throwException(exception);
+
+			if (_log.isInfoEnabled()) {
+				_log.info("Adding " + serviceReference);
 			}
-		};
+
+			String finalPortletName = portletName;
+			String finalPortletId = portletId;
+
+			FutureTask<com.liferay.portal.kernel.model.Portlet> futureTask =
+				new FutureTask<>(
+					new CompanyInheritableThreadLocalCallable<>(
+						() -> {
+							com.liferay.portal.kernel.model.Portlet
+								addedPortletModel = _addingPortlet(
+									serviceReference, portlet, finalPortletName,
+									finalPortletId);
+
+							if (addedPortletModel == null) {
+								_bundleContext.ungetService(serviceReference);
+							}
+
+							return addedPortletModel;
+						}));
+
+			if (_parallel &&
+				GetterUtil.getBoolean(
+					serviceReference.getProperty(
+						"com.liferay.portlet.deploy.parallel"),
+					true)) {
+
+				ExecutorService executorService =
+					SystemExecutorServiceUtil.getExecutorService();
+
+				executorService.submit(futureTask);
+			}
+			else {
+				futureTask.run();
+			}
+
+			return () -> {
+				try {
+					return futureTask.get();
+				}
+				catch (Exception exception) {
+					return ReflectionUtil.throwException(exception);
+				}
+			};
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Reference: 
 * https://liferay.atlassian.net/browse/LPD-59412
 * https://liferay.atlassian.net/browse/LPP-59291

In this PR we are making PortletTracker using the virtual instance targeted by the portlet when adding it. This makes this process work not just when deploying the CX but also when restarting the portal.

:warning: Please review thoroughly. I think this is safe, but please help to identify potential use cases that might be broken :warning: 

:warning: PortletTracker tests are off when DB Partitioning is enabled. So I'm not writing tests here as it looks like PortletTracker tests are to be improved:warning: 

Thank you