### PR TITLE
LPD-58667 Improve CompanyLocalServiceTest execution times

### DIFF
--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -77,7 +77,6 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -216,10 +215,14 @@ public class CompanyLocalServiceTest {
 		_companyLocalService.deleteCompany(_deletedCompany);
 
 		_cleanupData();
+
+		_exportedCompany = addCompany();
 	}
 
 	@AfterClass
-	public static void tearDownClass() {
+	public static void tearDownClass() throws Exception {
+		_companyLocalService.deleteCompany(_exportedCompany);
+
 		if (_safeCloseable != null) {
 			_safeCloseable.close();
 		}
@@ -876,38 +879,36 @@ public class CompanyLocalServiceTest {
 	public void testExportCompany() throws Exception {
 		Assume.assumeTrue(_db.isSupportsDBPartition());
 
-		Company company = CompanyTestUtil.addCompany();
-
 		try {
 			Configuration configuration =
 				CompanyLocalServiceTestUtil.createFactoryConfiguration(
-					_configurationAdmin, company.getCompanyId());
+					_configurationAdmin, _exportedCompany.getCompanyId());
 
 			String pid = configuration.getPid();
 
-			_companyLocalService.exportCompany(company.getCompanyId());
+			_companyLocalService.exportCompany(_exportedCompany.getCompanyId());
 
 			Assert.assertTrue(
 				ArrayUtil.contains(
 					CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
-					company.getCompanyId()));
+					_exportedCompany.getCompanyId()));
 			Assert.assertTrue(
 				_dbPartitionDB.existsPartition(
 					_connection,
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						company.getCompanyId())));
+						_exportedCompany.getCompanyId())));
 
 			CompanyLocalServiceTestUtil.checkStandaloneDBPartitionTables(
 				_connection, _dbPartitionDB,
 				CompanyLocalServiceTestUtil.getExportedPartitionName(
-					company.getCompanyId()),
+					_exportedCompany.getCompanyId()),
 				"Company", "VirtualHost");
 
 			Collection<ServiceReference<Portlet>> serviceReferences =
 				_bundleContext.getServiceReferences(
 					Portlet.class,
-					"(com.liferay.portlet.company=" + company.getCompanyId() +
-						")");
+					"(com.liferay.portlet.company=" +
+						_exportedCompany.getCompanyId() + ")");
 
 			Assert.assertFalse(serviceReferences.isEmpty());
 
@@ -918,9 +919,7 @@ public class CompanyLocalServiceTest {
 			_db.runSQL(
 				_dbPartitionDB.getDropPartitionSQL(
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						company.getCompanyId())));
-
-			_companyLocalService.deleteCompany(company);
+						_exportedCompany.getCompanyId())));
 		}
 	}
 
@@ -945,10 +944,8 @@ public class CompanyLocalServiceTest {
 	public void testExportCompanyWhenDBPartitionUtilFails() throws Exception {
 		Assume.assumeTrue(_db.isSupportsDBPartition());
 
-		Company company = CompanyTestUtil.addCompany();
-
-		int tablesCount = _getTablesCount(company.getCompanyId());
-		int viewsCount = _getViewsCount(company.getCompanyId());
+		int tablesCount = _getTablesCount(_exportedCompany.getCompanyId());
+		int viewsCount = _getViewsCount(_exportedCompany.getCompanyId());
 
 		try (AutoCloseable autoCloseable =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
@@ -968,7 +965,7 @@ public class CompanyLocalServiceTest {
 							return method.invoke(_dbPartitionDB, args);
 						}))) {
 
-			_companyLocalService.exportCompany(company.getCompanyId());
+			_companyLocalService.exportCompany(_exportedCompany.getCompanyId());
 
 			Assert.fail();
 		}
@@ -976,24 +973,22 @@ public class CompanyLocalServiceTest {
 			Assert.assertTrue(
 				ArrayUtil.contains(
 					CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
-					company.getCompanyId()));
+					_exportedCompany.getCompanyId()));
 			Assert.assertEquals(
-				tablesCount, _getTablesCount(company.getCompanyId()));
+				tablesCount, _getTablesCount(_exportedCompany.getCompanyId()));
 			Assert.assertEquals(
-				viewsCount, _getViewsCount(company.getCompanyId()));
+				viewsCount, _getViewsCount(_exportedCompany.getCompanyId()));
 			Assert.assertFalse(
 				_dbPartitionDB.existsPartition(
 					_connection,
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						company.getCompanyId())));
+						_exportedCompany.getCompanyId())));
 		}
 		finally {
 			_db.runSQL(
 				_dbPartitionDB.getDropPartitionSQL(
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						company.getCompanyId())));
-
-			_companyLocalService.deleteCompany(company);
+						_exportedCompany.getCompanyId())));
 		}
 	}
 
@@ -1606,6 +1601,7 @@ public class CompanyLocalServiceTest {
 	private static DB _db;
 	private static DBPartitionDB _dbPartitionDB;
 	private static Company _deletedCompany;
+	private static Company _exportedCompany;
 	private static List<String> _modelListenerList;
 
 	@Inject

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -225,16 +225,12 @@ public class CompanyLocalServiceTest {
 
 		_cleanupData();
 
-		_exportedCompany = addCompany();
-
-		_updatedCompany = addCompany();
+		_company = addCompany();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
-		_companyLocalService.deleteCompany(_exportedCompany);
-
-		_companyLocalService.deleteCompany(_updatedCompany);
+		_companyLocalService.deleteCompany(_company);
 
 		_cleanupData();
 
@@ -897,33 +893,33 @@ public class CompanyLocalServiceTest {
 		try {
 			Configuration configuration =
 				CompanyLocalServiceTestUtil.createFactoryConfiguration(
-					_configurationAdmin, _exportedCompany.getCompanyId());
+					_configurationAdmin, _company.getCompanyId());
 
 			String pid = configuration.getPid();
 
-			_companyLocalService.exportCompany(_exportedCompany.getCompanyId());
+			_companyLocalService.exportCompany(_company.getCompanyId());
 
 			Assert.assertTrue(
 				ArrayUtil.contains(
 					CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
-					_exportedCompany.getCompanyId()));
+					_company.getCompanyId()));
 			Assert.assertTrue(
 				_dbPartitionDB.existsPartition(
 					_connection,
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						_exportedCompany.getCompanyId())));
+						_company.getCompanyId())));
 
 			CompanyLocalServiceTestUtil.checkStandaloneDBPartitionTables(
 				_connection, _dbPartitionDB,
 				CompanyLocalServiceTestUtil.getExportedPartitionName(
-					_exportedCompany.getCompanyId()),
+					_company.getCompanyId()),
 				"Company", "VirtualHost");
 
 			Collection<ServiceReference<Portlet>> serviceReferences =
 				_bundleContext.getServiceReferences(
 					Portlet.class,
-					"(com.liferay.portlet.company=" +
-						_exportedCompany.getCompanyId() + ")");
+					"(com.liferay.portlet.company=" + _company.getCompanyId() +
+						")");
 
 			Assert.assertFalse(serviceReferences.isEmpty());
 
@@ -934,7 +930,7 @@ public class CompanyLocalServiceTest {
 			_db.runSQL(
 				_dbPartitionDB.getDropPartitionSQL(
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						_exportedCompany.getCompanyId())));
+						_company.getCompanyId())));
 		}
 	}
 
