### PR TITLE
LPD-77977 rebuild-legacy-database ant target ignores database.host property when executing in local without docker

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -17675,9 +17675,14 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 			<finally>
 				<lstopwatch action="total" name="upgrade-legacy-database" />
 
-				<print-docker-database-logs />
+				<if>
+					<isset property="database.docker.image" />
+					<then>
+						<print-docker-database-logs />
 
-				<print-docker-stats />
+						<print-docker-stats />
+					</then>
+				</if>
 			</finally>
 		</trycatch>
 	</target>


### PR DESCRIPTION
In https://liferay.atlassian.net/browse/LPD-72632 we want to measure the upgrade times in a local environment calling `rebuild-legacy-database` and `upgrade-legacy-database`

The problem is `rebuild-legacy-database` ant target is ignoring database.host property when executing in local without docker, so we cannot test with an external database.

This is working in the `rebuild-database` ant target, so just copying the code from there solves the problem.