### PR TITLE
LPD-20989 Add startup warning for SQL Server READ_COMMITTED_SNAPSHOT setting to prevent deadlocks

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portal/dao/jdbc/DataSourceFactoryImpl.java
@@ -47,6 +47,8 @@ import java.nio.file.Paths;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import java.util.Arrays;
@@ -173,13 +175,17 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 			_log.debug("Created data source " + dataSource.getClass());
 		}
 
-		if (Boolean.getBoolean("jdbc.data.source.anti.time.drift")) {
-			DBType dbType = DBManagerUtil.getDBType(
-				DialectDetector.getDialect(dataSource));
+		DBType dbType = DBManagerUtil.getDBType(
+			DialectDetector.getDialect(dataSource));
 
-			if (dbType == DBType.DB2) {
-				dataSource = new AntiTimeDriftDataSourceWrapper(dataSource);
-			}
+		if (Boolean.getBoolean("jdbc.data.source.anti.time.drift") &&
+			(dbType == DBType.DB2)) {
+
+			dataSource = new AntiTimeDriftDataSourceWrapper(dataSource);
+		}
+
+		if (dbType == DBType.SQLSERVER) {
+			_checkSqlServerReadCommittedSnapshot(dataSource);
 		}
 
 		return dataSource;
@@ -321,6 +327,41 @@ public class DataSourceFactoryImpl implements DataSourceFactory {
 					exception);
 
 				throw classNotFoundException;
+			}
+		}
+	}
+
+	private void _checkSqlServerReadCommittedSnapshot(DataSource dataSource) {
+		try (Connection connection = dataSource.getConnection();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select name, is_read_committed_snapshot_on from " +
+					"sys.databases where name = db_name()");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			if (resultSet.next()) {
+				boolean readCommittedSnapshotOn = resultSet.getBoolean(
+					"is_read_committed_snapshot_on");
+
+				if (!readCommittedSnapshotOn) {
+					if (_log.isWarnEnabled()) {
+						String databaseName = resultSet.getString("name");
+
+						_log.warn(
+							StringBundler.concat(
+								"read_committed_snapshot is disabled for ",
+								"database '", databaseName,
+								"'. This may cause deadlock issues. Enable it ",
+								"with: alter database ", databaseName,
+								" set read_committed_snapshot on"));
+					}
+				}
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to check read_committed_snapshot setting",
+					exception);
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/spring/hibernate/DialectDetector.java
+++ b/portal-impl/src/com/liferay/portal/spring/hibernate/DialectDetector.java
@@ -89,8 +89,21 @@ public class DialectDetector {
 			else if (dbName.startsWith("Microsoft") && (dbMajorVersion == 9)) {
 				dialect = new SQLServer2005Dialect();
 			}
-			else if (dbName.startsWith("Microsoft") && (dbMajorVersion >= 10)) {
-				dialect = new SQLServer2008Dialect();
+			else if (dbName.startsWith("Microsoft")) {
+				if (dbMajorVersion == 9) {
+					dialect = new SQLServer2005Dialect();
+				}
+				else if (dbMajorVersion >= 10) {
+					dialect = new SQLServer2008Dialect();
+				}
+
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"To avoid deadlock issues, enable ",
+							"read_committed_snapshot with: alter database ",
+							"[database_name] set read_committed_snapshot on"));
+				}
 			}
 			else if (dbName.startsWith("Oracle") && (dbMajorVersion >= 10)) {
 				dialect = new Oracle10gDialect();


### PR DESCRIPTION
Hi @LuisOrtiz89, @marianoalvarosaiz, I added check and warning messages for `READ_COMMITTED_SNAPSHOT` for MS SQL Server to the startup process (see @jorgediaz-lr's [comment](https://liferay.atlassian.net/browse/LPD-20989?focusedCommentId=2971639)).
In `DataSourceFactoryImpl` I placed it in `initDataSource` because it already contained a database vendor-specific test for DB2, but I am wondering if there is a more appropriate location for it. There may be other classes to add the warning, but I fear that it might be redundant.

Could you please take a look at it and share your thoughts?

Thank you in advance.