@@ -959,8 +955,8 @@ public class CompanyLocalServiceTest {
 	public void testExportCompanyWhenDBPartitionUtilFails() throws Exception {
 		Assume.assumeTrue(_db.isSupportsDBPartition());
 
-		int tablesCount = _getTablesCount(_exportedCompany.getCompanyId());
-		int viewsCount = _getViewsCount(_exportedCompany.getCompanyId());
+		int tablesCount = _getTablesCount(_company.getCompanyId());
+		int viewsCount = _getViewsCount(_company.getCompanyId());
 
 		try (AutoCloseable autoCloseable =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
@@ -980,7 +976,7 @@ public class CompanyLocalServiceTest {
 							return method.invoke(_dbPartitionDB, args);
 						}))) {
 
-			_companyLocalService.exportCompany(_exportedCompany.getCompanyId());
+			_companyLocalService.exportCompany(_company.getCompanyId());
 
 			Assert.fail();
 		}
@@ -988,22 +984,22 @@ public class CompanyLocalServiceTest {
 			Assert.assertTrue(
 				ArrayUtil.contains(
 					CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
-					_exportedCompany.getCompanyId()));
+					_company.getCompanyId()));
 			Assert.assertEquals(
-				tablesCount, _getTablesCount(_exportedCompany.getCompanyId()));
+				tablesCount, _getTablesCount(_company.getCompanyId()));
 			Assert.assertEquals(
-				viewsCount, _getViewsCount(_exportedCompany.getCompanyId()));
+				viewsCount, _getViewsCount(_company.getCompanyId()));
 			Assert.assertFalse(
 				_dbPartitionDB.existsPartition(
 					_connection,
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						_exportedCompany.getCompanyId())));
+						_company.getCompanyId())));
 		}
 		finally {
 			_db.runSQL(
 				_dbPartitionDB.getDropPartitionSQL(
 					CompanyLocalServiceTestUtil.getExportedPartitionName(
-						_exportedCompany.getCompanyId())));
+						_company.getCompanyId())));
 		}
 	}
 
@@ -1051,21 +1047,21 @@ public class CompanyLocalServiceTest {
 	public void testUpdateCompanyLocales() throws Exception {
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-				_updatedCompany.getCompanyId());
+				_company.getCompanyId());
 
 		String originalLanguageId = LocaleUtil.toLanguageId(
-			_updatedCompany.getLocale());
+			_company.getLocale());
 
-		TimeZone timeZone = _updatedCompany.getTimeZone();
+		TimeZone timeZone = _company.getTimeZone();
 
 		try {
 			String languageId = "ca_ES";
 
 			_companyLocalService.updateDisplay(
-				_updatedCompany.getCompanyId(), languageId, timeZone.getID());
+				_company.getCompanyId(), languageId, timeZone.getID());
 
 			_companyLocalService.updatePreferences(
-				_updatedCompany.getCompanyId(),
+				_company.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageId
 				).build());
@@ -1076,10 +1072,9 @@ public class CompanyLocalServiceTest {
 		}
 		finally {
 			_companyLocalService.updateDisplay(
-				_updatedCompany.getCompanyId(), originalLanguageId,
-				timeZone.getID());
+				_company.getCompanyId(), originalLanguageId, timeZone.getID());
 
-			_resetCompanyLocales(_updatedCompany.getCompanyId());
+			_resetCompanyLocales(_company.getCompanyId());
 
 			safeCloseable.close();
 		}
@@ -1089,20 +1084,19 @@ public class CompanyLocalServiceTest {
 	public void testUpdateCompanyLocalesUpdateGroupLocales() throws Exception {
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-				_updatedCompany.getCompanyId());
+				_company.getCompanyId());
 
 		String[] companyLanguageIds = _prefsProps.getStringArray(
-			_updatedCompany.getCompanyId(), PropsKeys.LOCALES, StringPool.COMMA,
+			_company.getCompanyId(), PropsKeys.LOCALES, StringPool.COMMA,
 			PropsValues.LOCALES_ENABLED);
 
 		Group group = null;
 
 		try {
-			User user = UserTestUtil.getAdminUser(
-				_updatedCompany.getCompanyId());
+			User user = UserTestUtil.getAdminUser(_company.getCompanyId());
 
 			group = GroupTestUtil.addGroup(
-				_updatedCompany.getCompanyId(), user.getUserId(),
+				_company.getCompanyId(), user.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			group = GroupTestUtil.updateDisplaySettings(
@@ -1122,7 +1116,7 @@ public class CompanyLocalServiceTest {
 			String languageIds = "en_US";
 
 			_companyLocalService.updatePreferences(
-				_updatedCompany.getCompanyId(),
+				_company.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageIds
 				).build());
@@ -1130,7 +1124,7 @@ public class CompanyLocalServiceTest {
 			Assert.assertEquals(
 				languageIds,
 				_prefsProps.getString(
-					_updatedCompany.getCompanyId(), PropsKeys.LOCALES));
+					_company.getCompanyId(), PropsKeys.LOCALES));
 
 			group = _groupLocalService.getGroup(group.getGroupId());
 
@@ -1145,7 +1139,7 @@ public class CompanyLocalServiceTest {
 			languageIds = "ca_ES,en_US";
 
 			_companyLocalService.updatePreferences(
-				_updatedCompany.getCompanyId(),
+				_company.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageIds
 				).build());
@@ -1161,7 +1155,7 @@ public class CompanyLocalServiceTest {
 					PropsKeys.LOCALES));
 		}
 		finally {
-			_resetCompanyLocales(_updatedCompany.getCompanyId());
+			_resetCompanyLocales(_company.getCompanyId());
 
 			GroupTestUtil.deleteGroup(group);
 
@@ -1175,14 +1169,14 @@ public class CompanyLocalServiceTest {
 
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-				_updatedCompany.getCompanyId());
+				_company.getCompanyId());
 
-		long companyId = _updatedCompany.getCompanyId();
+		long companyId = _company.getCompanyId();
 
 		String originalLanguageId = LocaleUtil.toLanguageId(
-			_updatedCompany.getLocale());
+			_company.getLocale());
 
-		TimeZone timeZone = _updatedCompany.getTimeZone();
+		TimeZone timeZone = _company.getTimeZone();
 
 		LayoutSetPrototype layoutSetPrototype = null;
 
@@ -1195,10 +1189,10 @@ public class CompanyLocalServiceTest {
 			String languageId = "ca_ES";
 
 			_companyLocalService.updateDisplay(
-				_updatedCompany.getCompanyId(), languageId, timeZone.getID());
+				_company.getCompanyId(), languageId, timeZone.getID());
 
 			_companyLocalService.updatePreferences(
-				_updatedCompany.getCompanyId(),
+				_company.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageId
 				).build());
@@ -1212,13 +1206,12 @@ public class CompanyLocalServiceTest {
 				layoutSetPrototype);
 
 			_companyLocalService.updateDisplay(
-				_updatedCompany.getCompanyId(), originalLanguageId,
-				timeZone.getID());
+				_company.getCompanyId(), originalLanguageId, timeZone.getID());
 
 			ActionableDynamicQuery actionableDynamicQuery =
 				_systemEventLocalService.getActionableDynamicQuery();
 
-			actionableDynamicQuery.setCompanyId(_updatedCompany.getCompanyId());
+			actionableDynamicQuery.setCompanyId(_company.getCompanyId());
 
 			actionableDynamicQuery.setPerformActionMethod(
 				(SystemEvent systemEvent) ->
@@ -1226,7 +1219,7 @@ public class CompanyLocalServiceTest {
 
 			actionableDynamicQuery.performActions();
 
-			_resetCompanyLocales(_updatedCompany.getCompanyId());
+			_resetCompanyLocales(_company.getCompanyId());
 
 			safeCloseable.close();
 		}
@@ -1236,34 +1229,31 @@ public class CompanyLocalServiceTest {
 	public void testUpdateDisplay() throws Exception {
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-				_updatedCompany.getCompanyId());
+				_company.getCompanyId());
 
 		String originalLanguageId = LocaleUtil.toLanguageId(
-			_updatedCompany.getLocale());
+			_company.getLocale());
 
