### PR TITLE
LPD-78995 Remove CompanyThreadLocal.setCompanyId or use CompanyThreadLocal.setCompanyIdWithSafeCloseable instead, where possible

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
@@ -211,8 +211,6 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 	}
 
 	protected void initThreadLocals(User user) throws Exception {
-		CompanyThreadLocal.setCompanyId(user.getCompanyId());
-
 		PrincipalThreadLocal.setName(user.getUserId());
 
 		if (!_usePermissionChecker) {


### PR DESCRIPTION
So far, the only place where removing/replacing `CompanyThreadLocal.setCompanyId` seems to be possible is in the `BaseAuthFilter`.

The other places are in question:

https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java#L457
https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java#L259
Using the `safeCloseable.setCompanyIdWithSafeCloseable()` - `safeCloseable.close()` construct causes the LayoutLocalServiceCopyLayoutContentTest.testCopyLayoutContentUpdateAndPublishDraftWithinPublication test to fail,
perhaps because it already uses an `AutoCloseable`: `CompanyConfigurationTemporarySwapper`.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal/portal-messaging/src/main/java/com/liferay/portal/messaging/internal/MessageBusThreadLocalUtil.java#L79
Conditional value setting. We don’t reset it later.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-background-task/portal-background-task-service/src/main/java/com/liferay/portal/background/task/internal/BackgroundTaskThreadLocalManagerImpl.java#L100
Conditional value setting. We don’t reset it later.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageImplGetAvailableLocalesTest.java#L60
https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-language/portal-language-test/src/testIntegration/java/com/liferay/portal/language/test/LanguageImplGetAvailableLocalesTest.java#L72
The setting is done by `CompanyTestUtil.resetCompanyLocales()`, and resetting is done by the current class in the finally clause.
Since they are not in the same class, we cannot replace it with `safeCloseable`.

https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/CompanyThreadLocalUsage.testjava#L16
We are using the `CompanyThreadLocal.setCompanyId()` method intentionally.

https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/access/control/AccessControlImpl.java#L64
It is set to the user's company ID. I don't know if we can omit it, as it is not set back to the original value.

https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalInstances.java#L104
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalInstances.java#L165
https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalInstances.java#L456
The company ID is not the original one, and it is not reset later.

https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterableInvokerUtil.java#L162
Conditional value setting. We don’t reset it later.

https://github.com/liferay/liferay-portal/blob/master/portal-kernel/test/unit/com/liferay/portal/kernel/security/auth/CompanyThreadLocalTest.java#L80
https://github.com/liferay/liferay-portal/blob/master/portal-kernel/test/unit/com/liferay/portal/kernel/security/auth/CompanyThreadLocalTest.java#L96
We are testing `CompanyThreadLocal.setCompanyId()` itself.

https://github.com/liferay/liferay-portal/blob/master/portal-test/src/com/liferay/portal/kernel/test/util/CompanyTestUtil.java#L102
The resetting of `CompanyThreadLocal._companyId` to the previous value is done in the tests that uses `CompanyTestUtil`

https://github.com/liferay/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/macros/PortalCache.macro#L12
https://github.com/liferay/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/macros/PortalCache.macro#L37
Not sure if we can use `safeCloseable` in a macro.