### PR TITLE
LPD-64714 Enable preupgrade data cleanup by default

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -12330,7 +12330,6 @@ ${update.properties}</echo>
 liferay.home=${liferay.home}
 
 upgrade.database.dl.storage.check.disabled=true
-upgrade.database.preupgrade.data.cleanup.enabled=true
 
 jdbc.default.jndi.name=
 jdbc.default.driverClassName=${database.driver}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -180,7 +180,7 @@
     #
     # Env: LIFERAY_UPGRADE_PERIOD_DATABASE_PERIOD_PREUPGRADE_PERIOD_DATA_PERIOD_CLEANUP_PERIOD_ENABLED
     #
-    upgrade.database.preupgrade.data.cleanup.enabled=false
+    upgrade.database.preupgrade.data.cleanup.enabled=true
 
     #
     # Set this to true to enable preupgrade verification.


### PR DESCRIPTION
In d9de863cac473a584b102198ad7b7a02502ac571 we disabled preupgrade data cleanup adding upgrade.database.preupgrade.data.cleanup.enabled=false in the portal.properties to avoid this new cleanup functionallity to be executed in 2025 Q3 version.

Once 2025 Q3 version was released, we can enable it reverting that commit.