-		TimeZone timeZone = _updatedCompany.getTimeZone();
+		TimeZone timeZone = _company.getTimeZone();
 
 		try {
-			User user = _userLocalService.getGuestUser(
-				_updatedCompany.getCompanyId());
+			User user = _userLocalService.getGuestUser(_company.getCompanyId());
 
 			_userLocalService.updateUser(user);
 
 			String languageId = LocaleUtil.toLanguageId(LocaleUtil.HUNGARY);
 
 			_companyLocalService.updateDisplay(
-				_updatedCompany.getCompanyId(), languageId, "CET");
+				_company.getCompanyId(), languageId, "CET");
 
-			user = _userLocalService.getGuestUser(
-				_updatedCompany.getCompanyId());
+			user = _userLocalService.getGuestUser(_company.getCompanyId());
 
 			Assert.assertEquals(languageId, user.getLanguageId());
 			Assert.assertEquals("CET", user.getTimeZoneId());
 		}
 		finally {
 			_companyLocalService.updateDisplay(
-				_updatedCompany.getCompanyId(), originalLanguageId,
-				timeZone.getID());
+				_company.getCompanyId(), originalLanguageId, timeZone.getID());
 
 			safeCloseable.close();
 		}
@@ -1273,34 +1263,32 @@ public class CompanyLocalServiceTest {
 	public void testUpdateInvalidCompanyNames() throws Exception {
 		SafeCloseable safeCloseable =
 			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-				_updatedCompany.getCompanyId());
+				_company.getCompanyId());
 
-		String companyName = _updatedCompany.getName();
+		String companyName = _company.getName();
 
 		Group group = null;
 
 		try {
-			long companyId = _updatedCompany.getCompanyId();
+			long companyId = _company.getCompanyId();
 
 			group = GroupTestUtil.addGroup(
 				companyId, _userLocalService.getGuestUserId(companyId),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			testUpdateCompanyNames(
-				_updatedCompany,
+				_company,
 				new String[] {StringPool.BLANK, group.getDescriptiveName()},
 				true);
 		}
 		finally {
-			_updatedCompany = _companyLocalService.updateCompany(
-				_updatedCompany.getCompanyId(),
-				_updatedCompany.getVirtualHostname(), _updatedCompany.getMx(),
-				_updatedCompany.getHomeURL(), true, null, companyName,
-				_updatedCompany.getLegalName(), _updatedCompany.getLegalId(),
-				_updatedCompany.getLegalType(), _updatedCompany.getSicCode(),
-				_updatedCompany.getTickerSymbol(),
-				_updatedCompany.getIndustry(), _updatedCompany.getType(),
-				_updatedCompany.getSize());
+			_company = _companyLocalService.updateCompany(
+				_company.getCompanyId(), _company.getVirtualHostname(),
+				_company.getMx(), _company.getHomeURL(), true, null,
+				companyName, _company.getLegalName(), _company.getLegalId(),
+				_company.getLegalType(), _company.getSicCode(),
+				_company.getTickerSymbol(), _company.getIndustry(),
+				_company.getType(), _company.getSize());
 
 			GroupTestUtil.deleteGroup(group);
 
@@ -1330,23 +1318,20 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testUpdateValidCompanyNames() throws Exception {
-		String companyName = _updatedCompany.getName();
+		String companyName = _company.getName();
 
 		try {
 			testUpdateCompanyNames(
-				_updatedCompany, new String[] {RandomTestUtil.randomString()},
-				false);
+				_company, new String[] {RandomTestUtil.randomString()}, false);
 		}
 		finally {
-			_updatedCompany = _companyLocalService.updateCompany(
-				_updatedCompany.getCompanyId(),
-				_updatedCompany.getVirtualHostname(), _updatedCompany.getMx(),
-				_updatedCompany.getHomeURL(), true, null, companyName,
-				_updatedCompany.getLegalName(), _updatedCompany.getLegalId(),
-				_updatedCompany.getLegalType(), _updatedCompany.getSicCode(),
-				_updatedCompany.getTickerSymbol(),
-				_updatedCompany.getIndustry(), _updatedCompany.getType(),
-				_updatedCompany.getSize());
+			_company = _companyLocalService.updateCompany(
+				_company.getCompanyId(), _company.getVirtualHostname(),
+				_company.getMx(), _company.getHomeURL(), true, null,
+				companyName, _company.getLegalName(), _company.getLegalId(),
+				_company.getLegalType(), _company.getSicCode(),
+				_company.getTickerSymbol(), _company.getIndustry(),
+				_company.getType(), _company.getSize());
 		}
 	}
 
@@ -1458,24 +1443,22 @@ public class CompanyLocalServiceTest {
 	protected void testUpdateMx(String mx, boolean valid, boolean mailMxUpdate)
 		throws Exception {
 
-		String originalMx = _updatedCompany.getMx();
+		String originalMx = _company.getMx();
 
 		try (SafeCloseable safeCloseable1 =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"MAIL_MX_UPDATE", mailMxUpdate);
 			SafeCloseable safeCloseable2 =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					_updatedCompany.getCompanyId())) {
+					_company.getCompanyId())) {
 
 			_companyLocalService.updateCompany(
-				_updatedCompany.getCompanyId(),
-				_updatedCompany.getVirtualHostname(), mx,
-				_updatedCompany.getMaxUsers(), _updatedCompany.isActive());
+				_company.getCompanyId(), _company.getVirtualHostname(), mx,
+				_company.getMaxUsers(), _company.isActive());
 
-			_updatedCompany = _companyLocalService.getCompany(
-				_updatedCompany.getCompanyId());
+			_company = _companyLocalService.getCompany(_company.getCompanyId());
 
-			String updatedMx = _updatedCompany.getMx();
+			String updatedMx = _company.getMx();
 
 			if (valid && mailMxUpdate) {
 				Assert.assertNotEquals(originalMx, updatedMx);
@@ -1493,10 +1476,9 @@ public class CompanyLocalServiceTest {
 			Assert.assertTrue(mailMxUpdate);
 		}
 		finally {
-			_updatedCompany = _companyLocalService.updateCompany(
-				_updatedCompany.getCompanyId(),
-				_updatedCompany.getVirtualHostname(), originalMx,
-				_updatedCompany.getMaxUsers(), _updatedCompany.isActive());
+			_company = _companyLocalService.updateCompany(
+				_company.getCompanyId(), _company.getVirtualHostname(),
+				originalMx, _company.getMaxUsers(), _company.isActive());
 		}
 	}
 
@@ -1509,17 +1491,17 @@ public class CompanyLocalServiceTest {
 		try {
 			originalVirtualHost =
 				_virtualHostLocalService.fetchCompanyDefaultVirtualHost(
-					_updatedCompany.getCompanyId());
+					_company.getCompanyId());
 
 			for (String virtualHostname : virtualHostnames) {
 				try (SafeCloseable safeCloseable =
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							_updatedCompany.getCompanyId())) {
+							_company.getCompanyId())) {
 
 					_companyLocalService.updateCompany(
-						_updatedCompany.getCompanyId(), virtualHostname,
-						_updatedCompany.getMx(), _updatedCompany.getMaxUsers(),
-						_updatedCompany.isActive());
+						_company.getCompanyId(), virtualHostname,
+						_company.getMx(), _company.getMaxUsers(),
+						_company.isActive());
 
 					Assert.assertFalse(expectFailure);
 				}
