### PR TITLE
LPD-75077 Follow-up: Normalize Object's tables and columns

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/db/ObjectDBResourceProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/db/ObjectDBResourceProvider.java
@@ -16,6 +16,7 @@ import com.liferay.object.relationship.util.ObjectRelationshipUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.db.DBResourceProvider;
 import com.liferay.portal.kernel.dao.db.DBInspector;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -242,9 +244,12 @@ public class ObjectDBResourceProvider implements DBResourceProvider {
 
 				if (dynamicObjectDefinitionLocalizationTable != null) {
 					return Collections.singletonMap(
-						objectDefinition.getLocalizationDBTableName(),
-						dynamicObjectDefinitionLocalizationTable.
-							getPrimaryKeyColumnNames());
+						dbInspector.normalizeName(
+							objectDefinition.getLocalizationDBTableName()),
+						TransformUtil.transform(
+							dynamicObjectDefinitionLocalizationTable.
+								getPrimaryKeyColumnNames(),
+							dbInspector::normalizeName, String.class));
 				}
 
 				return Collections.emptyMap();
@@ -260,10 +265,12 @@ public class ObjectDBResourceProvider implements DBResourceProvider {
 				objectDefinition.getLocalizationDBTableName())) {
 
 			return Collections.singletonMap(
-				objectDefinition.getLocalizationDBTableName(),
+				dbInspector.normalizeName(
+					objectDefinition.getLocalizationDBTableName()),
 				new String[] {
-					objectDefinition.getPKObjectFieldDBColumnName(),
-					"languageId"
+					dbInspector.normalizeName(
+						objectDefinition.getPKObjectFieldDBColumnName()),
+					dbInspector.normalizeName("languageId")
 				});
 		}
 
@@ -272,9 +279,10 @@ public class ObjectDBResourceProvider implements DBResourceProvider {
 
 	private Map<String, String[]>
 			_getObjectRelationshipTablesPrimaryKeyColumnNames(
-				Connection connection, ObjectDefinition objectDefinition,
+				Connection connection, DBInspector dbInspector,
+				ObjectDefinition objectDefinition,
 				Map<Long, ObjectDefinition> objectDefinitions)
-		throws PortalException {
+		throws PortalException, SQLException {
 
 		Map<String, String[]> objectRelationshipTablesPrimaryKeyColumnNames =
 			new HashMap<>();
@@ -304,9 +312,10 @@ public class ObjectDBResourceProvider implements DBResourceProvider {
 				"pkObjectFieldDBColumnName2");
 
 			objectRelationshipTablesPrimaryKeyColumnNames.put(
-				objectRelationship.getDBTableName(),
+				dbInspector.normalizeName(objectRelationship.getDBTableName()),
 				new String[] {
-					pkObjectFieldDBColumnName1, pkObjectFieldDBColumnName2
+					dbInspector.normalizeName(pkObjectFieldDBColumnName1),
+					dbInspector.normalizeName(pkObjectFieldDBColumnName2)
 				});
 		}
 
@@ -334,23 +343,28 @@ public class ObjectDBResourceProvider implements DBResourceProvider {
 
 				if (!objectDefinition.isUnmodifiableSystemObject()) {
 					tablesPrimaryKeyColumnNames.put(
-						objectDefinition.getDBTableName(),
+						dbInspector.normalizeName(
+							objectDefinition.getDBTableName()),
 						new String[] {
-							objectDefinition.getPKObjectFieldDBColumnName()
+							dbInspector.normalizeName(
+								objectDefinition.getPKObjectFieldDBColumnName())
 						});
 				}
 
 				tablesPrimaryKeyColumnNames.put(
-					objectDefinition.getExtensionDBTableName(),
+					dbInspector.normalizeName(
+						objectDefinition.getExtensionDBTableName()),
 					new String[] {
-						objectDefinition.getPKObjectFieldDBColumnName()
+						dbInspector.normalizeName(
+							objectDefinition.getPKObjectFieldDBColumnName())
 					});
 				tablesPrimaryKeyColumnNames.putAll(
 					_getObjectLocalizationTablePrimaryKeyColumnNames(
 						dbInspector, objectDefinition));
 				tablesPrimaryKeyColumnNames.putAll(
 					_getObjectRelationshipTablesPrimaryKeyColumnNames(
-						connection, objectDefinition, objectDefinitions));
+						connection, dbInspector, objectDefinition,
+						objectDefinitions));
 			}
 		}
 


### PR DESCRIPTION
Hi @marianoalvarosaiz 

I was doing some upgrade tests related to LPD-72632 using a MySQL database configured with `--lower-case-table-names=1` and I have noticed that we are not normalizing the Object's tables and columns.

Consequences:

- For PreupgradeVerifyDatabaseState it doesn't affect because we are comparing using CASE_INSENSITIVE_ORDER in the TreeSet.
- For PreupgradeVerifyDatabaseCharacterSet we are ignoring the Object tables as we match the problematic tables with the table list.
- For DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess it tries renaming Object tables to lowercase but they are already fine. This is why I noticed this problem!
```
     [java] 2026-02-02 18:06:57.282 INFO  [SystemExecutorServiceUtil-8][UpgradeProcess:116] Upgrading com.liferay.portal.upgrade.data.cleanup.DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess#20155
     [java] 2026-02-02 18:06:57.308 INFO  [SystemExecutorServiceUtil-8][DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess:22] Table AccountEntry_x_20155, altered because incorrect table name casing, was accountentry_x_20155
     [java] 2026-02-02 18:06:57.320 INFO  [SystemExecutorServiceUtil-8][DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess:22] Table Address_x_20155, altered because incorrect table name casing, was address_x_20155
     [java] 2026-02-02 18:06:57.332 INFO  [SystemExecutorServiceUtil-8][DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess:22] Table CPDefinition_x_20155, altered because incorrect table name casing, was cpdefinition_x_20155
```

I think the best option to avoid this is just call `dbInspector.normalizeName` when we are adding the table or columns to the Map, but feel free to change it.

**Note:** I am sending this as a follow up of LPD-75077 because you added this object logic in that LPD.