### PR TITLE
LPD-70942 Force liferay.mode=test for UpgradeManagerMbean test

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/tests/UpgradeManagerMbean.testcase
@@ -2,6 +2,7 @@
 definition {
 
 	property app.server.types = "tomcat";
+	property custom.system.properties = "liferay.mode=test";
 	property database.auto.upgrade.enabled = "true";
 	property database.types = "mysql";
 	property jmxremote.enabled = "true";


### PR DESCRIPTION
Related to [LPD-68770](https://liferay.atlassian.net/browse/LPD-68770), see https://github.com/brianchandotcom/liferay-portal/pull/167278 and https://github.com/brianchandotcom/liferay-portal/pull/167306

Force liferay.mode=test for UpgradeManagerMbean test system properties so that DBUpgrader.isUpgradeDatabaseAutoRunEnabled() returns true, even when StartupHelperUtil.isDBNew() is true. Without this, testing would require performing a complete database upgrade

[LPD-68770]: https://liferay.atlassian.net/browse/LPD-68770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