@@ -1537,7 +1519,7 @@ public class CompanyLocalServiceTest {
 		finally {
 			VirtualHost currentVirtualHost =
 				_virtualHostLocalService.fetchCompanyDefaultVirtualHost(
-					_updatedCompany.getCompanyId());
+					_company.getCompanyId());
 
 			String originalVirtualHostname = originalVirtualHost.getHostname();
 
@@ -1549,10 +1531,9 @@ public class CompanyLocalServiceTest {
 
 			_virtualHostLocalService.updateVirtualHost(originalVirtualHost);
 
-			_updatedCompany = _companyLocalService.updateCompany(
-				_updatedCompany.getCompanyId(), originalVirtualHostname,
-				_updatedCompany.getMx(), _updatedCompany.getMaxUsers(),
-				_updatedCompany.isActive());
+			_company = _companyLocalService.updateCompany(
+				_company.getCompanyId(), originalVirtualHostname,
+				_company.getMx(), _company.getMaxUsers(), _company.isActive());
 		}
 	}
 
@@ -1731,6 +1712,7 @@ public class CompanyLocalServiceTest {
 	private static ClassNameLocalService _classNameLocalService;
 
 	private static List<ClassName> _classNames;
+	private static Company _company;
 
 	@Inject
 	private static CompanyLocalService _companyLocalService;
@@ -1743,7 +1725,6 @@ public class CompanyLocalServiceTest {
 	private static DB _db;
 	private static DBPartitionDB _dbPartitionDB;
 	private static Company _deletedCompany;
-	private static Company _exportedCompany;
 	private static List<String> _modelListenerList;
 
 	@Inject
@@ -1757,7 +1738,6 @@ public class CompanyLocalServiceTest {
 	private static SystemEventLocalService _systemEventLocalService;
 
 	private static final TransactionConfig _transactionConfig;
-	private static Company _updatedCompany;
 
 	@Inject
 	private static UserGroupLocalService _userGroupLocalService;

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -30,7 +30,9 @@ import com.liferay.portal.kernel.backgroundtask.BackgroundTaskThreadLocal;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.CompanyMxException;
 import com.liferay.portal.kernel.exception.CompanyNameException;
@@ -40,6 +42,7 @@ import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.RequiredCompanyException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -52,11 +55,15 @@ import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.model.PasswordPolicyTable;
+import com.liferay.portal.kernel.model.PortalPreferenceValue;
 import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.UserGroupRole;
+import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -65,10 +72,12 @@ import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
+import com.liferay.portal.kernel.service.PortalPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.SystemEventLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -217,11 +226,17 @@ public class CompanyLocalServiceTest {
 		_cleanupData();
 
 		_exportedCompany = addCompany();
+
+		_updatedCompany = addCompany();
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_companyLocalService.deleteCompany(_exportedCompany);
+
+		_companyLocalService.deleteCompany(_updatedCompany);
+
+		_cleanupData();
 
 		if (_safeCloseable != null) {
 			_safeCloseable.close();
@@ -1034,20 +1049,23 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testUpdateCompanyLocales() throws Exception {
-		Company company = addCompany();
-		String languageId = "ca_ES";
+		SafeCloseable safeCloseable =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				_updatedCompany.getCompanyId());
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
+		String originalLanguageId = LocaleUtil.toLanguageId(
+			_updatedCompany.getLocale());
 
-			TimeZone timeZone = company.getTimeZone();
+		TimeZone timeZone = _updatedCompany.getTimeZone();
+
+		try {
+			String languageId = "ca_ES";
 
 			_companyLocalService.updateDisplay(
-				company.getCompanyId(), languageId, timeZone.getID());
+				_updatedCompany.getCompanyId(), languageId, timeZone.getID());
 
 			_companyLocalService.updatePreferences(
-				company.getCompanyId(),
+				_updatedCompany.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageId
 				).build());
@@ -1057,26 +1075,34 @@ public class CompanyLocalServiceTest {
 				_language.getAvailableLocales());
 		}
 		finally {
-			_companyLocalService.deleteCompany(company);
+			_companyLocalService.updateDisplay(
+				_updatedCompany.getCompanyId(), originalLanguageId,
+				timeZone.getID());
+
+			_resetCompanyLocales(_updatedCompany.getCompanyId());
+
+			safeCloseable.close();
 		}
 	}
 
 	@Test
 	public void testUpdateCompanyLocalesUpdateGroupLocales() throws Exception {
-		Company company = addCompany();
+		SafeCloseable safeCloseable =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				_updatedCompany.getCompanyId());
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
+		String[] companyLanguageIds = _prefsProps.getStringArray(
+			_updatedCompany.getCompanyId(), PropsKeys.LOCALES, StringPool.COMMA,
+			PropsValues.LOCALES_ENABLED);
 
-			String[] companyLanguageIds = _prefsProps.getStringArray(
-				company.getCompanyId(), PropsKeys.LOCALES, StringPool.COMMA,
-				PropsValues.LOCALES_ENABLED);
+		Group group = null;
 
-			User user = UserTestUtil.getAdminUser(company.getCompanyId());
+		try {
+			User user = UserTestUtil.getAdminUser(
+				_updatedCompany.getCompanyId());
 
-			Group group = GroupTestUtil.addGroup(
-				company.getCompanyId(), user.getUserId(),
+			group = GroupTestUtil.addGroup(
+				_updatedCompany.getCompanyId(), user.getUserId(),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			group = GroupTestUtil.updateDisplaySettings(
@@ -1096,7 +1122,7 @@ public class CompanyLocalServiceTest {
 			String languageIds = "en_US";
 
 			_companyLocalService.updatePreferences(
-				company.getCompanyId(),
+				_updatedCompany.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageIds
 				).build());
@@ -1104,7 +1130,7 @@ public class CompanyLocalServiceTest {
 			Assert.assertEquals(
 				languageIds,
 				_prefsProps.getString(
-					company.getCompanyId(), PropsKeys.LOCALES));
+					_updatedCompany.getCompanyId(), PropsKeys.LOCALES));
 
 			group = _groupLocalService.getGroup(group.getGroupId());
 
@@ -1119,7 +1145,7 @@ public class CompanyLocalServiceTest {
 			languageIds = "ca_ES,en_US";
 
 			_companyLocalService.updatePreferences(
-				company.getCompanyId(),
+				_updatedCompany.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageIds
 				).build());
@@ -1135,7 +1161,11 @@ public class CompanyLocalServiceTest {
 					PropsKeys.LOCALES));
 		}
 		finally {
-			_companyLocalService.deleteCompany(company);
+			_resetCompanyLocales(_updatedCompany.getCompanyId());
+
+			GroupTestUtil.deleteGroup(group);
+
+			safeCloseable.close();
 		}
 	}
 
@@ -1143,28 +1173,32 @@ public class CompanyLocalServiceTest {
 	public void testUpdateCompanyLocalesWithLayoutSetPrototype()
 		throws Exception {
 
-		Company company = addCompany();
+		SafeCloseable safeCloseable =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				_updatedCompany.getCompanyId());
 
-		long companyId = company.getCompanyId();
+		long companyId = _updatedCompany.getCompanyId();
 
-		String languageId = "ca_ES";
+		String originalLanguageId = LocaleUtil.toLanguageId(
+			_updatedCompany.getLocale());
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
+		TimeZone timeZone = _updatedCompany.getTimeZone();
 
+		LayoutSetPrototype layoutSetPrototype = null;
+
+		try {
 			long userId = _userLocalService.getGuestUserId(companyId);
 
-			addLayoutSetPrototype(
+			layoutSetPrototype = addLayoutSetPrototype(
 				companyId, userId, RandomTestUtil.randomString());
 
-			TimeZone timeZone = company.getTimeZone();
+			String languageId = "ca_ES";
 
 			_companyLocalService.updateDisplay(
-				company.getCompanyId(), languageId, timeZone.getID());
+				_updatedCompany.getCompanyId(), languageId, timeZone.getID());
 
 			_companyLocalService.updatePreferences(
-				company.getCompanyId(),
+				_updatedCompany.getCompanyId(),
 				UnicodePropertiesBuilder.put(
 					PropsKeys.LOCALES, languageId
 				).build());
@@ -1174,58 +1208,103 @@ public class CompanyLocalServiceTest {
 				_language.getAvailableLocales());
 		}
 		finally {
-			_companyLocalService.deleteCompany(company);
+			_layoutSetPrototypeLocalService.deleteLayoutSetPrototype(
+				layoutSetPrototype);
+
+			_companyLocalService.updateDisplay(
+				_updatedCompany.getCompanyId(), originalLanguageId,
+				timeZone.getID());
+
+			ActionableDynamicQuery actionableDynamicQuery =
+				_systemEventLocalService.getActionableDynamicQuery();
+
+			actionableDynamicQuery.setCompanyId(_updatedCompany.getCompanyId());
+
+			actionableDynamicQuery.setPerformActionMethod(
+				(SystemEvent systemEvent) ->
+					_systemEventLocalService.deleteSystemEvent(systemEvent));
+
+			actionableDynamicQuery.performActions();
+
+			_resetCompanyLocales(_updatedCompany.getCompanyId());
+
+			safeCloseable.close();
 		}
 	}
 
 	@Test
 	public void testUpdateDisplay() throws Exception {
-		Company company = addCompany();
+		SafeCloseable safeCloseable =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				_updatedCompany.getCompanyId());
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
+		String originalLanguageId = LocaleUtil.toLanguageId(
+			_updatedCompany.getLocale());
 
-			User user = _userLocalService.getGuestUser(company.getCompanyId());
+		TimeZone timeZone = _updatedCompany.getTimeZone();
+
+		try {
+			User user = _userLocalService.getGuestUser(
+				_updatedCompany.getCompanyId());
 
 			_userLocalService.updateUser(user);
 
 			String languageId = LocaleUtil.toLanguageId(LocaleUtil.HUNGARY);
 
 			_companyLocalService.updateDisplay(
-				company.getCompanyId(), languageId, "CET");
+				_updatedCompany.getCompanyId(), languageId, "CET");
 
-			user = _userLocalService.getGuestUser(company.getCompanyId());
+			user = _userLocalService.getGuestUser(
+				_updatedCompany.getCompanyId());
 
 			Assert.assertEquals(languageId, user.getLanguageId());
 			Assert.assertEquals("CET", user.getTimeZoneId());
 		}
 		finally {
-			_companyLocalService.deleteCompany(company.getCompanyId());
+			_companyLocalService.updateDisplay(
+				_updatedCompany.getCompanyId(), originalLanguageId,
+				timeZone.getID());
+
+			safeCloseable.close();
 		}
 	}
 
 	@Test
 	public void testUpdateInvalidCompanyNames() throws Exception {
-		Company company = addCompany();
+		SafeCloseable safeCloseable =
+			CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				_updatedCompany.getCompanyId());
 
