### PR TITLE
LPD-78141 New test properties in build-test.xml to execute upgrade throughput tests

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -17681,6 +17681,22 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 			</else>
 		</if>
 
+		<get-testcase-property property.name="database.upgrade.client.jvm.opts" />
+
+		<var name="database.upgrade.client.arg.line" value="" />
+
+		<if>
+			<and>
+				<isset property="database.upgrade.client.jvm.opts" />
+				<not>
+					<equals arg1="${database.upgrade.client.jvm.opts}" arg2="" trim="true" />
+				</not>
+			</and>
+			<then>
+				<var name="database.upgrade.client.arg.line" value="-jvm-opts=&quot;${database.upgrade.client.jvm.opts}&quot;" />
+			</then>
+		</if>
+
 		<trycatch property="upgrade.error">
 			<try>
 				<java
@@ -17692,6 +17708,8 @@ CATALINA_OPTS="$CATALINA_OPTS -Dcom.sun.management.jmxremote -Dcom.sun.managemen
 					timeout="${upgrade.client.timeout}"
 				>
 					<env key="JAVA_HOME" value="${java.jdk.home}" />
+
+					<arg line="${database.upgrade.client.arg.line}" />
 				</java>
 			</try>
 			<catch>

--- a/test.properties
+++ b/test.properties
@@ -7592,6 +7592,7 @@
         database.lowercase.enabled,\
         database.partition.enabled,\
         database.types,\
+        database.upgrade.client.jvm.opts,\
         database.upgrade.enabled,\
         databases.size,\
         delete.precompiled.jsps,\


### PR DESCRIPTION
We need to add new test properties in build-test.xml:

- **database.upgrade.client.jvm.opts** optional property to specify the JVM OPTS to the upgrade client with the profiler connection.
  * For example: `database.upgrade.client.jvm.opts=-agentpath:[your-kit-path]/bin/linux-x86-64libyjpagent.so=cpu=tracing,onexit=snapshot`
- **skip.run.selenium.test** optional property to avoid executing `run-selenium-test` when executing `run-simple-server`