-		long companyId = company.getCompanyId();
+		String companyName = _updatedCompany.getName();
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
+		Group group = null;
 
-			Group group = GroupTestUtil.addGroup(
+		try {
+			long companyId = _updatedCompany.getCompanyId();
+
+			group = GroupTestUtil.addGroup(
 				companyId, _userLocalService.getGuestUserId(companyId),
 				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
 			testUpdateCompanyNames(
-				company,
+				_updatedCompany,
 				new String[] {StringPool.BLANK, group.getDescriptiveName()},
 				true);
 		}
 		finally {
-			_companyLocalService.deleteCompany(companyId);
+			_updatedCompany = _companyLocalService.updateCompany(
+				_updatedCompany.getCompanyId(),
+				_updatedCompany.getVirtualHostname(), _updatedCompany.getMx(),
+				_updatedCompany.getHomeURL(), true, null, companyName,
+				_updatedCompany.getLegalName(), _updatedCompany.getLegalId(),
+				_updatedCompany.getLegalType(), _updatedCompany.getSicCode(),
+				_updatedCompany.getTickerSymbol(),
+				_updatedCompany.getIndustry(), _updatedCompany.getType(),
+				_updatedCompany.getSize());
+
+			GroupTestUtil.deleteGroup(group);
+
+			safeCloseable.close();
 		}
 	}
 
@@ -1251,14 +1330,23 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testUpdateValidCompanyNames() throws Exception {
-		Company company = addCompany();
+		String companyName = _updatedCompany.getName();
 
 		try {
 			testUpdateCompanyNames(
-				company, new String[] {RandomTestUtil.randomString()}, false);
+				_updatedCompany, new String[] {RandomTestUtil.randomString()},
+				false);
 		}
 		finally {
-			_companyLocalService.deleteCompany(company.getCompanyId());
+			_updatedCompany = _companyLocalService.updateCompany(
+				_updatedCompany.getCompanyId(),
+				_updatedCompany.getVirtualHostname(), _updatedCompany.getMx(),
+				_updatedCompany.getHomeURL(), true, null, companyName,
+				_updatedCompany.getLegalName(), _updatedCompany.getLegalId(),
+				_updatedCompany.getLegalType(), _updatedCompany.getSicCode(),
+				_updatedCompany.getTickerSymbol(),
+				_updatedCompany.getIndustry(), _updatedCompany.getType(),
+				_updatedCompany.getSize());
 		}
 	}
 
@@ -1370,24 +1458,24 @@ public class CompanyLocalServiceTest {
 	protected void testUpdateMx(String mx, boolean valid, boolean mailMxUpdate)
 		throws Exception {
 
-		Company company = addCompany();
-
-		String originalMx = company.getMx();
+		String originalMx = _updatedCompany.getMx();
 
 		try (SafeCloseable safeCloseable1 =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"MAIL_MX_UPDATE", mailMxUpdate);
 			SafeCloseable safeCloseable2 =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
+					_updatedCompany.getCompanyId())) {
 
 			_companyLocalService.updateCompany(
-				company.getCompanyId(), company.getVirtualHostname(), mx,
-				company.getMaxUsers(), company.isActive());
+				_updatedCompany.getCompanyId(),
+				_updatedCompany.getVirtualHostname(), mx,
+				_updatedCompany.getMaxUsers(), _updatedCompany.isActive());
 
-			company = _companyLocalService.getCompany(company.getCompanyId());
+			_updatedCompany = _companyLocalService.getCompany(
+				_updatedCompany.getCompanyId());
 
-			String updatedMx = company.getMx();
+			String updatedMx = _updatedCompany.getMx();
 
 			if (valid && mailMxUpdate) {
 				Assert.assertNotEquals(originalMx, updatedMx);
@@ -1405,7 +1493,10 @@ public class CompanyLocalServiceTest {
 			Assert.assertTrue(mailMxUpdate);
 		}
 		finally {
-			_companyLocalService.deleteCompany(company.getCompanyId());
+			_updatedCompany = _companyLocalService.updateCompany(
+				_updatedCompany.getCompanyId(),
+				_updatedCompany.getVirtualHostname(), originalMx,
+				_updatedCompany.getMaxUsers(), _updatedCompany.isActive());
 		}
 	}
 
@@ -1413,18 +1504,22 @@ public class CompanyLocalServiceTest {
 			String[] virtualHostnames, boolean expectFailure)
 		throws Exception {
 
-		Company company = addCompany();
+		VirtualHost originalVirtualHost = null;
 
 		try {
+			originalVirtualHost =
+				_virtualHostLocalService.fetchCompanyDefaultVirtualHost(
+					_updatedCompany.getCompanyId());
+
 			for (String virtualHostname : virtualHostnames) {
 				try (SafeCloseable safeCloseable =
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							company.getCompanyId())) {
+							_updatedCompany.getCompanyId())) {
 
 					_companyLocalService.updateCompany(
-						company.getCompanyId(), virtualHostname,
-						company.getMx(), company.getMaxUsers(),
-						company.isActive());
+						_updatedCompany.getCompanyId(), virtualHostname,
+						_updatedCompany.getMx(), _updatedCompany.getMaxUsers(),
+						_updatedCompany.isActive());
 
 					Assert.assertFalse(expectFailure);
 				}
@@ -1440,7 +1535,24 @@ public class CompanyLocalServiceTest {
 			}
 		}
 		finally {
-			_companyLocalService.deleteCompany(company.getCompanyId());
+			VirtualHost currentVirtualHost =
+				_virtualHostLocalService.fetchCompanyDefaultVirtualHost(
+					_updatedCompany.getCompanyId());
+
+			String originalVirtualHostname = originalVirtualHost.getHostname();
+
+			if (!originalVirtualHostname.equals(
+					currentVirtualHost.getHostname())) {
+
+				_virtualHostLocalService.deleteVirtualHost(currentVirtualHost);
+			}
+
+			_virtualHostLocalService.updateVirtualHost(originalVirtualHost);
+
+			_updatedCompany = _companyLocalService.updateCompany(
+				_updatedCompany.getCompanyId(), originalVirtualHostname,
+				_updatedCompany.getMx(), _updatedCompany.getMaxUsers(),
+				_updatedCompany.isActive());
 		}
 	}
 
@@ -1580,6 +1692,36 @@ public class CompanyLocalServiceTest {
 		return viewNames.size();
 	}
 
+	private void _resetCompanyLocales(long companyId) throws Exception {
+		ActionableDynamicQuery actionableDynamicQuery =
+			_portalPreferenceValueLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.eq("companyId", companyId));
+				dynamicQuery.add(
+					RestrictionsFactoryUtil.eq("key", PropsKeys.LOCALES));
+			});
+
+		actionableDynamicQuery.setPerformActionMethod(
+			(PortalPreferenceValue portalPreferenceValue) ->
+				_portalPreferenceValueLocalService.deletePortalPreferenceValue(
+					portalPreferenceValue));
+
+		actionableDynamicQuery.performActions();
+
+		PortalPreferences portalPreferences =
+			_portalPreferenceValueLocalService.getPortalPreferences(
+				_portalPreferencesLocalService.fetchPortalPreferences(
+					companyId, PortletKeys.PREFS_OWNER_TYPE_COMPANY),
+				false);
+
+		portalPreferences.resetValues(null);
+
+		LanguageUtil.resetAvailableLocales(companyId);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		CompanyLocalServiceTest.class);
 
@@ -1610,7 +1752,12 @@ public class CompanyLocalServiceTest {
 	private static SafeCloseable _safeCloseable;
 	private static final List<ServiceRegistration<?>> _serviceRegistrations =
 		new CopyOnWriteArrayList<>();
+
+	@Inject
+	private static SystemEventLocalService _systemEventLocalService;
+
 	private static final TransactionConfig _transactionConfig;
+	private static Company _updatedCompany;
 
 	@Inject
 	private static UserGroupLocalService _userGroupLocalService;
@@ -1669,6 +1816,10 @@ public class CompanyLocalServiceTest {
 
 	@Inject
 	private PortalPreferencesLocalService _portalPreferencesLocalService;
+
+	@Inject
+	private PortalPreferenceValueLocalService
+		_portalPreferenceValueLocalService;
 
 	@Inject
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceTest.java
@@ -166,6 +166,22 @@ public class CompanyLocalServiceTest {
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
 
+	public static void resetBackgroundTaskThreadLocal() throws Exception {
+		Class<?> backgroundTaskThreadLocalClass =
+			BackgroundTaskThreadLocal.class;
+
+		Field backgroundTaskIdField =
+			backgroundTaskThreadLocalClass.getDeclaredField(
+				"_backgroundTaskId");
+
+		backgroundTaskIdField.setAccessible(true);
+
+		Method setMethod = ThreadLocal.class.getDeclaredMethod(
+			"set", Object.class);
+
+		setMethod.invoke(backgroundTaskIdField.get(null), 0L);
+	}
+
 	@BeforeClass
 	public static void setUpClass() throws Exception {
 		Bundle bundle = FrameworkUtil.getBundle(
@@ -188,6 +204,18 @@ public class CompanyLocalServiceTest {
 			DBPartitionUtil.class, "_dbPartitionDB");
 		_safeCloseable = CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 			PortalInstancePool.getDefaultCompanyId());
+
+		_initializeClassNames();
+
+		_modelListenerList = _registerModelListeners();
+
+		_deletedCompany = addCompany();
+
+		_addCompanyUserGroupRole(_deletedCompany);
+
+		_companyLocalService.deleteCompany(_deletedCompany);
+
+		_cleanupData();
 	}
 
 	@AfterClass
@@ -197,48 +225,14 @@ public class CompanyLocalServiceTest {
 		}
 	}
 
-	public void resetBackgroundTaskThreadLocal() throws Exception {
-		Class<?> backgroundTaskThreadLocalClass =
-			BackgroundTaskThreadLocal.class;
-
-		Field backgroundTaskIdField =
-			backgroundTaskThreadLocalClass.getDeclaredField(
-				"_backgroundTaskId");
-
-		backgroundTaskIdField.setAccessible(true);
-
-		Method setMethod = ThreadLocal.class.getDeclaredMethod(
-			"set", Object.class);
-
-		setMethod.invoke(backgroundTaskIdField.get(null), 0L);
-	}
-
 	@Before
 	public void setUp() throws Exception {
-		_classNames = _classNameLocalService.getClassNames(
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		_initializeClassNames();
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		List<ClassName> classNames = ListUtil.remove(
-			_classNameLocalService.getClassNames(
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
-			_classNames);
-
-		for (ClassName className : classNames) {
-			_classNameLocalService.deleteClassName(className);
-		}
-
-		resetBackgroundTaskThreadLocal();
-
-		for (ServiceRegistration<?> serviceRegistration :
-				_serviceRegistrations) {
-
-			serviceRegistration.unregister();
-		}
-
-		_serviceRegistrations.clear();
+		_cleanupData();
 	}
 
 	@Test
@@ -738,47 +732,35 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testDeleteCompanyDeletesGroups() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		Assert.assertEquals(
 			0,
 			_groupLocalService.getGroupsCount(
-				company.getCompanyId(), GroupConstants.ANY_PARENT_GROUP_ID,
-				true));
+				_deletedCompany.getCompanyId(),
+				GroupConstants.ANY_PARENT_GROUP_ID, true));
 		Assert.assertEquals(
 			0,
 			_groupLocalService.getGroupsCount(
-				company.getCompanyId(), GroupConstants.ANY_PARENT_GROUP_ID,
-				false));
+				_deletedCompany.getCompanyId(),
+				GroupConstants.ANY_PARENT_GROUP_ID, false));
 	}
 
 	@Test
 	public void testDeleteCompanyDeletesLayoutPrototypes() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		Assert.assertEquals(
 			0,
 			_layoutPrototypeLocalService.searchCount(
-				company.getCompanyId(), true));
+				_deletedCompany.getCompanyId(), true));
 		Assert.assertEquals(
 			0,
 			_layoutPrototypeLocalService.searchCount(
-				company.getCompanyId(), false));
+				_deletedCompany.getCompanyId(), false));
 	}
 
 	@Test
 	public void testDeleteCompanyDeletesLayoutSetPrototypes() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		List<LayoutSetPrototype> layoutSetPrototypes =
 			_layoutSetPrototypeLocalService.getLayoutSetPrototypes(
-				company.getCompanyId());
+				_deletedCompany.getCompanyId());
 
 		Assert.assertEquals(
 			layoutSetPrototypes.toString(), 0, layoutSetPrototypes.size());
@@ -786,23 +768,15 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testDeleteCompanyDeletesOrganizations() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		Assert.assertEquals(
 			0,
 			_organizationLocalService.getOrganizationsCount(
-				company.getCompanyId(),
+				_deletedCompany.getCompanyId(),
 				OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID));
 	}
 
 	@Test
 	public void testDeleteCompanyDeletesPasswordPolicies() throws Throwable {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		TransactionInvokerUtil.invoke(
 			_transactionConfig,
 			() -> {
@@ -814,7 +788,7 @@ public class CompanyLocalServiceTest {
 							PasswordPolicyTable.INSTANCE
 						).where(
 							PasswordPolicyTable.INSTANCE.companyId.eq(
-								company.getCompanyId())
+								_deletedCompany.getCompanyId())
 						)));
 
 				return null;
@@ -823,28 +797,20 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testDeleteCompanyDeletesPortalInstance() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		_companyLocalService.forEachCompanyId(
 			companyId -> Assert.assertNotEquals(
-				"Company instance was not deleted", company.getCompanyId(),
-				(long)companyId));
+				"Company instance was not deleted",
+				_deletedCompany.getCompanyId(), (long)companyId));
 	}
 
 	@Test
 	public void testDeleteCompanyDeletesPortalPreferences() throws Throwable {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		TransactionInvokerUtil.invoke(
 			_transactionConfig,
 			() -> {
 				Assert.assertNull(
 					_portalPreferencesLocalService.fetchPortalPreferences(
-						company.getCompanyId(),
+						_deletedCompany.getCompanyId(),
 						PortletKeys.PREFS_OWNER_TYPE_COMPANY));
 
 				return null;
@@ -853,17 +819,13 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testDeleteCompanyDeletesPortlets() throws Throwable {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		TransactionInvokerUtil.invoke(
 			_transactionConfig,
 			() -> {
 				Assert.assertEquals(
 					0,
 					_portletLocalService.getPortletsCount(
-						company.getCompanyId()));
+						_deletedCompany.getCompanyId()));
 
 				return null;
 			});
@@ -871,11 +833,8 @@ public class CompanyLocalServiceTest {
 
 	@Test
 	public void testDeleteCompanyDeletesRoles() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
-		List<Role> roles = _roleLocalService.getRoles(company.getCompanyId());
+		List<Role> roles = _roleLocalService.getRoles(
+			_deletedCompany.getCompanyId());
 
 		Assert.assertEquals(roles.toString(), 0, roles.size());
 	}
@@ -886,69 +845,23 @@ public class CompanyLocalServiceTest {
 
 		Assume.assumeFalse(DBPartition.isPartitionEnabled());
 
-		List<String> list = _registerModelListeners();
-
-		Company company = addCompany();
-
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
-
-			long userId = _userLocalService.getGuestUserId(
-				company.getCompanyId());
-
-			Group group = GroupTestUtil.addGroup(
-				company.getCompanyId(), userId,
-				GroupConstants.DEFAULT_PARENT_GROUP_ID);
-
-			UserGroup userGroup = UserGroupTestUtil.addUserGroup(
-				group.getGroupId());
-
-			User user = addUser(
-				company.getCompanyId(), userId, group.getGroupId(),
-				getServiceContext(company.getCompanyId()));
-
-			_userGroupLocalService.addUserUserGroup(
-				user.getUserId(), userGroup);
-
-			Role role = _roleLocalService.addRole(
-				RandomTestUtil.randomString(), userId, Group.class.getName(),
-				group.getClassPK(), StringUtil.randomString(),
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), StringUtil.randomString()),
-				Collections.emptyMap(), RoleConstants.TYPE_SITE,
-				StringPool.BLANK, getServiceContext(company.getCompanyId()));
-
-			_userGroupRoleLocalService.addUserGroupRole(
-				user.getUserId(), group.getGroupId(), role.getRoleId());
-		}
-		finally {
-			_companyLocalService.deleteCompany(company.getCompanyId());
-		}
-
-		Assert.assertEquals(UserGroupRole.class.getName(), list.get(0));
-		Assert.assertEquals(Role.class.getName(), list.get(1));
+		Assert.assertEquals(
+			UserGroupRole.class.getName(), _modelListenerList.get(0));
+		Assert.assertEquals(Role.class.getName(), _modelListenerList.get(1));
 	}
 
 	@Test
 	public void testDeleteCompanyDeletesUsers() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
 		List<User> users = _userLocalService.getCompanyUsers(
-			company.getCompanyId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+			_deletedCompany.getCompanyId(), QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS);
 
 		Assert.assertEquals(users.toString(), 0, users.size());
 	}
 
 	@Test(expected = NoSuchVirtualHostException.class)
 	public void testDeleteCompanyDeletesVirtualHost() throws Exception {
-		Company company = addCompany();
-
-		_companyLocalService.deleteCompany(company);
-
-		_virtualHostLocalService.getVirtualHost(company.getWebId());
+		_virtualHostLocalService.getVirtualHost(_deletedCompany.getWebId());
 	}
 
 	@Test(expected = RequiredCompanyException.class)
@@ -1364,7 +1277,7 @@ public class CompanyLocalServiceTest {
 			false);
 	}
 
-	protected Company addCompany() throws Exception {
+	protected static Company addCompany() throws Exception {
 		long counterCompanyId =
 			_counterLocalService.increment(Company.class.getName()) + 1;
 
@@ -1384,7 +1297,7 @@ public class CompanyLocalServiceTest {
 		return company;
 	}
 
-	protected Company addCompany(String webId) throws Exception {
+	protected static Company addCompany(String webId) throws Exception {
 		Company company = _companyLocalService.addCompany(
 			null, webId, webId, "test.com", 0, true, true, null, null, null,
 			null, null, null);
@@ -1392,6 +1305,29 @@ public class CompanyLocalServiceTest {
 		PortalInstances.initCompany(company);
 
 		return company;
+	}
+
+	protected static User addUser(
+			long companyId, long userId, long groupId,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		return UserTestUtil.addUser(
+			companyId, userId,
+			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
+			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), new long[] {groupId},
+			serviceContext);
+	}
+
+	protected static ServiceContext getServiceContext(long companyId) {
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setAddGroupPermissions(true);
+		serviceContext.setAddGuestPermissions(true);
+		serviceContext.setCompanyId(companyId);
+
+		return serviceContext;
 	}
 
 	protected LayoutSetPrototype addLayoutSetPrototype(
@@ -1405,29 +1341,6 @@ public class CompanyLocalServiceTest {
 			).build(),
 			new HashMap<Locale, String>(), true, true,
 			getServiceContext(companyId));
-	}
-
-	protected User addUser(
-			long companyId, long userId, long groupId,
-			ServiceContext serviceContext)
-		throws Exception {
-
-		return UserTestUtil.addUser(
-			companyId, userId,
-			RandomTestUtil.randomString(NumericStringRandomizerBumper.INSTANCE),
-			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
-			RandomTestUtil.randomString(), new long[] {groupId},
-			serviceContext);
-	}
-
-	protected ServiceContext getServiceContext(long companyId) {
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setAddGroupPermissions(true);
-		serviceContext.setAddGuestPermissions(true);
-		serviceContext.setCompanyId(companyId);
-
-		return serviceContext;
 	}
 
 	protected void testUpdateCompanyNames(
@@ -1536,44 +1449,73 @@ public class CompanyLocalServiceTest {
 		}
 	}
 
-	private List<String> _getObjectNames(String objectType, long companyId)
+	private static void _addCompanyUserGroupRole(Company company)
 		throws Exception {
 
-		List<String> objectNames = new ArrayList<>();
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					company.getCompanyId())) {
 
-		DatabaseMetaData databaseMetaData = _connection.getMetaData();
-		String partitionName = CompanyLocalServiceTestUtil.getPartitionName(
-			companyId);
+			long userId = _userLocalService.getGuestUserId(
+				company.getCompanyId());
 
-		try (ResultSet resultSet = databaseMetaData.getTables(
-				_dbPartitionDB.getCatalog(_connection, partitionName),
-				_dbPartitionDB.getSchema(_connection, partitionName), null,
-				new String[] {objectType})) {
+			Group group = GroupTestUtil.addGroup(
+				company.getCompanyId(), userId,
+				GroupConstants.DEFAULT_PARENT_GROUP_ID);
 
-			while (resultSet.next()) {
-				objectNames.add(resultSet.getString("TABLE_NAME"));
-			}
+			UserGroup userGroup = UserGroupTestUtil.addUserGroup(
+				group.getGroupId());
+
+			User user = addUser(
+				company.getCompanyId(), userId, group.getGroupId(),
+				getServiceContext(company.getCompanyId()));
+
+			_userGroupLocalService.addUserUserGroup(
+				user.getUserId(), userGroup);
+
+			Role role = _roleLocalService.addRole(
+				RandomTestUtil.randomString(), userId, Group.class.getName(),
+				group.getClassPK(), StringUtil.randomString(),
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), StringUtil.randomString()),
+				Collections.emptyMap(), RoleConstants.TYPE_SITE,
+				StringPool.BLANK, getServiceContext(company.getCompanyId()));
+
+			_userGroupRoleLocalService.addUserGroupRole(
+				user.getUserId(), group.getGroupId(), role.getRoleId());
+		}
+	}
+
+	private static void _cleanupData() throws Exception {
+		List<ClassName> classNames = ListUtil.remove(
+			_classNameLocalService.getClassNames(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+			_classNames);
+
+		for (ClassName className : classNames) {
+			_classNameLocalService.deleteClassName(className);
 		}
 
-		return objectNames;
+		resetBackgroundTaskThreadLocal();
+
+		for (ServiceRegistration<?> serviceRegistration :
+				_serviceRegistrations) {
+
+			serviceRegistration.unregister();
+		}
+
+		_serviceRegistrations.clear();
 	}
 
-	private int _getTablesCount(long companyId) throws Exception {
-		List<String> tableNames = _getObjectNames("TABLE", companyId);
-
-		return tableNames.size();
+	private static void _initializeClassNames() throws Exception {
+		_classNames = _classNameLocalService.getClassNames(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 	}
 
-	private int _getViewsCount(long companyId) throws Exception {
-		List<String> viewNames = _getObjectNames("VIEW", companyId);
-
-		return viewNames.size();
-	}
-
-	private List<String> _registerModelListeners() {
+	private static List<String> _registerModelListeners() {
 		List<String> list = new CopyOnWriteArrayList<>();
 
-		Bundle bundle = FrameworkUtil.getBundle(getClass());
+		Bundle bundle = FrameworkUtil.getBundle(CompanyLocalServiceTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -1609,16 +1551,79 @@ public class CompanyLocalServiceTest {
 		return list;
 	}
 
+	private List<String> _getObjectNames(String objectType, long companyId)
+		throws Exception {
+
+		List<String> objectNames = new ArrayList<>();
+
+		DatabaseMetaData databaseMetaData = _connection.getMetaData();
+		String partitionName = CompanyLocalServiceTestUtil.getPartitionName(
+			companyId);
+
+		try (ResultSet resultSet = databaseMetaData.getTables(
+				_dbPartitionDB.getCatalog(_connection, partitionName),
+				_dbPartitionDB.getSchema(_connection, partitionName), null,
+				new String[] {objectType})) {
+
+			while (resultSet.next()) {
+				objectNames.add(resultSet.getString("TABLE_NAME"));
+			}
+		}
+
+		return objectNames;
+	}
+
+	private int _getTablesCount(long companyId) throws Exception {
+		List<String> tableNames = _getObjectNames("TABLE", companyId);
+
+		return tableNames.size();
+	}
+
+	private int _getViewsCount(long companyId) throws Exception {
+		List<String> viewNames = _getObjectNames("VIEW", companyId);
+
+		return viewNames.size();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		CompanyLocalServiceTest.class);
 
 	private static BundleContext _bundleContext;
+
+	@Inject
+	private static ClassNameLocalService _classNameLocalService;
+
 	private static List<ClassName> _classNames;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
 	private static Connection _connection;
+
+	@Inject
+	private static CounterLocalService _counterLocalService;
+
 	private static DB _db;
 	private static DBPartitionDB _dbPartitionDB;
+	private static Company _deletedCompany;
+	private static List<String> _modelListenerList;
+
+	@Inject
+	private static RoleLocalService _roleLocalService;
+
 	private static SafeCloseable _safeCloseable;
+	private static final List<ServiceRegistration<?>> _serviceRegistrations =
+		new CopyOnWriteArrayList<>();
 	private static final TransactionConfig _transactionConfig;
+
+	@Inject
+	private static UserGroupLocalService _userGroupLocalService;
+
+	@Inject
+	private static UserGroupRoleLocalService _userGroupRoleLocalService;
+
+	@Inject
+	private static UserLocalService _userLocalService;
 
 	static {
 		TransactionConfig.Builder builder = new TransactionConfig.Builder();
@@ -1631,16 +1636,7 @@ public class CompanyLocalServiceTest {
 	}
 
 	@Inject
-	private ClassNameLocalService _classNameLocalService;
-
-	@Inject
-	private CompanyLocalService _companyLocalService;
-
-	@Inject
 	private ConfigurationAdmin _configurationAdmin;
-
-	@Inject
-	private CounterLocalService _counterLocalService;
 
 	@Inject
 	private DDMStructureLocalService _ddmStructureLocalService;
@@ -1685,25 +1681,10 @@ public class CompanyLocalServiceTest {
 	private PrefsProps _prefsProps;
 
 	@Inject
-	private RoleLocalService _roleLocalService;
-
-	private final List<ServiceRegistration<?>> _serviceRegistrations =
-		new CopyOnWriteArrayList<>();
-
-	@Inject
 	private Sites _sites;
 
 	@Inject
 	private StagingLocalService _stagingLocalService;
-
-	@Inject
-	private UserGroupLocalService _userGroupLocalService;
-
-	@Inject
-	private UserGroupRoleLocalService _userGroupRoleLocalService;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 	@Inject
 	private VirtualHostLocalService _virtualHostLocalService;


### PR DESCRIPTION
The `testDeleteCompany*`, `testExportCompany*`, and `testUpdate*` tests operate on shared objects: `_deletedCompany`, `_exportedCompany`, and `_updatedCompany`, respectively.

`_deletedCompany` is created and deleted in `setUpClass`, while `_exportedCompany` and `_updatedCompany` are created in `setUpClass` and deleted in `tearDownClass`.

Some initialization and cleanup logic was also moved into the `*Class` methods, as it is necessary for proper data housekeeping of the shared company objects.

I also added cleanup logic for leftover portlet preferences and system events.

The `testDeleteCompany*`, `testExportCompany*`, and `testUpdate*` tests now run significantly faster. However, creating the shared company objects adds overhead, especially when the corresponding test methods are not executed.
A potential improvement would be to create each shared company object only if its corresponding test is run—for example, only creating `_updatedCompany` when a `testUpdate*` is executed.