### PR TITLE
LPD-86109 Fixed FileNotFoundException at the end of upgrade process reporting

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: commit
-description: Create a Git commit with a Jira-prefixed message derived from the staged diff. Use when the user asks to commit, wants to commit changes, or invokes /commit.
-argument-hint: "[optional message hint]"
 allowed-tools: [Bash, Glob, Grep, Read]
+argument-hint: "[optional message hint]"
+description: Create a Git commit with a Jira-prefixed message derived from the staged diff. Use when the user asks to commit, wants to commit changes, or invokes /commit.
+name: commit
 ---
 
 # Commit Changes

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: commit
+description: Commit staged/unstaged changes with an auto-generated message. Analyzes the diff to produce a Jira-prefixed commit title and optional body. Use when the user asks to commit, wants to commit changes, or says /commit.
+argument-hint: "[optional message hint]"
+allowed-tools: [Bash, Read, Grep, Glob]
+---.
+
+# Commit Changes
+
+Create a well-crafted git commit for the current changes.
+
+## 1. Gather Context
+
+- If Claude modified or created files during this conversation, commit **only** those files. Stage them explicitly by name using `git add <file1> <file2> ...`. Do not include the user's own changes.
+- If Claude did **not** modify any files in this conversation, commit **all** changes — stage modified/deleted files (but NOT untracked files). If there are untracked files, ask the user whether to include them.
+
+Never use `git add -A` or `git add .`.
+
+If there are no changes at all (no staged, no unstaged, no untracked), tell the user there is nothing to commit and stop.
+
+## 2. Extract the Jira Ticket
+
+The ticket ID is a pattern like `LPD-12345`, `LCD-12345`, `LRCI-1234`, etc. (uppercase letters, hyphen, digits).
+
+1. **Branch name** — extract the ticket from the current branch name (e.g., branch `LPD-83847` → ticket `LPD-83847`).
+2. **Previous commits** — if the branch name has no ticket, look at the last 5 commit messages for a ticket prefix.
+3. **User argument** — if `$ARGUMENTS` contains a ticket ID, use that instead.
+4. **Not found** — if no ticket is found anywhere, ask the user for one.
+
+## 3. Analyze the Diff and Write the Commit Message
+
+Read and understand the actual code changes (the diff). Then compose the commit message:
+
+### Title (first line)
+
+Format: `<TICKET> <What is being fixed/added/improved>`
+
+- Start with the Jira ticket ID
+- Follow with a concise summary of **what** is being fixed or achieved — describe the problem or behavior change, not the code changes
+- Use sentence case (capitalize first word only)
+- No period at the end
+- Keep under 72 characters total (ticket + space + summary)
+- If a second Jira ticket is relevant (e.g., the change addresses a sub-task tracked elsewhere), include it after the first: `LPD-12345 LPD-67890 Summary`
+
+Examples of good titles:
+- `LPD-84627 Prevent dispatch trigger loss when analytics admin user is missing`
+- `LPD-83357 Add validation to prevent folder changes for CMS object definitions`
+- `LPD-83630 Fix typo`
+- `LCD-50509 Grant ArgoCD permission to correct namespace`
+
+### Body (optional)
+
+Add a body **only** if the title alone doesn't fully explain the change. Skip the body for trivial/obvious changes (typo fixes, simple renames, single-line changes).
+
+When included:
+- Separate from title with a blank line
+- Explain **why** the change is needed — describe the problem, the previous behavior, or the motivation, not the code changes themselves
+- Wrap lines at 72 characters
+- Use plain prose, not bullet points (match the repo convention)
+
+If `$ARGUMENTS` contains a hint or description (not a ticket ID), incorporate it into the message.
+
+## 4. Confirm and Commit
+
+Show the user the proposed commit message and ask for confirmation. If they approve (or say nothing needs changing), create the commit:
+
+```bash
+git commit -m "$(cat <<'EOF'
+<title>
+
+<body if applicable>
+EOF
+)"
+```
+
+If the user wants changes, adjust and re-confirm.
+
+## 5. Post-Commit
+
+Run `git status` to confirm the commit succeeded and show the result.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,80 +1,84 @@
 ---
 name: commit
-description: Commit staged/unstaged changes with an auto-generated message. Analyzes the diff to produce a Jira-prefixed commit title and optional body. Use when the user asks to commit, wants to commit changes, or says /commit.
+description: Create a Git commit with a Jira-prefixed message derived from the staged diff. Use when the user asks to commit, wants to commit changes, or invokes /commit.
 argument-hint: "[optional message hint]"
-allowed-tools: [Bash, Read, Grep, Glob]
----.
+allowed-tools: [Bash, Glob, Grep, Read]
+---
 
 # Commit Changes
 
-Create a well-crafted git commit for the current changes.
+Compose a well-crafted Git commit for the current set of changes.
 
 ## 1. Gather Context
 
-- If Claude modified or created files during this conversation, commit **only** those files. Stage them explicitly by name using `git add <file1> <file2> ...`. Do not include the user's own changes.
-- If Claude did **not** modify any files in this conversation, commit **all** changes — stage modified/deleted files (but NOT untracked files). If there are untracked files, ask the user whether to include them.
+- When Claude modified or created files during this conversation, commit **only** those files. Stage them explicitly by name with `git add <file1> <file2> ...`. Do not include the user's own changes.
+- When Claude did **not** modify any files in this conversation, commit **all** changes. Stage modified and deleted files, but leave untracked files alone. When untracked files exist, ask the user whether to include them.
 
 Never use `git add -A` or `git add .`.
 
-If there are no changes at all (no staged, no unstaged, no untracked), tell the user there is nothing to commit and stop.
+When nothing is staged, unstaged, or untracked, inform the user that there is nothing to commit and stop.
 
 ## 2. Extract the Jira Ticket
 
-The ticket ID is a pattern like `LPD-12345`, `LCD-12345`, `LRCI-1234`, etc. (uppercase letters, hyphen, digits).
+The ticket ID follows the pattern `LPD-12345`, `LCD-12345`, `LRCI-1234`, and similar forms (uppercase letters, hyphen, digits). Resolve the ticket in this order:
 
-1. **Branch name** — extract the ticket from the current branch name (e.g., branch `LPD-83847` → ticket `LPD-83847`).
-2. **Previous commits** — if the branch name has no ticket, look at the last 5 commit messages for a ticket prefix.
-3. **User argument** — if `$ARGUMENTS` contains a ticket ID, use that instead.
-4. **Not found** — if no ticket is found anywhere, ask the user for one.
+1. **Branch Name** — extract the ticket from the current branch (e.g., branch `LPD-83847` yields ticket `LPD-83847`).
+2. **Recent Commits** — when the branch name lacks a ticket, scan the last five commit messages for a ticket prefix.
+3. **User Argument** — when `${ARGUMENTS}` supplies a ticket ID, prefer that value.
+4. **Fallback** — when no ticket surfaces, prompt the user for one.
 
-## 3. Analyze the Diff and Write the Commit Message
+## 3. Compose the Commit Message
 
-Read and understand the actual code changes (the diff). Then compose the commit message:
+Read the diff, understand the actual behavior change, then compose the message.
 
-### Title (first line)
+### Title
 
-Format: `<TICKET> <What is being fixed/added/improved>`
+Format: `<TICKET> <Summary of behavior change>`
 
-- Start with the Jira ticket ID
-- Follow with a concise summary of **what** is being fixed or achieved — describe the problem or behavior change, not the code changes
-- Use sentence case (capitalize first word only)
-- No period at the end
-- Keep under 72 characters total (ticket + space + summary)
-- If a second Jira ticket is relevant (e.g., the change addresses a sub-task tracked elsewhere), include it after the first: `LPD-12345 LPD-67890 Summary`
+- Lead with the Jira ticket ID.
+- Follow with a concise summary of the outcome — the problem resolved or the behavior changed, not the code itself.
+- Use sentence case (capitalize the first word only).
+- Omit a trailing period.
+- Keep the full line under 72 characters, including the ticket prefix.
+- When a companion Jira ticket also applies (e.g., a related subtask), append it after the first: `LPD-12345 LPD-67890 Summary`.
 
-Examples of good titles:
-- `LPD-84627 Prevent dispatch trigger loss when analytics admin user is missing`
+Examples:
+
+- `LCD-50509 Grant ArgoCD permission to the correct namespace`
 - `LPD-83357 Add validation to prevent folder changes for CMS object definitions`
 - `LPD-83630 Fix typo`
-- `LCD-50509 Grant ArgoCD permission to correct namespace`
+- `LPD-84627 Prevent dispatch trigger loss when the Analytics admin user is missing`
 
-### Body (optional)
+### Body
 
-Add a body **only** if the title alone doesn't fully explain the change. Skip the body for trivial/obvious changes (typo fixes, simple renames, single-line changes).
+Add a body **only** when the title alone does not fully convey the change. Omit the body for trivial edits such as typo fixes, simple renames, or single-line changes.
 
-When included:
-- Separate from title with a blank line
-- Explain **why** the change is needed — describe the problem, the previous behavior, or the motivation, not the code changes themselves
-- Wrap lines at 72 characters
-- Use plain prose, not bullet points (match the repo convention)
+When a body is warranted:
 
-If `$ARGUMENTS` contains a hint or description (not a ticket ID), incorporate it into the message.
+- Separate it from the title with a blank line.
+- Explain **why** the change is needed — the problem, the prior behavior, or the motivation. Do not restate the code.
+- Wrap lines at 72 characters.
+- Write plain prose rather than bullet points, matching the repository convention.
+
+When `${ARGUMENTS}` carries a hint or description rather than a ticket ID, incorporate it into the message.
 
 ## 4. Confirm and Commit
 
-Show the user the proposed commit message and ask for confirmation. If they approve (or say nothing needs changing), create the commit:
+Present the proposed commit message to the user and request confirmation. Once they approve, create the commit:
 
 ```bash
-git commit -m "$(cat <<'EOF'
+COMMIT_MESSAGE=$(cat <<'EOF'
 <title>
 
 <body if applicable>
 EOF
-)"
+)
+
+git commit --message "${COMMIT_MESSAGE}"
 ```
 
-If the user wants changes, adjust and re-confirm.
+When the user requests changes, revise the message and reconfirm.
 
 ## 5. Post-Commit
 
-Run `git status` to confirm the commit succeeded and show the result.
+Run `git status` to confirm the commit succeeded, then display the result.

--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: jira-bug
+description: Create a Jira bug ticket in the LPD project. Use when the user asks to create/file a Jira bug or LPD ticket.
+argument-hint: "[commit-hash-or-description]"
+allowed-tools: Bash(git *), Bash(curl *), Read, Grep, Glob
+---
+
+# Create a Jira Bug in LPD
+
+Create a bug ticket in the LPD Jira project using the REST API with credentials from `$JIRA_API_USER` and `$JIRA_API_TOKEN` environment variables.
+
+## Input
+
+If `$ARGUMENTS` is a commit hash, inspect the commit with `git show` to understand the fix and infer the bug it addresses. If it is a description, use that directly.
+
+## Gather Information
+
+Ask the user for any missing details:
+- **Summary** — short title describing the bug
+- **Steps to Reproduce** — clear, minimal steps
+- **Expected Behavior**
+- **Actual Behavior**
+
+## Required Fields
+
+The LPD project requires these fields. Use these defaults unless the user specifies otherwise:
+- **Affects Version**: `Master` (id: `16660`)
+- **Component**: Ask the user or infer from the code area. Common ones:
+  - `Headless Batch Engine API` (id: `16022`)
+  - `Data Integration > Export/Import` (id: `16131`)
+  - `Content Publishing > Resource Importer` (id: `15805`)
+  - If unsure, search components: `curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" "https://liferay.atlassian.net/rest/api/3/project/LPD/components" | python3 -c "import json,sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"`
+- **Cross Cutting Properties** (`customfield_10979`): `None` (id: `14468`)
+
+## Create the Ticket
+
+Use the Jira REST API v3 to create the issue:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue" \
+  -d '<JSON payload>'
+```
+
+Use Atlassian Document Format (ADF) for the description with sections: Description, Steps to Reproduce, Expected Behavior, Actual Behavior. Include a Fix section if a commit is referenced.
+
+## Output
+
+Return the ticket key and URL: `https://liferay.atlassian.net/browse/<KEY>`

--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -1,51 +1,64 @@
 ---
 name: jira-bug
-description: Create a Jira bug ticket in the LPD project. Use when the user asks to create/file a Jira bug or LPD ticket.
-argument-hint: "[commit-hash-or-description]"
-allowed-tools: Bash(git *), Bash(curl *), Read, Grep, Glob
+description: Create a Jira bug ticket in the LPD project through the REST API. Use when the user asks to create or file a Jira bug or LPD ticket.
+argument-hint: "[commit hash or description]"
+allowed-tools: Bash(curl *), Bash(git *), Glob, Grep, Read
 ---
 
 # Create a Jira Bug in LPD
 
-Create a bug ticket in the LPD Jira project using the REST API with credentials from `$JIRA_API_USER` and `$JIRA_API_TOKEN` environment variables.
+Create a bug ticket in the LPD Jira project through the REST API, authenticating with credentials from the `${JIRA_API_USER}` and `${JIRA_API_TOKEN}` environment variables.
 
 ## Input
 
-If `$ARGUMENTS` is a commit hash, inspect the commit with `git show` to understand the fix and infer the bug it addresses. If it is a description, use that directly.
+When `${ARGUMENTS}` is a commit hash, inspect the commit with `git show` to understand the fix and infer the bug it addresses. When `${ARGUMENTS}` is a free-form description, use it directly.
 
 ## Gather Information
 
-Ask the user for any missing details:
-- **Summary** — short title describing the bug
-- **Steps to Reproduce** — clear, minimal steps
-- **Expected Behavior**
-- **Actual Behavior**
+Request any missing details from the user:
+
+- **Summary** — short title describing the bug.
+- **Steps to Reproduce** — clear, minimal steps.
+- **Expected Behavior** — what should have happened.
+- **Actual Behavior** — what happened instead.
 
 ## Required Fields
 
-The LPD project requires these fields. Use these defaults unless the user specifies otherwise:
-- **Affects Version**: `Master` (id: `16660`)
-- **Component**: Ask the user or infer from the code area. Common ones:
-  - `Headless Batch Engine API` (id: `16022`)
-  - `Data Integration > Export/Import` (id: `16131`)
-  - `Content Publishing > Resource Importer` (id: `15805`)
-  - If unsure, search components: `curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" "https://liferay.atlassian.net/rest/api/3/project/LPD/components" | python3 -c "import json,sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"`
-- **Cross Cutting Properties** (`customfield_10979`): `None` (id: `14468`)
+The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
+
+- **Affects Version**: `Master` (id: `16660`).
+- **Component**: Select from the list below, or infer from the code area. Common components include:
+	- `Content Publishing > Resource Importer` (id: `15805`)
+	- `Data Integration > Export/Import` (id: `16131`)
+	- `Headless Batch Engine API` (id: `16022`)
+- **Cross Cutting Properties** (`customfield_10979`): `None` (id: `14468`).
+
+When no listed component matches, search by keyword:
+
+```bash
+curl \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/project/LPD/components" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}" \
+	| python3 -c "import json, sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"
+```
 
 ## Create the Ticket
 
-Use the Jira REST API v3 to create the issue:
+Submit the issue through Jira REST API v3:
 
 ```bash
-curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
-  -X POST \
-  -H "Content-Type: application/json" \
-  "https://liferay.atlassian.net/rest/api/3/issue" \
-  -d '<JSON payload>'
+curl \
+	--data '<JSON payload>' \
+	--header "Content-Type: application/json" \
+	--request POST \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/issue" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-Use Atlassian Document Format (ADF) for the description with sections: Description, Steps to Reproduce, Expected Behavior, Actual Behavior. Include a Fix section if a commit is referenced.
+Author the description in Atlassian Document Format (ADF) with the following sections, in order: Description, Steps to Reproduce, Expected Behavior, Actual Behavior. Append a Fix section when a commit is referenced.
 
 ## Output
 
-Return the ticket key and URL: `https://liferay.atlassian.net/browse/<KEY>`
+Return the ticket key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.

--- a/.claude/skills/jira-bug/SKILL.md
+++ b/.claude/skills/jira-bug/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: jira-bug
-description: Create a Jira bug ticket in the LPD project through the REST API. Use when the user asks to create or file a Jira bug or LPD ticket.
-argument-hint: "[commit hash or description]"
 allowed-tools: Bash(curl *), Bash(git *), Glob, Grep, Read
+argument-hint: "[commit hash or description]"
+description: Create a Jira bug ticket in the LPD project through the REST API. Use when the user asks to create or file a Jira bug or LPD ticket.
+name: jira-bug
 ---
 
 # Create a Jira Bug in LPD
@@ -26,12 +26,12 @@ Request any missing details from the user:
 
 The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
 
-- **Affects Version**: `Master` (id: `16660`).
+- **Affects Version**: `Master` (ID: `16660`).
 - **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (id: `15805`)
-	- `Data Integration > Export/Import` (id: `16131`)
-	- `Headless Batch Engine API` (id: `16022`)
-- **Cross Cutting Properties** (`customfield_10979`): `None` (id: `14468`).
+	- `Content Publishing > Resource Importer` (ID: `15805`)
+	- `Data Integration > Export/Import` (ID: `16131`)
+	- `Headless Batch Engine API` (ID: `16022`)
+- **Cross Cutting Properties** (`customfield_10979`): `None` (ID: `14468`).
 
 When no listed component matches, search by keyword:
 

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -1,50 +1,63 @@
 ---
 name: jira-task
-description: Create a Jira task in the LPD project. Use when the user asks to create a Jira task or LPD task ticket.
-argument-hint: "[commit-hash-or-description]"
-allowed-tools: Bash(git *), Bash(curl *), Read, Grep, Glob
+description: Create a Jira task in the LPD project through the REST API. Use when the user asks to create a Jira task or LPD task ticket.
+argument-hint: "[commit hash or description]"
+allowed-tools: Bash(curl *), Bash(git *), Glob, Grep, Read
 ---
 
 # Create a Jira Task in LPD
 
-Create a task ticket in the LPD Jira project using the REST API with credentials from `$JIRA_API_USER` and `$JIRA_API_TOKEN` environment variables.
+Create a task ticket in the LPD Jira project through the REST API, authenticating with credentials from the `${JIRA_API_USER}` and `${JIRA_API_TOKEN}` environment variables.
 
 ## Input
 
-If `$ARGUMENTS` is a commit hash, inspect the commit with `git show` to understand the work and infer the task. If it is a description, use that directly.
+When `${ARGUMENTS}` is a commit hash, inspect the commit with `git show` to understand the work and infer the task. When `${ARGUMENTS}` is a free-form description, use it directly.
 
 ## Gather Information
 
-Ask the user for any missing details:
-- **Summary** — short title describing the task
-- **Description** — what needs to be done and why
+Request any missing details from the user:
+
+- **Summary** — short title describing the task.
+- **Description** — what needs to be done and why.
 
 ## Required Fields
 
-The LPD project requires these fields. Use these defaults unless the user specifies otherwise:
-- **Issue Type**: `Task` (id: `10002`)
-- **Component**: Ask the user or infer from the code area. Common ones:
-  - `Headless Batch Engine API` (id: `16022`)
-  - `Data Integration > Export/Import` (id: `16131`)
-  - `Content Publishing > Resource Importer` (id: `15805`)
-  - If unsure, search components: `curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" "https://liferay.atlassian.net/rest/api/3/project/LPD/components" | python3 -c "import json,sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"`
+The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
 
-Note: Unlike bugs, tasks do NOT require Affects Version or Cross Cutting Properties fields.
+- **Component**: Select from the list below, or infer from the code area. Common components include:
+	- `Content Publishing > Resource Importer` (id: `15805`)
+	- `Data Integration > Export/Import` (id: `16131`)
+	- `Headless Batch Engine API` (id: `16022`)
+- **Issue Type**: `Task` (id: `10002`).
+
+Note: Unlike bugs, tasks do not require the Affects Version or Cross Cutting Properties fields.
+
+When no listed component matches, search by keyword:
+
+```bash
+curl \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/project/LPD/components" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}" \
+	| python3 -c "import json, sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"
+```
 
 ## Create the Ticket
 
-Use the Jira REST API v3 to create the issue:
+Submit the issue through Jira REST API v3:
 
 ```bash
-curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
-  -X POST \
-  -H "Content-Type: application/json" \
-  "https://liferay.atlassian.net/rest/api/3/issue" \
-  -d '<JSON payload>'
+curl \
+	--data '<JSON payload>' \
+	--header "Content-Type: application/json" \
+	--request POST \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/issue" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-Use Atlassian Document Format (ADF) for the description with sections: Description, Acceptance Criteria (if applicable). Include a Reference section if a commit is referenced.
+Author the description in Atlassian Document Format (ADF) with the following sections, in order: Description, Acceptance Criteria (when applicable). Append a Reference section when a commit is referenced.
 
 ## Output
 
-Return the ticket key and URL: `https://liferay.atlassian.net/browse/<KEY>`
+Return the ticket key and the browse URL: `https://liferay.atlassian.net/browse/<KEY>`.

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: jira-task
-description: Create a Jira task in the LPD project through the REST API. Use when the user asks to create a Jira task or LPD task ticket.
-argument-hint: "[commit hash or description]"
 allowed-tools: Bash(curl *), Bash(git *), Glob, Grep, Read
+argument-hint: "[commit hash or description]"
+description: Create a Jira task in the LPD project through the REST API. Use when the user asks to create a Jira task or LPD task ticket.
+name: jira-task
 ---
 
 # Create a Jira Task in LPD
@@ -25,10 +25,10 @@ Request any missing details from the user:
 The LPD project requires the following fields. Apply these defaults unless the user specifies otherwise:
 
 - **Component**: Select from the list below, or infer from the code area. Common components include:
-	- `Content Publishing > Resource Importer` (id: `15805`)
-	- `Data Integration > Export/Import` (id: `16131`)
-	- `Headless Batch Engine API` (id: `16022`)
-- **Issue Type**: `Task` (id: `10002`).
+	- `Content Publishing > Resource Importer` (ID: `15805`)
+	- `Data Integration > Export/Import` (ID: `16131`)
+	- `Headless Batch Engine API` (ID: `16022`)
+- **Issue Type**: `Task` (ID: `10002`).
 
 Note: Unlike bugs, tasks do not require the Affects Version or Cross Cutting Properties fields.
 

--- a/.claude/skills/jira-task/SKILL.md
+++ b/.claude/skills/jira-task/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: jira-task
+description: Create a Jira task in the LPD project. Use when the user asks to create a Jira task or LPD task ticket.
+argument-hint: "[commit-hash-or-description]"
+allowed-tools: Bash(git *), Bash(curl *), Read, Grep, Glob
+---
+
+# Create a Jira Task in LPD
+
+Create a task ticket in the LPD Jira project using the REST API with credentials from `$JIRA_API_USER` and `$JIRA_API_TOKEN` environment variables.
+
+## Input
+
+If `$ARGUMENTS` is a commit hash, inspect the commit with `git show` to understand the work and infer the task. If it is a description, use that directly.
+
+## Gather Information
+
+Ask the user for any missing details:
+- **Summary** — short title describing the task
+- **Description** — what needs to be done and why
+
+## Required Fields
+
+The LPD project requires these fields. Use these defaults unless the user specifies otherwise:
+- **Issue Type**: `Task` (id: `10002`)
+- **Component**: Ask the user or infer from the code area. Common ones:
+  - `Headless Batch Engine API` (id: `16022`)
+  - `Data Integration > Export/Import` (id: `16131`)
+  - `Content Publishing > Resource Importer` (id: `15805`)
+  - If unsure, search components: `curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" "https://liferay.atlassian.net/rest/api/3/project/LPD/components" | python3 -c "import json,sys; [print(f'{c[\"id\"]:>6} {c[\"name\"]}') for c in json.load(sys.stdin) if 'SEARCH_TERM' in c['name'].lower()]"`
+
+Note: Unlike bugs, tasks do NOT require Affects Version or Cross Cutting Properties fields.
+
+## Create the Ticket
+
+Use the Jira REST API v3 to create the issue:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue" \
+  -d '<JSON payload>'
+```
+
+Use Atlassian Document Format (ADF) for the description with sections: Description, Acceptance Criteria (if applicable). Include a Reference section if a commit is referenced.
+
+## Output
+
+Return the ticket key and URL: `https://liferay.atlassian.net/browse/<KEY>`

--- a/.claude/skills/markdown-format/SKILL.md
+++ b/.claude/skills/markdown-format/SKILL.md
@@ -1,0 +1,114 @@
+---
+allowed-tools: [Bash, Edit, Glob, Grep, Read, Write]
+argument-hint: "[path to Markdown file]"
+description: Format a Markdown file to match Liferay conventions — frontmatter order, Title Case headings, braced shell variables, long-form CLI flags, and professional prose. Use when the user asks to format, clean up, polish, or copy-edit a Markdown file destined for the Liferay repository.
+name: markdown-format
+---
+
+# Markdown Formatter
+
+Apply Liferay Markdown conventions to the target file so structure, casing, and prose land consistent and professional.
+
+## Input
+
+When `${ARGUMENTS}` is a path to a Markdown file, format that file. When no path is supplied, ask the user which file to format.
+
+## Workflow
+
+### 1. Read the File
+
+Read the target file in full before making changes. Note the frontmatter, headings, code blocks, and any conventions already in use.
+
+### 2. Apply the Conventions
+
+Work through the checks below in order. Fix each category before moving to the next.
+
+### 3. Validate
+
+Reread the file after the pass and confirm every check still holds.
+
+### 4. Report
+
+Summarize the changes, grouped by category (frontmatter, headings, prose, shell, lists).
+
+## Conventions
+
+### Frontmatter
+
+- Sort keys alphabetically (e.g., `allowed-tools`, `argument-hint`, `description`, `name`).
+- Sort the values inside `allowed-tools` alphabetically.
+
+### Headings
+
+- Apply Title Case at every heading level — including `###` and deeper.
+- Follow every heading with a blank line before the body content.
+- Use the correct casing for brand and product names: Arquillian, Atlassian, GitHub, Gradle, Jira, JUnit, Liferay, Mockito, Playwright, Poshi, REST API, TypeScript.
+
+### Prose
+
+- Write "ID" in uppercase when the word appears in prose. Reserve lowercase `id` for code contexts such as JSON keys, identifier names, and URL parameters.
+- Avoid contractions. Write "do not" rather than "don't", "does not" rather than "doesn't", "it is" rather than "it's".
+- Use complete sentences. Avoid fragments that look like sentences but omit parts.
+- Do not hyphenate short prefixes that are not standalone words. Write "nonoverlapping", "multiline", "coworking", "predestined".
+- Do not end URLs with a trailing slash.
+- Use literal UTF-8 characters (em dashes, curly quotes) rather than HTML entities such as `&#8212;` or `&#8220;`.
+- When a specific field or feature name appears in prose, bold it so the capitalization reads as a proper name: "set the **Git Pull Request** field".
+
+### Shell Variables
+
+- Brace every shell variable reference as `${VAR}`, both in code and in prose. Write `${JIRA_API_USER}` rather than `$JIRA_API_USER`.
+
+### CLI Commands
+
+- Prefer long-form flags: `--data` instead of `-d`, `--header` instead of `-H`, `--message` instead of `-m`, `--request` instead of `-X`, `--set-upstream` instead of `-u`, `--silent` instead of `-s`, `--user` instead of `-u`.
+- Sort flags alphabetically by flag name.
+- When a command's arguments span multiple lines, place the command alone on the first line and each argument on its own subsequent line. Do not mix arguments on the command line with arguments below.
+- Indent continuation lines with a tab character, matching Liferay's shell-script convention.
+
+### Multiline Heredocs
+
+Lift multiline heredoc values into named variables so the containing command keeps its sorted order:
+
+```bash
+PR_BODY=$(cat <<'EOF'
+<body>
+EOF
+)
+
+gh pr create \
+	--base master \
+	--body "${PR_BODY}" \
+	--head <username>:<branch> \
+	--repo <target-org/repo> \
+	--title "<title>"
+```
+
+### Inline JSON
+
+Add a space after `:` and `,`, but no space after `{` or before `}`. Example: `{"key": "value", "other": "data"}`.
+
+### Lists
+
+- Sort unordered lists alphabetically when the order does not carry meaning (component catalogs, tool options, brand lists).
+- Preserve order for numbered workflow steps, priority rankings, and any sequence where the order conveys information.
+
+### Example Rewrites
+
+Short-form, unsorted, unbraced:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" -X POST \
+  -d '{"key":"value"}' \
+  "https://example.com/api"
+```
+
+Long-form, sorted, braced, tab-indented:
+
+```bash
+curl \
+	--data '{"key": "value"}' \
+	--request POST \
+	--silent \
+	--url "https://example.com/api" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
+```

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,8 +1,8 @@
 ---
-name: pr
-description: Create a GitHub pull request for the current branch, transition the corresponding Jira ticket to review, and record the PR link on the ticket. Use when the user asks to create a PR, send a PR, or invokes /pr.
-argument-hint: "[optional target-org/repo or message hint]"
 allowed-tools: [Bash, Glob, Grep, Read]
+argument-hint: "[optional target-org/repo or message hint]"
+description: Create a GitHub pull request for the current branch, transition the corresponding Jira ticket to review, and record the PR link on the ticket. Use when the user asks to create a PR, send a PR, or invokes /pr.
+name: pr
 ---
 
 # Create Pull Request
@@ -98,16 +98,16 @@ curl \
 	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-- **Bug** (type id `10004`): Use the bug ticket directly. The transition to **In Review** uses id `71`.
-- **Task** (parent, type id `10002`): Locate its Technical Task subtask and use that subtask's key. Every subsequent operation (transition, PR field, PR title, summary) must reference the **subtask's key**. The transition to **In Peer Review** uses id `31`.
-- **Technical Task** (subtask, type id `10153`): Use it directly. The transition to **In Peer Review** uses id `31`.
+- **Bug** (type ID `10004`): Use the bug ticket directly. The transition to **In Review** uses ID `71`.
+- **Task** (parent, type ID `10002`): Locate its Technical Task subtask and use that subtask's key. Every subsequent operation (transition, PR field, PR title, summary) must reference the **subtask's key**. The transition to **In Peer Review** uses ID `31`.
+- **Technical Task** (subtask, type ID `10153`): Use it directly. The transition to **In Peer Review** uses ID `31`.
 
 ### Ensure the Ticket Is In Progress First
 
 Before transitioning to review, check the ticket's current status. When it is not already "In Progress", transition it to In Progress first. The transition ID depends on the issue type:
 
-- **Bug**: In Progress transition id is `61`.
-- **Technical Task**: In Progress transition id is `41`.
+- **Bug**: In Progress transition ID is `61`.
+- **Technical Task**: In Progress transition ID is `41`.
 
 ```bash
 curl \
@@ -121,7 +121,7 @@ curl \
 
 ### Transition to Review
 
-For **Bug** tickets (In Review, id `71`):
+For **Bug** tickets (In Review, ID `71`):
 
 ```bash
 curl \
@@ -133,7 +133,7 @@ curl \
 	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-For **Technical Task** tickets or a subtask resolved from a Task (In Peer Review, id `31`):
+For **Technical Task** tickets or a subtask resolved from a Task (In Peer Review, ID `31`):
 
 ```bash
 curl \
@@ -145,7 +145,7 @@ curl \
 	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-Then set the Git Pull Request field on the target ticket:
+Then set the **Git Pull Request** field on the target ticket:
 
 ```bash
 curl \

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,157 +1,169 @@
 ---
 name: pr
-description: Create a GitHub pull request for the current branch, update the Jira ticket to In Review, and set the PR link. Use when the user asks to create a PR, send a PR, or says /pr.
+description: Create a GitHub pull request for the current branch, transition the corresponding Jira ticket to review, and record the PR link on the ticket. Use when the user asks to create a PR, send a PR, or invokes /pr.
 argument-hint: "[optional target-org/repo or message hint]"
-allowed-tools: [Bash, Read, Grep, Glob]
+allowed-tools: [Bash, Glob, Grep, Read]
 ---
 
 # Create Pull Request
 
-Create a GitHub PR for the current branch and update the Jira ticket.
+Create a GitHub pull request for the current branch and update the linked Jira ticket.
 
 ## 1. Gather Context
 
-If there are uncommitted changes, warn the user and stop — they should commit first (suggest `/commit`).
+When uncommitted changes exist, warn the user and stop. They should commit first (suggest `/commit`).
 
 ## 2. Extract the Jira Ticket
 
-The ticket ID is a pattern like `LPD-12345`, `LCD-12345`, `LRCI-1234`, etc. (uppercase letters, hyphen, digits).
+The ticket ID follows the pattern `LPD-12345`, `LCD-12345`, `LRCI-1234`, and similar forms (uppercase letters, hyphen, digits). Resolve the ticket in this order:
 
-1. **Branch name** — extract the ticket from the current branch name (e.g., branch `LPD-83847` → ticket `LPD-83847`).
-2. **Previous commits** — if the branch name has no ticket, look at the commit messages.
-3. **User argument** — if `$ARGUMENTS` contains a ticket ID, use that instead.
-4. **Not found** — if no ticket is found anywhere, ask the user for one.
+1. **Branch Name** — extract the ticket from the current branch (e.g., branch `LPD-83847` yields ticket `LPD-83847`).
+2. **Recent Commits** — when the branch name lacks a ticket, scan recent commit messages for a ticket prefix.
+3. **User Argument** — when `${ARGUMENTS}` supplies a ticket ID, prefer that value.
+4. **Fallback** — when no ticket surfaces, prompt the user for one.
 
 ## 3. Determine the Target
 
-- **Fork owner**: If `$ARGUMENTS` specifies a GitHub org/user, use that. Otherwise, ask the user to choose from: `liferay-bpm`, `liferay-content-management`, `liferay-page-management`.
-- **Fork remote**: Use the user's remote (default: `origin`). Identify the GitHub username from the remote URL (e.g., `git@github.com:brianchandotcom/liferay-portal.git` → `brianchandotcom`).
-- **Target repo**: Default is `<fork-owner>/liferay-portal`. If `$ARGUMENTS` specifies a different `org/repo`, use that.
-- **Base branch**: `master`.
+- **Base Branch**: `master`.
+- **Fork Owner**: When `${ARGUMENTS}` names a GitHub organization or user, use that. Otherwise, ask the user to choose from `liferay-bpm`, `liferay-content-management`, or `liferay-page-management`.
+- **Fork Remote**: Use the user's remote (default: `origin`). Identify the GitHub username from the remote URL (e.g., `git@github.com:brianchandotcom/liferay-portal.git` yields `brianchandotcom`).
 - **Head**: `<github-username>:<branch-name>`.
+- **Target Repository**: `<fork-owner>/liferay-portal` by default. When `${ARGUMENTS}` names a different `org/repo`, use that.
 
 ## 4. Push the Branch
 
-Push the branch to the user's remote if not already pushed or if there are new local commits:
+Push the branch to the user's remote when it has not been pushed or when new local commits exist:
 
 ```bash
-git push -u origin <branch-name>
+git push --set-upstream origin <branch-name>
 ```
 
-## 5. Analyze Changes and Create the PR
+## 5. Analyze Changes and Create the Pull Request
 
-Read the full diff (`git diff master...HEAD`) and all commit messages to understand what changed.
+Read the full diff (`git diff master...HEAD`) and every commit message on the branch to understand the complete scope of changes.
 
-### PR Title
+### Pull Request Title
 
-Keep it short (under 72 characters). Use the Jira ticket as prefix:
+Keep it concise (under 72 characters) and prefix with the Jira ticket:
 
 ```
 LPD-83847 Fix OutOfMemoryError during batch engine import
 ```
 
-### PR Body
+### Pull Request Body
 
-Use this format:
+Use the following format:
 
 ```markdown
 https://liferay.atlassian.net/browse/TICKET-ID
 
 **What is being fixed:** Explain the problem or bug that motivated the
-change. What was going wrong or what was missing.
+change — what was going wrong or what was missing.
 
 **How it is being fixed:** Explain the approach taken across all commits.
-Describe the key changes and why this approach was chosen. Write in plain
-prose, not bullet points.
+Describe the key changes and the reasoning behind the approach. Write in
+plain prose rather than bullet points.
 ```
 
-### Create the PR
+### Create the Pull Request
 
 ```bash
-gh pr create --repo <target-org/repo> --head <username>:<branch> --base master --title "<title>" --body "$(cat <<'EOF'
+PR_BODY=$(cat <<'EOF'
 <body>
 EOF
-)"
+)
+
+gh pr create \
+	--base master \
+	--body "${PR_BODY}" \
+	--head <username>:<branch> \
+	--repo <target-org/repo> \
+	--title "<title>"
 ```
 
-Show the user the proposed title and body before creating. If they approve, proceed.
+Present the proposed title and body to the user before submitting. Proceed once they approve.
 
-## 6. Update Jira Ticket
+## 6. Update the Jira Ticket
 
-After the PR is created successfully, transition the Jira ticket to review and set the **Git Pull Request** field using the Jira REST API.
+Once the pull request is created successfully, transition the Jira ticket into review and record the pull request URL in the **Git Pull Request** field via the Jira REST API.
 
-### Determine the ticket type and resolve the target ticket
+### Determine the Ticket Type and Resolve the Target Ticket
 
-LPD uses different workflows depending on the issue type. Check the issue type first:
+LPD applies different workflows depending on the issue type. Check the issue type first:
 
 ```bash
-curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
-  "https://liferay.atlassian.net/rest/api/3/issue/<TICKET>?fields=issuetype,subtasks"
+curl \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/issue/<TICKET>?fields=issuetype,subtasks" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-- **Bug** (type id `10004`): Use the bug ticket directly. Transition to **In Review** uses id `71`.
-- **Technical Task** (subtask, type id `10153`): Use it directly. Transition to **In Peer Review** uses id `31`.
-- **Task** (parent, type id `10002`): Find its Technical Task subtask and use that subtask's key instead. All subsequent operations (transition, PR field, PR title, summary) should reference the **subtask's key**. Transition to **In Peer Review** uses id `31`.
+- **Bug** (type id `10004`): Use the bug ticket directly. The transition to **In Review** uses id `71`.
+- **Task** (parent, type id `10002`): Locate its Technical Task subtask and use that subtask's key. Every subsequent operation (transition, PR field, PR title, summary) must reference the **subtask's key**. The transition to **In Peer Review** uses id `31`.
+- **Technical Task** (subtask, type id `10153`): Use it directly. The transition to **In Peer Review** uses id `31`.
 
-### Ensure the ticket is In Progress first
+### Ensure the Ticket Is In Progress First
 
-Before transitioning to review, check the ticket's current status. If it is **not** already "In Progress", transition it to In Progress first. The transition ID depends on the issue type:
+Before transitioning to review, check the ticket's current status. When it is not already "In Progress", transition it to In Progress first. The transition ID depends on the issue type:
 
-- **Bug**: In Progress transition id is `61`
-- **Technical Task**: In Progress transition id is `41`
+- **Bug**: In Progress transition id is `61`.
+- **Technical Task**: In Progress transition id is `41`.
 
 ```bash
-curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
-  -X POST \
-  -H "Content-Type: application/json" \
-  "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>/transitions" \
-  -d '{
-    "transition": {"id": "<61-for-bug|41-for-task>"}
-  }'
+curl \
+	--data '{"transition": {"id": "<61-for-bug|41-for-task>"}}' \
+	--header "Content-Type: application/json" \
+	--request POST \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>/transitions" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-### Transition to review
+### Transition to Review
 
 For **Bug** tickets (In Review, id `71`):
 
 ```bash
-curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
-  -X POST \
-  -H "Content-Type: application/json" \
-  "https://liferay.atlassian.net/rest/api/3/issue/<BUG>/transitions" \
-  -d '{
-    "transition": {"id": "71"}
-  }'
+curl \
+	--data '{"transition": {"id": "71"}}' \
+	--header "Content-Type: application/json" \
+	--request POST \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/issue/<BUG>/transitions" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-For **Technical Task** tickets or subtask resolved from a Task (In Peer Review, id `31`):
+For **Technical Task** tickets or a subtask resolved from a Task (In Peer Review, id `31`):
 
 ```bash
-curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
-  -X POST \
-  -H "Content-Type: application/json" \
-  "https://liferay.atlassian.net/rest/api/3/issue/<TECHNICAL-TASK>/transitions" \
-  -d '{
-    "transition": {"id": "31"}
-  }'
+curl \
+	--data '{"transition": {"id": "31"}}' \
+	--header "Content-Type: application/json" \
+	--request POST \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/issue/<TECHNICAL-TASK>/transitions" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
 Then set the Git Pull Request field on the target ticket:
 
 ```bash
-curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
-  -X PUT \
-  -H "Content-Type: application/json" \
-  "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>" \
-  -d '{"fields": {"customfield_10201": "<PR-URL>"}}'
+curl \
+	--data '{"fields": {"customfield_10201": "<PR-URL>"}}' \
+	--header "Content-Type: application/json" \
+	--request PUT \
+	--silent \
+	--url "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>" \
+	--user "${JIRA_API_USER}:${JIRA_API_TOKEN}"
 ```
 
-- `customfield_10201` = "Git Pull Request" text field
+- `customfield_10201` is the "Git Pull Request" text field.
 
-If the transition fails (e.g., ticket is already in a later status), still try to set the PR field separately. Verify the update by fetching the ticket status and PR field.
+When the transition fails (for example, when the ticket is already in a later status), still attempt to set the PR field separately. Confirm the update by fetching the ticket status and PR field afterward.
 
 ## 7. Summary
 
-Report back:
-- PR URL
-- Jira ticket status and link
+Report back with:
+
+- The pull request URL.
+- The Jira ticket status and link.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: pr
+description: Create a GitHub pull request for the current branch, update the Jira ticket to In Review, and set the PR link. Use when the user asks to create a PR, send a PR, or says /pr.
+argument-hint: "[optional target-org/repo or message hint]"
+allowed-tools: [Bash, Read, Grep, Glob]
+---
+
+# Create Pull Request
+
+Create a GitHub PR for the current branch and update the Jira ticket.
+
+## 1. Gather Context
+
+If there are uncommitted changes, warn the user and stop — they should commit first (suggest `/commit`).
+
+## 2. Extract the Jira Ticket
+
+The ticket ID is a pattern like `LPD-12345`, `LCD-12345`, `LRCI-1234`, etc. (uppercase letters, hyphen, digits).
+
+1. **Branch name** — extract the ticket from the current branch name (e.g., branch `LPD-83847` → ticket `LPD-83847`).
+2. **Previous commits** — if the branch name has no ticket, look at the commit messages.
+3. **User argument** — if `$ARGUMENTS` contains a ticket ID, use that instead.
+4. **Not found** — if no ticket is found anywhere, ask the user for one.
+
+## 3. Determine the Target
+
+- **Fork owner**: If `$ARGUMENTS` specifies a GitHub org/user, use that. Otherwise, ask the user to choose from: `liferay-bpm`, `liferay-content-management`, `liferay-page-management`.
+- **Fork remote**: Use the user's remote (default: `origin`). Identify the GitHub username from the remote URL (e.g., `git@github.com:brianchandotcom/liferay-portal.git` → `brianchandotcom`).
+- **Target repo**: Default is `<fork-owner>/liferay-portal`. If `$ARGUMENTS` specifies a different `org/repo`, use that.
+- **Base branch**: `master`.
+- **Head**: `<github-username>:<branch-name>`.
+
+## 4. Push the Branch
+
+Push the branch to the user's remote if not already pushed or if there are new local commits:
+
+```bash
+git push -u origin <branch-name>
+```
+
+## 5. Analyze Changes and Create the PR
+
+Read the full diff (`git diff master...HEAD`) and all commit messages to understand what changed.
+
+### PR Title
+
+Keep it short (under 72 characters). Use the Jira ticket as prefix:
+
+```
+LPD-83847 Fix OutOfMemoryError during batch engine import
+```
+
+### PR Body
+
+Use this format:
+
+```markdown
+https://liferay.atlassian.net/browse/TICKET-ID
+
+**What is being fixed:** Explain the problem or bug that motivated the
+change. What was going wrong or what was missing.
+
+**How it is being fixed:** Explain the approach taken across all commits.
+Describe the key changes and why this approach was chosen. Write in plain
+prose, not bullet points.
+```
+
+### Create the PR
+
+```bash
+gh pr create --repo <target-org/repo> --head <username>:<branch> --base master --title "<title>" --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Show the user the proposed title and body before creating. If they approve, proceed.
+
+## 6. Update Jira Ticket
+
+After the PR is created successfully, transition the Jira ticket to review and set the **Git Pull Request** field using the Jira REST API.
+
+### Determine the ticket type and resolve the target ticket
+
+LPD uses different workflows depending on the issue type. Check the issue type first:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TICKET>?fields=issuetype,subtasks"
+```
+
+- **Bug** (type id `10004`): Use the bug ticket directly. Transition to **In Review** uses id `71`.
+- **Technical Task** (subtask, type id `10153`): Use it directly. Transition to **In Peer Review** uses id `31`.
+- **Task** (parent, type id `10002`): Find its Technical Task subtask and use that subtask's key instead. All subsequent operations (transition, PR field, PR title, summary) should reference the **subtask's key**. Transition to **In Peer Review** uses id `31`.
+
+### Ensure the ticket is In Progress first
+
+Before transitioning to review, check the ticket's current status. If it is **not** already "In Progress", transition it to In Progress first. The transition ID depends on the issue type:
+
+- **Bug**: In Progress transition id is `61`
+- **Technical Task**: In Progress transition id is `41`
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>/transitions" \
+  -d '{
+    "transition": {"id": "<61-for-bug|41-for-task>"}
+  }'
+```
+
+### Transition to review
+
+For **Bug** tickets (In Review, id `71`):
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<BUG>/transitions" \
+  -d '{
+    "transition": {"id": "71"}
+  }'
+```
+
+For **Technical Task** tickets or subtask resolved from a Task (In Peer Review, id `31`):
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TECHNICAL-TASK>/transitions" \
+  -d '{
+    "transition": {"id": "31"}
+  }'
+```
+
+Then set the Git Pull Request field on the target ticket:
+
+```bash
+curl -s -u "$JIRA_API_USER:$JIRA_API_TOKEN" \
+  -X PUT \
+  -H "Content-Type: application/json" \
+  "https://liferay.atlassian.net/rest/api/3/issue/<TARGET-TICKET>" \
+  -d '{"fields": {"customfield_10201": "<PR-URL>"}}'
+```
+
+- `customfield_10201` = "Git Pull Request" text field
+
+If the transition fails (e.g., ticket is already in a later status), still try to set the PR field separately. Verify the update by fetching the ticket status and PR field.
+
+## 7. Summary
+
+Report back:
+- PR URL
+- Jira ticket status and link

--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: test-plan
+description: Generate a targeted local test plan for branch changes. Use when the user wants to know what tests to run before merging, asks for a test plan, wants to validate their changes locally, or mentions running tests for their branch. This skill analyzes commits on top of master and produces a runnable shell script with unit, integration, playwright, and poshi tests that fit within a 20-minute local run budget.
+allowed-tools: [Read, Glob, Grep, Bash, Agent]
+---
+
+# Test Plan Generator
+
+You generate a runnable shell script that executes the tests most likely to break given the current branch's changes compared to master.
+
+The context: our test suite is massive — running it all takes hours. We merge aggressively and rely on a daily full test run (results within 24 hours of merge). This skill produces a focused test script (under 20 minutes) to mitigate risk before merging. It is not meant to catch everything — just the most likely breakages.
+
+## How This Project Organizes Tests
+
+Read the reference file for detailed test organization patterns:
+
+```
+${CLAUDE_SKILL_DIR}/references/test-organization.md
+```
+
+## Workflow
+
+### 1. Understand the Changes
+
+```bash
+git diff master...HEAD --name-only
+git log master..HEAD --oneline
+```
+
+Read the changed files to understand what the changes actually do — not just which files were touched, but what behavior changed. This understanding drives the test selection.
+
+### 2. Identify What Could Break
+
+Think about the blast radius of the changes:
+
+- **API/interface changes** (portal-kernel, *-api modules): anything that depends on the changed API could break. Search for consumers.
+- **Service implementation changes**: tests for that service, plus tests for features that depend on it.
+- **Shared infrastructure changes** (e.g., a registry, a framework class, a base class): all modules that use that infrastructure could break. Find representative tests across the affected modules.
+- **Mechanical/repetitive changes** (e.g., adding a property to 200 files): the core logic test is essential, but also include a representative sample of end-to-end tests from affected modules to verify the mechanical change doesn't break anything.
+- **Web layer changes**: playwright and poshi tests for the affected UI.
+
+The goal is not "find all tests in modules that were touched" — it's "find tests that exercise the code paths that changed."
+
+### 3. Find the Tests
+
+For each area that could break, search for test files. Use parallel Agent/Glob calls for speed. Read `${CLAUDE_SKILL_DIR}/references/test-organization.md` for the exact patterns and conventions.
+
+**Verify every test file you list actually exists** using Glob before including it.
+
+### 4. Prioritize for the 20-Minute Budget
+
+Apply this priority order:
+
+**Always include:**
+1. Unit tests for directly changed code — fast (~5-15s per class), highest signal
+2. Integration tests that directly test changed functionality
+3. Tests that exercise the core logic change end-to-end
+
+**Include if budget allows:**
+4. Representative integration tests from affected downstream modules — pick a few that cover different usage patterns rather than running all of them
+5. Playwright tests for affected web modules (~1-3 min per spec)
+
+**Include if still within budget:**
+6. Poshi tests (~2-5 min each)
+7. More downstream module tests for broader coverage
+
+When the change affects many modules (e.g., a framework change), don't try to test every single module. Pick a diverse sample that covers different usage patterns of the changed code.
+
+### 5. Write the Script
+
+Delete any existing `test.sh` in the repository root first, then write a new one. The script must be self-contained and runnable with `bash test.sh`. Use this structure:
+
+```bash
+#!/bin/bash
+#
+# Test plan for branch: <branch-name>
+# Generated: <date>
+# Estimated time: <X>m / 20m budget
+#
+# Changes: <N> commits, <N> files changed
+# Affected areas: <list of module groups/components>
+#
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+EXIT_CODE=0
+
+<test commands — one per line, no blank lines between them>
+
+exit $EXIT_CODE
+```
+
+**Critical rules for the script:**
+- Replace `<test commands>` with the actual test commands you discovered
+- Every command must be suffixed with `|| EXIT_CODE=1` so failures are recorded but execution continues. The script exits with `$EXIT_CODE` at the end — 0 if all passed, 1 if any failed.
+- Use `"$REPO_ROOT/gradlew" -p "$REPO_ROOT/modules"` for gradle tasks (gradlew is at the repo root)
+- Use `npx --prefix "$REPO_ROOT/modules/test/playwright" playwright test` for playwright
+- All test types (unit, integration, playwright, poshi) are included directly — the portal is assumed to be running
+- Add a single-line comment before each command explaining why it was selected — do not repeat the test or module name in the comment, just state the reason.
+
+After writing the script, run `chmod +x test.sh` to make it executable, and tell the user to run it with `./test.sh`.
+
+## Guidelines
+
+- Verify every test file exists using Glob before adding it to the script
+- If changes are purely cosmetic (formatting, comments), say so and generate a script that just exits 0 with a header explaining why

--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: test-plan
-description: Generate a targeted local test plan for branch changes. Use when the user wants to know what tests to run before merging, asks for a test plan, wants to validate their changes locally, or mentions running tests for their branch. This skill analyzes commits on top of master and produces a runnable shell script with unit, integration, playwright, and poshi tests that fit within a 20-minute local run budget.
-allowed-tools: [Read, Glob, Grep, Bash, Agent]
+description: Generate a targeted local test plan for branch changes. Use when the user wants to know which tests to run before merging, asks for a test plan, wants to validate changes locally, or mentions running tests for their branch. This skill analyzes commits on top of master and produces a runnable shell script covering Unit, Integration, Playwright, and Poshi tests within a 20-minute local budget.
+allowed-tools: [Agent, Bash, Glob, Grep, Read]
 ---
 
 # Test Plan Generator
 
-You generate a runnable shell script that executes the tests most likely to break given the current branch's changes compared to master.
+Produce a runnable shell script that executes the tests most likely to regress given the current branch's changes compared to master.
 
-The context: our test suite is massive — running it all takes hours. We merge aggressively and rely on a daily full test run (results within 24 hours of merge). This skill produces a focused test script (under 20 minutes) to mitigate risk before merging. It is not meant to catch everything — just the most likely breakages.
+The full test suite takes hours to run, so the team merges aggressively and relies on a daily full-suite run that delivers results within 24 hours of merge. This skill produces a focused pre-merge script (under 20 minutes) that mitigates risk without attempting full coverage — its goal is to catch the most likely regressions, not every possible one.
 
 ## How This Project Organizes Tests
 
-Read the reference file for detailed test organization patterns:
+Consult the reference file for detailed test organization patterns:
 
 ```
 ${CLAUDE_SKILL_DIR}/references/test-organization.md
@@ -27,48 +27,51 @@ git diff master...HEAD --name-only
 git log master..HEAD --oneline
 ```
 
-Read the changed files to understand what the changes actually do — not just which files were touched, but what behavior changed. This understanding drives the test selection.
+Read the changed files to understand what the changes actually do — not merely which files were touched, but what behavior changed. This understanding drives the test selection.
 
-### 2. Identify What Could Break
+### 2. Identify What Could Regress
 
-Think about the blast radius of the changes:
+Consider the blast radius of each change:
 
-- **API/interface changes** (portal-kernel, *-api modules): anything that depends on the changed API could break. Search for consumers.
-- **Service implementation changes**: tests for that service, plus tests for features that depend on it.
-- **Shared infrastructure changes** (e.g., a registry, a framework class, a base class): all modules that use that infrastructure could break. Find representative tests across the affected modules.
-- **Mechanical/repetitive changes** (e.g., adding a property to 200 files): the core logic test is essential, but also include a representative sample of end-to-end tests from affected modules to verify the mechanical change doesn't break anything.
-- **Web layer changes**: playwright and poshi tests for the affected UI.
+- **API or Interface Changes** (`portal-kernel`, `*-api` modules): Anything that depends on the changed API could regress. Search for consumers.
+- **Mechanical or Repetitive Changes** (e.g., adding a property across 200 files): The core logic test is essential. Also include a representative sample of end-to-end tests from affected modules to verify the mechanical change does not introduce regressions.
+- **Service Implementation Changes**: Tests for the service itself, along with tests for features that depend on it.
+- **Shared Infrastructure Changes** (e.g., a registry, a framework class, a base class): Every module that relies on that infrastructure could regress. Select representative tests spanning the affected modules.
+- **Web Layer Changes**: Playwright and Poshi tests for the affected UI.
 
-The goal is not "find all tests in modules that were touched" — it's "find tests that exercise the code paths that changed."
+The objective is not to "find every test in modules that were touched" — it is to find tests that exercise the code paths that changed.
 
 ### 3. Find the Tests
 
-For each area that could break, search for test files. Use parallel Agent/Glob calls for speed. Read `${CLAUDE_SKILL_DIR}/references/test-organization.md` for the exact patterns and conventions.
+For each area that could regress, search for test files. Use parallel Agent and Glob calls for speed. Consult `${CLAUDE_SKILL_DIR}/references/test-organization.md` for the exact patterns and conventions.
 
-**Verify every test file you list actually exists** using Glob before including it.
+**Verify every test file exists** using Glob before including it in the plan.
 
-### 4. Prioritize for the 20-Minute Budget
+### 4. Prioritize Within the 20-Minute Budget
 
-Apply this priority order:
+Apply the following priority order:
 
 **Always include:**
-1. Unit tests for directly changed code — fast (~5-15s per class), highest signal
-2. Integration tests that directly test changed functionality
-3. Tests that exercise the core logic change end-to-end
 
-**Include if budget allows:**
-4. Representative integration tests from affected downstream modules — pick a few that cover different usage patterns rather than running all of them
-5. Playwright tests for affected web modules (~1-3 min per spec)
+1. Unit tests for directly changed code — fast (approximately 5–15 seconds per class) and highest signal.
+2. Integration tests that directly exercise the changed functionality.
+3. Tests that exercise the core logic change end-to-end.
 
-**Include if still within budget:**
-6. Poshi tests (~2-5 min each)
-7. More downstream module tests for broader coverage
+**Include when budget allows:**
 
-When the change affects many modules (e.g., a framework change), don't try to test every single module. Pick a diverse sample that covers different usage patterns of the changed code.
+4. Representative integration tests from affected downstream modules — choose a few that cover distinct usage patterns rather than running them all.
+5. Playwright tests for affected web modules (approximately 1–3 minutes per spec).
+
+**Include when still within budget:**
+
+6. Poshi tests (approximately 2–5 minutes each).
+7. Additional downstream module tests for broader coverage.
+
+When the change affects many modules (for example, a framework change), do not attempt to test every single module. Choose a diverse sample that covers different usage patterns of the changed code.
 
 ### 5. Write the Script
 
-Delete any existing `test.sh` in the repository root first, then write a new one. The script must be self-contained and runnable with `bash test.sh`. Use this structure:
+Delete any existing `test.sh` at the repository root, then write a new one. The script must be self-contained and runnable via `bash test.sh`. Use this structure:
 
 ```bash
 #!/bin/bash
@@ -78,28 +81,29 @@ Delete any existing `test.sh` in the repository root first, then write a new one
 # Estimated time: <X>m / 20m budget
 #
 # Changes: <N> commits, <N> files changed
-# Affected areas: <list of module groups/components>
+# Affected areas: <list of module groups or components>
 #
 
-REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$(dirname "${0}")" && pwd)"
 EXIT_CODE=0
 
 <test commands — one per line, no blank lines between them>
 
-exit $EXIT_CODE
+exit ${EXIT_CODE}
 ```
 
 **Critical rules for the script:**
-- Replace `<test commands>` with the actual test commands you discovered
-- Every command must be suffixed with `|| EXIT_CODE=1` so failures are recorded but execution continues. The script exits with `$EXIT_CODE` at the end — 0 if all passed, 1 if any failed.
-- Use `"$REPO_ROOT/gradlew" -p "$REPO_ROOT/modules"` for gradle tasks (gradlew is at the repo root)
-- Use `npx --prefix "$REPO_ROOT/modules/test/playwright" playwright test` for playwright
-- All test types (unit, integration, playwright, poshi) are included directly — the portal is assumed to be running
-- Add a single-line comment before each command explaining why it was selected — do not repeat the test or module name in the comment, just state the reason.
 
-After writing the script, run `chmod +x test.sh` to make it executable, and tell the user to run it with `./test.sh`.
+- Replace `<test commands>` with the actual commands discovered during selection.
+- Suffix every command with `|| EXIT_CODE=1` so failures are recorded without halting execution. The script exits with `${EXIT_CODE}` at the end — `0` when all tests pass, `1` when any fail.
+- Use `"${REPO_ROOT}/gradlew" --project-dir "${REPO_ROOT}/modules"` for Gradle tasks (the `gradlew` wrapper lives at the repository root).
+- Use `npx --prefix "${REPO_ROOT}/modules/test/playwright" playwright test` for Playwright.
+- All test types (Unit, Integration, Playwright, Poshi) run directly — the portal is assumed to be running.
+- Precede each command with a single-line comment explaining why it was selected. State the rationale; do not restate the test name or module.
+
+After writing the script, mark it executable with `chmod +x test.sh` and instruct the user to run it via `./test.sh`.
 
 ## Guidelines
 
-- Verify every test file exists using Glob before adding it to the script
-- If changes are purely cosmetic (formatting, comments), say so and generate a script that just exits 0 with a header explaining why
+- Verify every test file exists with Glob before adding it to the script.
+- When the changes are purely cosmetic (formatting, comments), say so and generate a script that exits `0` with a header explaining why.

--- a/.claude/skills/test-plan/SKILL.md
+++ b/.claude/skills/test-plan/SKILL.md
@@ -1,7 +1,7 @@
 ---
-name: test-plan
-description: Generate a targeted local test plan for branch changes. Use when the user wants to know which tests to run before merging, asks for a test plan, wants to validate changes locally, or mentions running tests for their branch. This skill analyzes commits on top of master and produces a runnable shell script covering Unit, Integration, Playwright, and Poshi tests within a 20-minute local budget.
 allowed-tools: [Agent, Bash, Glob, Grep, Read]
+description: Generate a targeted local test plan for branch changes. Use when the user wants to know which tests to run before merging, asks for a test plan, wants to validate changes locally, or mentions running tests for their branch. This skill analyzes commits on top of master and produces a runnable shell script covering Unit, Integration, Playwright, and Poshi tests within a 20-minute local budget.
+name: test-plan
 ---
 
 # Test Plan Generator
@@ -45,7 +45,7 @@ The objective is not to "find every test in modules that were touched" — it is
 
 For each area that could regress, search for test files. Use parallel Agent and Glob calls for speed. Consult `${CLAUDE_SKILL_DIR}/references/test-organization.md` for the exact patterns and conventions.
 
-**Verify every test file exists** using Glob before including it in the plan.
+**Verify every test file exists** before including it in the plan.
 
 ### 4. Prioritize Within the 20-Minute Budget
 
@@ -105,5 +105,5 @@ After writing the script, mark it executable with `chmod +x test.sh` and instruc
 
 ## Guidelines
 
-- Verify every test file exists with Glob before adding it to the script.
+- Verify every test file exists before adding it to the script.
 - When the changes are purely cosmetic (formatting, comments), say so and generate a script that exits `0` with a header explaining why.

--- a/.claude/skills/test-plan/references/test-organization.md
+++ b/.claude/skills/test-plan/references/test-organization.md
@@ -1,0 +1,98 @@
+# Liferay Portal Test Organization Reference
+
+## Module Structure
+
+Standard module layout:
+```
+modules/apps/{module-group}/
+├── {module}-api/           # API/interfaces (rarely has tests)
+├── {module}-service/       # Implementation
+│   └── src/test/java/      # Unit tests live here
+├── {module}-test/          # Separate test module
+│   └── src/testIntegration/java/  # Integration tests live here
+├── {module}-web/           # Web/portlet layer
+├── {module}-web-test/      # Web integration tests (sometimes)
+├── {module}-test-util/     # Shared test utilities
+├── build.gradle
+└── test.properties         # Test-to-component mapping
+```
+
+## Test Type Details
+
+### Unit Tests
+
+- **Location**: `{module-group}/{module}-service/src/test/java/**/*Test.java`
+- **Also in**: `portal-impl/src/test/java/**/*Test.java` for core code
+- **Framework**: JUnit 4, Mockito
+- **Run command**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test`
+- **Run specific class**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test --tests "com.liferay.{package}.SomeTest"`
+- **Speed**: ~5-15 seconds per test class
+- **Naming**: Source file name + `Test` suffix (e.g., `BlogsEntryLocalServiceImpl.java` → `BlogsEntryLocalServiceImplTest.java`)
+
+### Integration Tests
+
+- **Location**: `{module-group}/{module}-test/src/testIntegration/java/**/*Test.java`
+- **Also in**: `{module-group}/{module}-web-test/src/testIntegration/java/` for web tests
+- **Framework**: Arquillian + JUnit bridge (`@RunWith(Arquillian.class)`)
+- **Run command**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration`
+- **Run specific class**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration --tests "com.liferay.{package}.SomeTest"`
+- **Speed**: ~30-120 seconds per test class (needs portal context)
+- **Note**: These require a running Liferay instance or will bootstrap one
+
+### Playwright Tests
+
+- **Location**: `modules/test/playwright/tests/{module-web}/**/*.spec.ts`
+- **Config**: `modules/test/playwright/playwright.config.ts` (imports per-module configs)
+- **Run all for a module**: `cd modules/test/playwright && npx playwright test tests/{module-web}/`
+- **Run specific file**: `cd modules/test/playwright && npx playwright test tests/{module-web}/main/someTest.spec.ts`
+- **Speed**: ~1-3 minutes per spec file
+- **Structure**: Each module directory typically has `main/config.ts` and `main/*.spec.ts`
+- **Coverage**: ~131 module directories, ~630 spec files
+
+### Poshi Functional Tests
+
+- **Location**: `portal-web/test/functional/com/liferay/portalweb/`
+- **Test files**: `tests/enduser/**/*.testcase` (~514 files)
+- **Macros**: `macros/*.macro` (~516 files)
+- **Speed**: ~2-5 minutes per test method
+- **Annotations**:
+  - `@component-name` — links to a component (e.g., `"portal-headless"`)
+  - `@priority` — 1-5 (5 = most critical)
+  - `testray.main.component.name` — component for test reporting
+- **Organization**: `tests/enduser/{category}/{subcategory}/` (categories: abtest, collaboration, contentdashboard, documentmanagement, exportimport, publications, staging, wem, etc.)
+
+## Mapping Source Changes to Tests
+
+### Direct mapping (same module)
+A change to `modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java` maps to:
+- Unit test: `modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java`
+
+### Cross-module mapping (test module)
+A change to `modules/apps/blogs/blogs-service/` maps to:
+- Integration tests in: `modules/apps/blogs/blogs-test/src/testIntegration/java/`
+
+### Using test.properties for broader mapping
+Each module group has a `test.properties` at `modules/apps/{module-group}/test.properties` containing:
+
+```properties
+# Maps to poshi component name
+testray.main.component.name=Blogs
+
+# Defines which test classes run for this module's changes
+modules.includes.required.test.batch.class.names.includes[modules-unit][relevant][rule-name]=\
+    apps/blogs/**/*Test.java
+
+modules.includes.required.test.batch.class.names.includes[modules-integration-postgresql163][relevant][rule-name]=\
+    apps/blogs/**/*Test.java,\
+    apps/headless/headless-delivery/headless-delivery-test/**/BaseBlog*Test.java,\
+    apps/headless/headless-delivery/headless-delivery-test/**/Blog*Test.java
+```
+
+Use `testray.main.component.name` to find related poshi `.testcase` files by searching for matching `@component-name` or `testray.main.component.name` properties inside them.
+
+### Playwright mapping
+Map the module's web component name to its playwright directory:
+- Change in `modules/apps/blogs/blogs-web/` → tests in `modules/test/playwright/tests/blogs-web/`
+- Change in `modules/apps/document-library/document-library-web/` → tests in `modules/test/playwright/tests/document-library-web/`
+
+The directory name in `modules/test/playwright/tests/` matches the `-web` module name.

--- a/.claude/skills/test-plan/references/test-organization.md
+++ b/.claude/skills/test-plan/references/test-organization.md
@@ -3,82 +3,88 @@
 ## Module Structure
 
 Standard module layout:
+
 ```
 modules/apps/{module-group}/
-├── {module}-api/           # API/interfaces (rarely has tests)
-├── {module}-service/       # Implementation
-│   └── src/test/java/      # Unit tests live here
-├── {module}-test/          # Separate test module
-│   └── src/testIntegration/java/  # Integration tests live here
-├── {module}-web/           # Web/portlet layer
-├── {module}-web-test/      # Web integration tests (sometimes)
-├── {module}-test-util/     # Shared test utilities
+├── {module}-api/                   # API and interfaces (rarely has tests)
+├── {module}-service/               # Implementation
+│   └── src/test/java/              # Unit tests live here
+├── {module}-test/                  # Separate test module
+│   └── src/testIntegration/java/   # Integration tests live here
+├── {module}-test-util/             # Shared test utilities
+├── {module}-web/                   # Web and portlet layer
+├── {module}-web-test/              # Web integration tests (when applicable)
 ├── build.gradle
-└── test.properties         # Test-to-component mapping
+└── test.properties                 # Test-to-component mapping
 ```
 
 ## Test Type Details
 
 ### Unit Tests
 
-- **Location**: `{module-group}/{module}-service/src/test/java/**/*Test.java`
-- **Also in**: `portal-impl/src/test/java/**/*Test.java` for core code
-- **Framework**: JUnit 4, Mockito
-- **Run command**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test`
-- **Run specific class**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test --tests "com.liferay.{package}.SomeTest"`
-- **Speed**: ~5-15 seconds per test class
-- **Naming**: Source file name + `Test` suffix (e.g., `BlogsEntryLocalServiceImpl.java` → `BlogsEntryLocalServiceImplTest.java`)
+- **Location**: `{module-group}/{module}-service/src/test/java/**/*Test.java`.
+- **Also In**: `portal-impl/src/test/java/**/*Test.java` for core code.
+- **Framework**: JUnit 4 with Mockito.
+- **Naming**: Source file name with a `Test` suffix (e.g., `BlogsEntryLocalServiceImpl.java` maps to `BlogsEntryLocalServiceImplTest.java`).
+- **Run All in a Module**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test`.
+- **Run a Specific Class**: `cd modules && ../gradlew :apps:{module-group}:{module}-service:test --tests "com.liferay.{package}.SomeTest"`.
+- **Speed**: Approximately 5–15 seconds per test class.
 
 ### Integration Tests
 
-- **Location**: `{module-group}/{module}-test/src/testIntegration/java/**/*Test.java`
-- **Also in**: `{module-group}/{module}-web-test/src/testIntegration/java/` for web tests
-- **Framework**: Arquillian + JUnit bridge (`@RunWith(Arquillian.class)`)
-- **Run command**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration`
-- **Run specific class**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration --tests "com.liferay.{package}.SomeTest"`
-- **Speed**: ~30-120 seconds per test class (needs portal context)
-- **Note**: These require a running Liferay instance or will bootstrap one
+- **Location**: `{module-group}/{module}-test/src/testIntegration/java/**/*Test.java`.
+- **Also In**: `{module-group}/{module}-web-test/src/testIntegration/java/` for web tests.
+- **Framework**: Arquillian with the JUnit bridge (`@RunWith(Arquillian.class)`).
+- **Note**: Integration tests require a running Liferay instance or will bootstrap one.
+- **Run All in a Module**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration`.
+- **Run a Specific Class**: `cd modules && ../gradlew :apps:{module-group}:{module}-test:testIntegration --tests "com.liferay.{package}.SomeTest"`.
+- **Speed**: Approximately 30–120 seconds per test class (portal context required).
 
 ### Playwright Tests
 
-- **Location**: `modules/test/playwright/tests/{module-web}/**/*.spec.ts`
-- **Config**: `modules/test/playwright/playwright.config.ts` (imports per-module configs)
-- **Run all for a module**: `cd modules/test/playwright && npx playwright test tests/{module-web}/`
-- **Run specific file**: `cd modules/test/playwright && npx playwright test tests/{module-web}/main/someTest.spec.ts`
-- **Speed**: ~1-3 minutes per spec file
-- **Structure**: Each module directory typically has `main/config.ts` and `main/*.spec.ts`
-- **Coverage**: ~131 module directories, ~630 spec files
+- **Location**: `modules/test/playwright/tests/{module-web}/**/*.spec.ts`.
+- **Config**: `modules/test/playwright/playwright.config.ts` (imports per-module configs).
+- **Coverage**: Approximately 131 module directories and 630 spec files.
+- **Run All for a Module**: `cd modules/test/playwright && npx playwright test tests/{module-web}/`.
+- **Run a Specific File**: `cd modules/test/playwright && npx playwright test tests/{module-web}/main/someTest.spec.ts`.
+- **Speed**: Approximately 1–3 minutes per spec file.
+- **Structure**: Each module directory typically contains `main/config.ts` and `main/*.spec.ts`.
 
 ### Poshi Functional Tests
 
-- **Location**: `portal-web/test/functional/com/liferay/portalweb/`
-- **Test files**: `tests/enduser/**/*.testcase` (~514 files)
-- **Macros**: `macros/*.macro` (~516 files)
-- **Speed**: ~2-5 minutes per test method
+- **Location**: `portal-web/test/functional/com/liferay/portalweb/`.
 - **Annotations**:
-  - `@component-name` — links to a component (e.g., `"portal-headless"`)
-  - `@priority` — 1-5 (5 = most critical)
-  - `testray.main.component.name` — component for test reporting
-- **Organization**: `tests/enduser/{category}/{subcategory}/` (categories: abtest, collaboration, contentdashboard, documentmanagement, exportimport, publications, staging, wem, etc.)
+	- `@component-name` — links to a component (e.g., `"portal-headless"`).
+	- `@priority` — ranges from 1 to 5, with 5 denoting the most critical.
+	- `testray.main.component.name` — the component used for test reporting.
+- **Macros**: `macros/*.macro` (approximately 516 files).
+- **Organization**: `tests/enduser/{category}/{subcategory}/` with categories such as `abtest`, `collaboration`, `contentdashboard`, `documentmanagement`, `exportimport`, `publications`, `staging`, and `wem`.
+- **Speed**: Approximately 2–5 minutes per test method.
+- **Test Files**: `tests/enduser/**/*.testcase` (approximately 514 files).
 
 ## Mapping Source Changes to Tests
 
-### Direct mapping (same module)
+### Direct Mapping (Same Module)
+
 A change to `modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/util/PingbackMethodImpl.java` maps to:
-- Unit test: `modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java`
 
-### Cross-module mapping (test module)
+- Unit test: `modules/apps/blogs/blogs-service/src/test/java/com/liferay/blogs/internal/util/PingbackMethodImplTest.java`.
+
+### Cross-Module Mapping (Test Module)
+
 A change to `modules/apps/blogs/blogs-service/` maps to:
-- Integration tests in: `modules/apps/blogs/blogs-test/src/testIntegration/java/`
 
-### Using test.properties for broader mapping
-Each module group has a `test.properties` at `modules/apps/{module-group}/test.properties` containing:
+- Integration tests in `modules/apps/blogs/blogs-test/src/testIntegration/java/`.
+
+### Using test.properties for Broader Mapping
+
+Each module group has a `test.properties` file at `modules/apps/{module-group}/test.properties` containing:
 
 ```properties
-# Maps to poshi component name
+# Maps to the Poshi component name.
 testray.main.component.name=Blogs
 
-# Defines which test classes run for this module's changes
+# Defines which test classes run for this module's changes.
 modules.includes.required.test.batch.class.names.includes[modules-unit][relevant][rule-name]=\
     apps/blogs/**/*Test.java
 
@@ -88,11 +94,11 @@ modules.includes.required.test.batch.class.names.includes[modules-integration-po
     apps/headless/headless-delivery/headless-delivery-test/**/Blog*Test.java
 ```
 
-Use `testray.main.component.name` to find related poshi `.testcase` files by searching for matching `@component-name` or `testray.main.component.name` properties inside them.
+Use `testray.main.component.name` to locate related Poshi `.testcase` files by searching for matching `@component-name` or `testray.main.component.name` annotations.
 
-### Playwright mapping
-Map the module's web component name to its playwright directory:
-- Change in `modules/apps/blogs/blogs-web/` → tests in `modules/test/playwright/tests/blogs-web/`
-- Change in `modules/apps/document-library/document-library-web/` → tests in `modules/test/playwright/tests/document-library-web/`
+### Playwright Mapping
 
-The directory name in `modules/test/playwright/tests/` matches the `-web` module name.
+Map the module's web component name to its Playwright directory. The directory name under `modules/test/playwright/tests/` mirrors the `-web` module name:
+
+- A change in `modules/apps/blogs/blogs-web/` maps to tests in `modules/test/playwright/tests/blogs-web/`.
+- A change in `modules/apps/document-library/document-library-web/` maps to tests in `modules/test/playwright/tests/document-library-web/`.

--- a/cloud/scripts/bootstrap.sh
+++ b/cloud/scripts/bootstrap.sh
@@ -98,6 +98,8 @@ function _download_and_extract_files {
 		exit 1
 	fi
 
+	rm --force "${output_file}"
+
 	curl \
 		--location \
 		--output "${output_file}" \
@@ -106,7 +108,7 @@ function _download_and_extract_files {
 
 	local output_dir="${output_file%.tar.gz}"
 
-	mkdir "${output_dir}"
+	mkdir --parent "${output_dir}"
 
 	tar \
 		--directory "${output_dir}" \

--- a/modules/.releng/test/jenkins-results-parser/artifact.properties
+++ b/modules/.releng/test/jenkins-results-parser/artifact.properties
@@ -1,3 +1,3 @@
-artifact.git.id=e630605b39b62e6b2dab0076339b259ed483569f
-artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1791/com.liferay.jenkins.results.parser-1.0.1791-sources.jar
-artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1791/com.liferay.jenkins.results.parser-1.0.1791.jar
+artifact.git.id=8823abedac69537866fc78d455c552a422e1dde7
+artifact.sources.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1792/com.liferay.jenkins.results.parser-1.0.1792-sources.jar
+artifact.url=https://repository-cdn.liferay.com/nexus/content/repositories/liferay-public-releases/com/liferay/com.liferay.jenkins.results.parser/1.0.1792/com.liferay.jenkins.results.parser-1.0.1792.jar

--- a/modules/apps/asset/asset-tags-admin-web/src/test/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContextTest.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/test/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsDisplayContextTest.java
@@ -28,7 +28,7 @@ import jakarta.servlet.http.HttpServletRequest;
 
 import java.util.List;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -51,16 +51,16 @@ public class AssetTagsDisplayContextTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
-	@AfterClass
-	public static void tearDownClass() {
-		_portletURLUtilMockedStatic.close();
-		_stagingGroupHelperUtilMockedStatic.close();
-	}
-
 	@Before
 	public void setUp() throws Exception {
 		_setUpLanguageUtil();
 		_setUpPortletURLUtil();
+	}
+
+	@After
+	public void tearDown() {
+		_portletURLUtilMockedStatic.close();
+		_stagingGroupHelperUtilMockedStatic.close();
 	}
 
 	@Test

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/security/permission/resource/BookmarksEntryModelResourcePermissionWrapper.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/security/permission/resource/BookmarksEntryModelResourcePermissionWrapper.java
@@ -30,7 +30,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Preston Crary
  */
 @Component(
-	property = "model.class.name=com.liferay.bookmarks.model.BookmarksEntry",
+	property = {
+		"model.class.name=com.liferay.bookmarks.model.BookmarksEntry",
+		"permissions.view.dynamic.inheritance.checking=true"
+	},
 	service = ModelResourcePermission.class
 )
 public class BookmarksEntryModelResourcePermissionWrapper

--- a/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/security/permission/resource/BookmarksFolderModelResourcePermissionWrapper.java
+++ b/modules/apps/bookmarks/bookmarks-service/src/main/java/com/liferay/bookmarks/internal/security/permission/resource/BookmarksFolderModelResourcePermissionWrapper.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Preston Crary
  */
 @Component(
-	property = "model.class.name=com.liferay.bookmarks.model.BookmarksFolder",
+	property = {
+		"model.class.name=com.liferay.bookmarks.model.BookmarksFolder",
+		"permissions.view.dynamic.inheritance.checking=true"
+	},
 	service = ModelResourcePermission.class
 )
 public class BookmarksFolderModelResourcePermissionWrapper

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/AssetCategorySitemapURLProvider.java
@@ -152,7 +152,7 @@ public class AssetCategorySitemapURLProvider implements SitemapURLProvider {
 			_sitemapManager.addURLElement(
 				element, alternateFriendlyURL, typeSettingsUnicodeProperties,
 				layout.getModifiedDate(), categoryFriendlyURL,
-				alternateFriendlyURLs);
+				alternateFriendlyURLs, layout.getGroupId());
 		}
 	}
 

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/site/provider/CPDefinitionSitemapURLProvider.java
@@ -167,7 +167,7 @@ public class CPDefinitionSitemapURLProvider implements SitemapURLProvider {
 			_sitemapManager.addURLElement(
 				element, alternateFriendlyURL, typeSettingsUnicodeProperties,
 				layout.getModifiedDate(), productFriendlyURL,
-				alternateFriendlyURLs);
+				alternateFriendlyURLs, layout.getGroupId());
 		}
 	}
 

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -69,8 +70,9 @@ public class ResourceActionPostUpgradeDataCleanupProcess
 			while (resultSet1.next()) {
 				String name = resultSet1.getString("name");
 
-				if (!name.startsWith("com.liferay.") &&
-					!name.startsWith("com_liferay_")) {
+				if (Validator.isNull(name) ||
+					(!name.startsWith("com.liferay.") &&
+					 !name.startsWith("com_liferay_"))) {
 
 					continue;
 				}

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourceActionPostUpgradeDataCleanupProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourceActionPostUpgradeDataCleanupProcessTest.java
@@ -7,6 +7,7 @@ package com.liferay.data.cleanup.internal.verify.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
@@ -184,6 +185,37 @@ public class ResourceActionPostUpgradeDataCleanupProcessTest
 					role.getRoleId(), resourceActionActionId);
 			},
 			getPostUpgradeDataCleanupProcessClassName(), LoggerTestUtil.DEBUG);
+	}
+
+	@Test
+	public void testResourceActionWithBlankNameIsIgnored() throws Exception {
+		AtomicReference<ResourceAction> resourceActionAtomicReference =
+			new AtomicReference<>();
+		String resourceActionActionId = "VIEW";
+		String resourceActionName = StringPool.BLANK;
+
+		test(
+			logCapture -> {
+				List<String> messages = logCapture.getMessages();
+
+				Assert.assertTrue(messages.toString(), messages.isEmpty());
+
+				ResourceAction resourceAction =
+					_resourceActionLocalService.fetchResourceAction(
+						resourceActionAtomicReference.get(
+						).getResourceActionId());
+
+				Assert.assertNotNull(resourceAction);
+			},
+			() -> {
+				if (resourceActionAtomicReference.get() != null) {
+					_resourceActionLocalService.deleteResourceAction(
+						resourceActionAtomicReference.get());
+				}
+			},
+			() -> resourceActionAtomicReference.set(
+				_resourceActionLocalService.addResourceAction(
+					resourceActionName, resourceActionActionId, 1)));
 	}
 
 	@Test

--- a/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/asset/model/test/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-test/src/testIntegration/java/com/liferay/depot/internal/asset/model/test/DepotAssetRendererFactoryWrapperTest.java
@@ -1,0 +1,194 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.depot.internal.asset.model.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.AssetRendererFactoryCustomizer;
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetRenderer;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.depot.constants.DepotConstants;
+import com.liferay.depot.model.DepotEntry;
+import com.liferay.depot.service.DepotEntryGroupRelLocalService;
+import com.liferay.depot.service.DepotEntryLocalService;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFileEntryTypeConstants;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.exportimport.kernel.service.StagingLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.constants.TestDataConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.io.ByteArrayInputStream;
+
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class DepotAssetRendererFactoryWrapperTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testGetAssetRenderer() throws Exception {
+		_testGetAssetRenderer(
+			assetRenderer -> Assert.assertNull(assetRenderer), false);
+		_testGetAssetRenderer(
+			assetRenderer -> Assert.assertNotNull(assetRenderer), true);
+	}
+
+	private DLFileEntry _addDLFileEntry(Group group) throws Exception {
+		byte[] bytes = TestDataConstants.TEST_BYTE_ARRAY;
+
+		return _dlFileEntryLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(),
+			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString(),
+			ContentTypes.APPLICATION_OCTET_STREAM,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK,
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_BASIC_DOCUMENT, null,
+			null, new ByteArrayInputStream(bytes), bytes.length, null, null,
+			null,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private Group _enableLocalStaging(Group group) throws Exception {
+		_stagingLocalService.enableLocalStaging(
+			TestPropsValues.getUserId(), group, false, false,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		return group.getStagingGroup();
+	}
+
+	private ServiceContext _getServiceContext(Group group) throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		HttpServletRequest httpServletRequest = new MockHttpServletRequest();
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setScopeGroupId(group.getGroupId());
+
+		httpServletRequest.setAttribute(WebKeys.THEME_DISPLAY, themeDisplay);
+
+		serviceContext.setRequest(httpServletRequest);
+
+		return serviceContext;
+	}
+
+	private void _testGetAssetRenderer(
+			UnsafeConsumer<AssetRenderer<?>, Exception> unsafeConsumer,
+			boolean addDepotEntryGroupRel)
+		throws Exception {
+
+		DepotEntry depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			new HashMap<>(), DepotConstants.TYPE_ASSET_LIBRARY,
+			ServiceContextTestUtil.getServiceContext());
+
+		Group group = GroupTestUtil.addGroup();
+
+		DLFileEntry dlFileEntry = _addDLFileEntry(depotEntry.getGroup());
+
+		_enableLocalStaging(depotEntry.getGroup());
+
+		if (addDepotEntryGroupRel) {
+			_depotEntryGroupRelLocalService.addDepotEntryGroupRel(
+				depotEntry.getDepotEntryId(), group.getGroupId());
+		}
+
+		Group stagedGroup = _enableLocalStaging(group);
+
+		AssetRendererFactory<Object> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				DLFileEntry.class.getName());
+
+		AssetRendererFactory<?> customizedAssetRendererFactory =
+			_assetRendererFactory.customize(assetRendererFactory);
+
+		ServiceContextThreadLocal.pushServiceContext(
+			_getServiceContext(stagedGroup));
+
+		try {
+			unsafeConsumer.accept(
+				customizedAssetRendererFactory.getAssetRenderer(
+					dlFileEntry.getFileEntryId()));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+
+			_stagingLocalService.disableStaging(
+				group, ServiceContextTestUtil.getServiceContext());
+
+			_groupLocalService.deleteGroup(group);
+
+			_stagingLocalService.disableStaging(
+				depotEntry.getGroup(),
+				ServiceContextTestUtil.getServiceContext());
+
+			_depotEntryLocalService.deleteDepotEntry(depotEntry);
+		}
+	}
+
+	@Inject
+	private AssetRendererFactoryCustomizer _assetRendererFactory;
+
+	@Inject
+	private DepotEntryGroupRelLocalService _depotEntryGroupRelLocalService;
+
+	@Inject
+	private DepotEntryLocalService _depotEntryLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private GroupLocalService _groupLocalService;
+
+	@Inject
+	private StagingLocalService _stagingLocalService;
+
+}

--- a/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
+++ b/modules/apps/depot/depot-web/src/main/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapper.java
@@ -32,6 +32,8 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import jakarta.portlet.PortletURL;
 import jakarta.portlet.WindowState;
@@ -105,14 +107,43 @@ public class DepotAssetRendererFactoryWrapper<T>
 			return null;
 		}
 
-		if (group.isControlPanel() ||
-			ArrayUtil.contains(
-				_siteConnectedGroupGroupProvider.
-					getCurrentAndAncestorSiteAndDepotGroupIds(
-						_getGroupId(group.getGroupId())),
-				groupId)) {
+		if (group.isControlPanel()) {
+			return assetRenderer;
+		}
+
+		long[] currentAndAncestorSiteAndDepotGroupIds =
+			_siteConnectedGroupGroupProvider.
+				getCurrentAndAncestorSiteAndDepotGroupIds(
+					_getGroupId(group.getGroupId()));
+
+		if (ArrayUtil.contains(
+				currentAndAncestorSiteAndDepotGroupIds, groupId)) {
 
 			return assetRenderer;
+		}
+
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			groupId);
+
+		if (depotEntry != null) {
+			StagingGroupHelper stagingGroupHelper =
+				StagingGroupHelperUtil.getStagingGroupHelper();
+
+			Group depotEntryGroup = depotEntry.getGroup();
+
+			if (stagingGroupHelper.isLocalLiveGroup(depotEntryGroup) ||
+				stagingGroupHelper.isRemoteLiveGroup(depotEntryGroup)) {
+
+				Group stagedDepotEntryGroup = depotEntryGroup.getStagingGroup();
+
+				if ((stagedDepotEntryGroup != null) &&
+					ArrayUtil.contains(
+						currentAndAncestorSiteAndDepotGroupIds,
+						stagedDepotEntryGroup.getGroupId())) {
+
+					return assetRenderer;
+				}
+			}
 		}
 
 		if (!FeatureFlagManagerUtil.isEnabled(
@@ -121,10 +152,9 @@ public class DepotAssetRendererFactoryWrapper<T>
 			return null;
 		}
 
-		DepotEntry depotEntry = _depotEntryLocalService.getGroupDepotEntry(
-			groupId);
+		if ((depotEntry != null) &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
 
-		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
 			return assetRenderer;
 		}
 

--- a/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
+++ b/modules/apps/depot/depot-web/src/test/java/com/liferay/depot/web/internal/asset/model/DepotAssetRendererFactoryWrapperTest.java
@@ -20,14 +20,19 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.function.Consumer;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 /**
@@ -39,6 +44,16 @@ public class DepotAssetRendererFactoryWrapperTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_setUpStagingGroupHelper();
+	}
+
+	@After
+	public void tearDown() {
+		_stagingGroupHelperUtilMockedStatic.close();
+	}
 
 	@Test
 	public void testAssetRendererReturnsFallbackGroup() throws Exception {
@@ -235,7 +250,7 @@ public class DepotAssetRendererFactoryWrapperTest {
 		DepotEntry depotEntry = Mockito.mock(DepotEntry.class);
 
 		Mockito.when(
-			_depotEntryLocalService.getGroupDepotEntry(Mockito.anyLong())
+			_depotEntryLocalService.fetchGroupDepotEntry(Mockito.anyLong())
 		).thenReturn(
 			depotEntry
 		);
@@ -339,6 +354,35 @@ public class DepotAssetRendererFactoryWrapperTest {
 
 		return groupId;
 	}
+
+	private void _setUpStagingGroupHelper() {
+		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
+			StagingGroupHelperUtil.class);
+
+		StagingGroupHelper stagingGroupHelper = Mockito.mock(
+			StagingGroupHelper.class);
+
+		Mockito.when(
+			StagingGroupHelperUtil.getStagingGroupHelper()
+		).thenReturn(
+			stagingGroupHelper
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isLocalLiveGroup(Mockito.any())
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isRemoteLiveGroup(Mockito.any())
+		).thenReturn(
+			false
+		);
+	}
+
+	private static MockedStatic<StagingGroupHelperUtil>
+		_stagingGroupHelperUtilMockedStatic;
 
 	private final AssetRendererFactory<Object> _assetRendererFactory =
 		Mockito.mock(AssetRendererFactory.class);

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFileEntryModelResourcePermissionWrapper.java
@@ -44,7 +44,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Preston Crary
  */
 @Component(
-	property = "model.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+	property = {
+		"model.class.name=com.liferay.document.library.kernel.model.DLFileEntry",
+		"permissions.view.dynamic.inheritance.checking=true"
+	},
 	service = ModelResourcePermission.class
 )
 public class DLFileEntryModelResourcePermissionWrapper

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFolderModelResourcePermissionWrapper.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/security/permission/resource/DLFolderModelResourcePermissionWrapper.java
@@ -29,7 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Preston Crary
  */
 @Component(
-	property = "model.class.name=com.liferay.document.library.kernel.model.DLFolder",
+	property = {
+		"model.class.name=com.liferay.document.library.kernel.model.DLFolder",
+		"permissions.view.dynamic.inheritance.checking=true"
+	},
 	service = ModelResourcePermission.class
 )
 public class DLFolderModelResourcePermissionWrapper

--- a/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilderTest.java
+++ b/modules/apps/document-library/document-library-web/src/test/java/com/liferay/document/library/web/internal/display/context/logic/UIItemsBuilderTest.java
@@ -44,9 +44,9 @@ import java.net.URISyntaxException;
 import org.assertj.core.api.AbstractUriAssert;
 import org.assertj.core.api.Assertions;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -64,8 +64,8 @@ public class UIItemsBuilderTest {
 	public static LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
+	@Before
+	public void setUp() throws Exception {
 		_setUpGroupPermissionUtil();
 		_setUpPortletURLUtil();
 		_setUpStagedModelDataHandlerRegistryUtil();
@@ -108,8 +108,8 @@ public class UIItemsBuilderTest {
 		portalUtil.setPortal(new PortalImpl());
 	}
 
-	@AfterClass
-	public static void tearDownClass() {
+	@After
+	public void tearDown() {
 		_groupPermissionUtilMockedStatic.close();
 		_portletURLUtilMockedStatic.close();
 		_stagedModelDataHandlerRegistryUtilMockedStatic.close();
@@ -221,71 +221,6 @@ public class UIItemsBuilderTest {
 		Assert.assertTrue(uiItemsBuilder.isPublishActionAvailable());
 	}
 
-	private static void _setUpGroupPermissionUtil() {
-		_groupPermissionUtilMockedStatic = Mockito.mockStatic(
-			GroupPermissionUtil.class);
-	}
-
-	private static void _setUpPortletURLUtil() throws Exception {
-		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
-
-		Mockito.when(
-			PortletURLUtil.getCurrent(
-				Mockito.any(LiferayPortletRequest.class),
-				Mockito.any(LiferayPortletResponse.class))
-		).thenReturn(
-			new MockLiferayPortletURL()
-		);
-	}
-
-	private static void _setUpStagedModelDataHandlerRegistryUtil() {
-		_stagedModelDataHandlerRegistryUtilMockedStatic = Mockito.mockStatic(
-			StagedModelDataHandlerRegistryUtil.class);
-
-		StagedModelDataHandler<FileEntry> stagedModelDataHandler = Mockito.mock(
-			StagedModelDataHandler.class);
-
-		Mockito.when(
-			stagedModelDataHandler.getExportableStatuses()
-		).thenReturn(
-			new int[] {0}
-		);
-
-		Mockito.<StagedModelDataHandler>when(
-			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
-				FileEntry.class.getName())
-		).thenReturn(
-			stagedModelDataHandler
-		);
-	}
-
-	private static void _setUpStagingGroupHelper() {
-		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
-			StagingGroupHelperUtil.class);
-
-		StagingGroupHelper stagingGroupHelper = Mockito.mock(
-			StagingGroupHelper.class);
-
-		Mockito.when(
-			StagingGroupHelperUtil.getStagingGroupHelper()
-		).thenReturn(
-			stagingGroupHelper
-		);
-
-		Mockito.when(
-			stagingGroupHelper.isStagingGroup(Mockito.anyLong())
-		).thenReturn(
-			true
-		);
-
-		Mockito.when(
-			stagingGroupHelper.isStagedPortlet(
-				Mockito.anyLong(), Mockito.anyString())
-		).thenReturn(
-			true
-		);
-	}
-
 	private void _addExportImportPortletInfoPermission(
 		ThemeDisplay themeDisplay, boolean contains) {
 
@@ -349,6 +284,71 @@ public class UIItemsBuilderTest {
 		return new UIItemsBuilder(
 			mockHttpServletRequest, _fileEntry, _fileVersion, null,
 			versioningStrategy, _dlurlHelper);
+	}
+
+	private void _setUpGroupPermissionUtil() {
+		_groupPermissionUtilMockedStatic = Mockito.mockStatic(
+			GroupPermissionUtil.class);
+	}
+
+	private void _setUpPortletURLUtil() throws Exception {
+		_portletURLUtilMockedStatic = Mockito.mockStatic(PortletURLUtil.class);
+
+		Mockito.when(
+			PortletURLUtil.getCurrent(
+				Mockito.any(LiferayPortletRequest.class),
+				Mockito.any(LiferayPortletResponse.class))
+		).thenReturn(
+			new MockLiferayPortletURL()
+		);
+	}
+
+	private void _setUpStagedModelDataHandlerRegistryUtil() {
+		_stagedModelDataHandlerRegistryUtilMockedStatic = Mockito.mockStatic(
+			StagedModelDataHandlerRegistryUtil.class);
+
+		StagedModelDataHandler<FileEntry> stagedModelDataHandler = Mockito.mock(
+			StagedModelDataHandler.class);
+
+		Mockito.when(
+			stagedModelDataHandler.getExportableStatuses()
+		).thenReturn(
+			new int[] {0}
+		);
+
+		Mockito.<StagedModelDataHandler>when(
+			StagedModelDataHandlerRegistryUtil.getStagedModelDataHandler(
+				FileEntry.class.getName())
+		).thenReturn(
+			stagedModelDataHandler
+		);
+	}
+
+	private void _setUpStagingGroupHelper() {
+		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
+			StagingGroupHelperUtil.class);
+
+		StagingGroupHelper stagingGroupHelper = Mockito.mock(
+			StagingGroupHelper.class);
+
+		Mockito.when(
+			StagingGroupHelperUtil.getStagingGroupHelper()
+		).thenReturn(
+			stagingGroupHelper
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isStagingGroup(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			stagingGroupHelper.isStagedPortlet(
+				Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			true
+		);
 	}
 
 	private static DLURLHelper _dlurlHelper;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -601,19 +601,18 @@ public class DDMFormDisplayContext {
 		return LanguageUtil.get(resourceBundle, "submit-form");
 	}
 
-	public String getSuccessPageDescription(Locale locale)
-		throws PortalException {
-
+	public String getSuccessPageDescription() throws PortalException {
 		DDMFormSuccessPageSettings ddmFormSuccessPageSettings =
 			getDDMFormSuccessPageSettings();
 
 		LocalizedValue body = ddmFormSuccessPageSettings.getBody();
 
 		return GetterUtil.getString(
-			body.getString(locale), body.getString(body.getDefaultLocale()));
+			body.getString(_renderRequest.getLocale()),
+			body.getString(body.getDefaultLocale()));
 	}
 
-	public String getSuccessPageTitle(Locale locale) throws PortalException {
+	public String getSuccessPageTitle() throws PortalException {
 		DDMFormSuccessPageSettings ddmFormSuccessPageSettings =
 			getDDMFormSuccessPageSettings();
 
@@ -621,7 +620,7 @@ public class DDMFormDisplayContext {
 
 		return HtmlUtil.escape(
 			GetterUtil.getString(
-				title.getString(locale),
+				title.getString(_renderRequest.getLocale()),
 				title.getString(title.getDefaultLocale())));
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/display/view.jsp
@@ -80,8 +80,8 @@ boolean limitToOneSubmissionPerUser = DDMFormInstanceSubmissionLimitStatusUtil.i
 					pageTitle = LanguageUtil.get(request, "this-form-is-no-longer-available");
 				}
 				else if (showSuccessPage) {
-					pageDescription = ddmFormDisplayContext.getSuccessPageDescription(displayLocale);
-					pageTitle = ddmFormDisplayContext.getSuccessPageTitle(displayLocale);
+					pageDescription = ddmFormDisplayContext.getSuccessPageDescription();
+					pageTitle = ddmFormDisplayContext.getSuccessPageTitle();
 				}
 				else {
 					Map<String, String> limitToOneSubmissionPerUserMap = ddmFormDisplayContext.getLimitToOneSubmissionPerUserMap();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/test/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContextTest.java
@@ -21,6 +21,7 @@ import com.liferay.dynamic.data.mapping.model.DDMFormInstanceVersion;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
 import com.liferay.dynamic.data.mapping.model.DDMFormSuccessPageSettings;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.model.impl.DDMFormInstanceImpl;
 import com.liferay.dynamic.data.mapping.render.DDMFormFieldRenderingContext;
 import com.liferay.dynamic.data.mapping.service.DDMFormInstanceLocalService;
@@ -32,6 +33,7 @@ import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMStorageAdapterRegistry;
 import com.liferay.dynamic.data.mapping.storage.constants.FieldConstants;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesMerger;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
@@ -599,6 +601,58 @@ public class DDMFormDisplayContextTest {
 
 		Assert.assertEquals(
 			submitLabel, ddmFormDisplayContext.getSubmitLabel());
+	}
+
+	@Test
+	public void testGetSuccessPage() throws Exception {
+		DDMFormSuccessPageSettings ddmFormSuccessPageSettings = Mockito.mock(
+			DDMFormSuccessPageSettings.class);
+
+		String enValue = RandomTestUtil.randomString();
+		String ptValue = RandomTestUtil.randomString();
+
+		LocalizedValue localizedValue =
+			DDMFormValuesTestUtil.createLocalizedValue(
+				enValue, ptValue, LocaleUtil.SPAIN);
+
+		Mockito.when(
+			ddmFormSuccessPageSettings.getBody()
+		).thenReturn(
+			localizedValue
+		);
+
+		Mockito.when(
+			ddmFormSuccessPageSettings.getTitle()
+		).thenReturn(
+			localizedValue
+		);
+
+		MockRenderRequest mockRenderRequest = new MockRenderRequest();
+
+		mockRenderRequest.addPreferredLocale(LocaleUtil.US);
+		mockRenderRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _mockThemeDisplay(false));
+
+		DDMFormDisplayContext ddmFormDisplayContext = Mockito.spy(
+			_createDDMFormDisplayContext(mockRenderRequest));
+
+		Mockito.doReturn(
+			ddmFormSuccessPageSettings
+		).when(
+			ddmFormDisplayContext
+		).getDDMFormSuccessPageSettings();
+
+		Assert.assertEquals(
+			enValue, ddmFormDisplayContext.getSuccessPageDescription());
+		Assert.assertEquals(
+			enValue, ddmFormDisplayContext.getSuccessPageTitle());
+
+		mockRenderRequest.addPreferredLocale(LocaleUtil.BRAZIL);
+
+		Assert.assertEquals(
+			ptValue, ddmFormDisplayContext.getSuccessPageDescription());
+		Assert.assertEquals(
+			ptValue, ddmFormDisplayContext.getSuccessPageTitle());
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/staged/model/repository/DDMFormInstanceRecordStagedModelRepositoryUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/exportimport/staged/model/repository/DDMFormInstanceRecordStagedModelRepositoryUtil.java
@@ -37,6 +37,8 @@ public class DDMFormInstanceRecordStagedModelRepositoryUtil {
 		ServiceContext serviceContext = portletDataContext.createServiceContext(
 			ddmFormInstanceRecord);
 
+		serviceContext.setAttribute(
+			"ipAddress", ddmFormInstanceRecord.getIpAddress());
 		serviceContext.setAttribute("validateDDMFormValues", Boolean.FALSE);
 
 		if (portletDataContext.isDataStrategyMirror()) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMFormInstanceRecordLocalServiceImpl.java
@@ -45,6 +45,7 @@ import com.liferay.dynamic.data.mapping.storage.StorageType;
 import com.liferay.dynamic.data.mapping.util.DDMFormUtil;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidator;
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -83,6 +84,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.TimeZoneUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
@@ -588,12 +590,7 @@ public class DDMFormInstanceRecordLocalServiceImpl
 			ddmFormInstance.getVersion());
 		ddmFormInstanceRecord.setVersion(_VERSION_DEFAULT);
 
-		HttpServletRequest httpServletRequest = serviceContext.getRequest();
-
-		if (httpServletRequest != null) {
-			ddmFormInstanceRecord.setIpAddress(
-				httpServletRequest.getRemoteAddr());
-		}
+		_setIpAddress(ddmFormInstanceRecord, serviceContext);
 
 		ddmFormInstanceRecord = ddmFormInstanceRecordPersistence.update(
 			ddmFormInstanceRecord);
@@ -964,6 +961,27 @@ public class DDMFormInstanceRecordLocalServiceImpl
 		return lastAttributes.equals(latestAttributes);
 	}
 
+	private void _setIpAddress(
+		DDMFormInstanceRecord ddmFormInstanceRecord,
+		ServiceContext serviceContext) {
+
+		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		if (httpServletRequest != null) {
+			ddmFormInstanceRecord.setIpAddress(
+				httpServletRequest.getRemoteAddr());
+
+			return;
+		}
+
+		String ipAddress = GetterUtil.getString(
+			serviceContext.getAttribute("ipAddress"));
+
+		if (!Validator.isBlank(ipAddress)) {
+			ddmFormInstanceRecord.setIpAddress(ipAddress);
+		}
+	}
+
 	private void _startWorkflowInstance(
 			long companyId, DDMFormInstance ddmFormInstance,
 			DDMFormInstanceRecord ddmFormInstanceRecord,
@@ -991,7 +1009,10 @@ public class DDMFormInstanceRecordLocalServiceImpl
 				"entryTitleXML", ddmFormInstance.getName()
 			).build());
 
-		if (_isEmailNotificationEnabled(ddmFormInstance)) {
+		if (_isEmailNotificationEnabled(ddmFormInstance) &&
+			!ExportImportThreadLocal.isImportInProcess() &&
+			!ExportImportThreadLocal.isStagingInProcess()) {
+
 			_ddmFormEmailNotificationSender.sendEmailNotification(
 				ddmFormInstanceRecord, serviceContext);
 		}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
@@ -32,7 +32,9 @@ import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -60,6 +62,46 @@ public class DDMFormInstanceRecordStagedModelDataHandlerTest
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	@TestInfo("LPD-85617")
+	public void testExportImportPreservesIpAddress() throws Exception {
+		String fieldName = RandomTestUtil.randomString();
+
+		DDMFormInstance ddmFormInstance = addFormInstanceWithTextField(
+			fieldName);
+
+		DDMFormValues ddmFormValues = DDMFormValuesTestUtil.createDDMFormValues(
+			ddmFormInstance.getDDMForm());
+
+		DDMFormFieldValue ddmFormFieldValue = createTextDDMFormFieldValue(
+			ddmFormValues.getDefaultLocale(), fieldName,
+			RandomTestUtil.randomString());
+
+		ddmFormValues.addDDMFormFieldValue(ddmFormFieldValue);
+
+		DDMFormInstanceRecord ddmFormInstanceRecord =
+			DDMFormInstanceRecordTestUtil.addDDMFormInstanceRecord(
+				ddmFormInstance, ddmFormValues, stagingGroup,
+				TestPropsValues.getUserId());
+
+		ddmFormInstanceRecord.setIpAddress("1.2.3.4");
+
+		ddmFormInstanceRecord =
+			DDMFormInstanceRecordLocalServiceUtil.updateDDMFormInstanceRecord(
+				ddmFormInstanceRecord);
+
+		exportImportStagedModel(ddmFormInstanceRecord);
+
+		DDMFormInstanceRecord importedDDMFormInstanceRecord =
+			DDMFormInstanceRecordLocalServiceUtil.
+				getDDMFormInstanceRecordByUuidAndGroupId(
+					ddmFormInstanceRecord.getUuid(), liveGroup.getGroupId());
+
+		Assert.assertEquals(
+			ddmFormInstanceRecord.getIpAddress(),
+			importedDDMFormInstanceRecord.getIpAddress());
+	}
 
 	@Test
 	public void testVersionMatchingAfterExportImport() throws Exception {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/exportimport/data/handler/test/DDMFormInstanceRecordStagedModelDataHandlerTest.java
@@ -65,7 +65,7 @@ public class DDMFormInstanceRecordStagedModelDataHandlerTest
 
 	@Test
 	@TestInfo("LPD-85617")
-	public void testExportImportPreservesIpAddress() throws Exception {
+	public void testExportImportPreservesIPAddress() throws Exception {
 		String fieldName = RandomTestUtil.randomString();
 
 		DDMFormInstance ddmFormInstance = addFormInstanceWithTextField(

--- a/modules/apps/export-import/export-import-report-service/src/test/java/com/liferay/exportimport/report/internal/empty/model/EmptyModelManagerImplTest.java
+++ b/modules/apps/export-import/export-import-report-service/src/test/java/com/liferay/exportimport/report/internal/empty/model/EmptyModelManagerImplTest.java
@@ -31,10 +31,8 @@ import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,19 +50,6 @@ public class EmptyModelManagerImplTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
-	@BeforeClass
-	public static void setUpClass() {
-		ReflectionTestUtil.setFieldValue(_emptyModelManager, "_log", _log);
-
-		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
-			StagingGroupHelperUtil.class);
-	}
-
-	@AfterClass
-	public static void tearDownClass() {
-		_stagingGroupHelperUtilMockedStatic.close();
-	}
-
 	@Before
 	public void setUp() {
 		ReflectionTestUtil.setFieldValue(
@@ -75,8 +60,10 @@ public class EmptyModelManagerImplTest {
 			_exportImportReportEntryLocalService);
 		ReflectionTestUtil.setFieldValue(
 			_emptyModelManager, "_groupLocalService", _groupLocalService);
+		ReflectionTestUtil.setFieldValue(_emptyModelManager, "_log", _log);
 
-		_stagingGroupHelperUtilMockedStatic.reset();
+		_stagingGroupHelperUtilMockedStatic = Mockito.mockStatic(
+			StagingGroupHelperUtil.class);
 	}
 
 	@After
@@ -84,6 +71,8 @@ public class EmptyModelManagerImplTest {
 		Mockito.verifyNoMoreInteractions(
 			_classNameLocalService, _exportImportReportEntryLocalService,
 			_group, _groupLocalService, _log, _user);
+
+		_stagingGroupHelperUtilMockedStatic.close();
 	}
 
 	@Test

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalArticleModelResourcePermissionWrapper.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalArticleModelResourcePermissionWrapper.java
@@ -34,7 +34,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Preston Crary
  */
 @Component(
-	property = "model.class.name=com.liferay.journal.model.JournalArticle",
+	property = {
+		"model.class.name=com.liferay.journal.model.JournalArticle",
+		"permissions.view.dynamic.inheritance.checking=true"
+	},
 	service = ModelResourcePermission.class
 )
 public class JournalArticleModelResourcePermissionWrapper

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalFolderModelResourcePermissionWrapper.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/security/permission/resource/JournalFolderModelResourcePermissionWrapper.java
@@ -30,7 +30,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Preston Crary
  */
 @Component(
-	property = "model.class.name=com.liferay.journal.model.JournalFolder",
+	property = {
+		"model.class.name=com.liferay.journal.model.JournalFolder",
+		"permissions.view.dynamic.inheritance.checking=true"
+	},
 	service = ModelResourcePermission.class
 )
 public class JournalFolderModelResourcePermissionWrapper

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/site/provider/JournalArticleSitemapURLProvider.java
@@ -333,8 +333,8 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			for (String alternateURL : alternateURLs.values()) {
 				_sitemapManager.addURLElement(
 					element, alternateURL, null,
-					journalArticle.getModifiedDate(), articleURL,
-					alternateURLs);
+					journalArticle.getModifiedDate(), articleURL, alternateURLs,
+					articleLayout.getGroupId());
 			}
 
 			processedArticleIds.add(journalArticle.getArticleId());

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/site/provider/LayoutSitemapURLProvider.java
@@ -136,7 +136,8 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		for (String alternateURL : alternateURLs.values()) {
 			_sitemapManager.addURLElement(
 				element, alternateURL, typeSettingsUnicodeProperties,
-				layout.getModifiedDate(), layoutFullURL, alternateURLs);
+				layout.getModifiedDate(), layoutFullURL, alternateURLs,
+				layout.getGroupId());
 		}
 	}
 

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/security/permission/resource/MBCategoryPermissionRegistrar.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/security/permission/resource/MBCategoryPermissionRegistrar.java
@@ -43,6 +43,8 @@ public class MBCategoryPermissionRegistrar {
 		Dictionary<String, Object> properties =
 			HashMapDictionaryBuilder.<String, Object>put(
 				"model.class.name", MBCategory.class.getName()
+			).put(
+				"permissions.view.dynamic.inheritance.checking", "true"
 			).build();
 
 		_serviceRegistration = bundleContext.registerService(

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/security/permission/resource/MBMessagePermissionRegistrar.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/internal/security/permission/resource/MBMessagePermissionRegistrar.java
@@ -49,6 +49,8 @@ public class MBMessagePermissionRegistrar {
 		Dictionary<String, Object> properties =
 			HashMapDictionaryBuilder.<String, Object>put(
 				"model.class.name", MBMessage.class.getName()
+			).put(
+				"permissions.view.dynamic.inheritance.checking", "true"
 			).build();
 
 		_serviceRegistration = bundleContext.registerService(

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -109,7 +110,8 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 	}
 
 	public static List<InfoFieldValue<Object>> getInfoFieldValues(
-			DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
+			String defaultLanguageId, DLAppLocalService dlAppLocalService,
+			DLURLHelper dlURLHelper,
 			FriendlyURLEntryLocalService friendlyURLEntryLocalService,
 			ListTypeEntryLocalService listTypeEntryLocalService,
 			ObjectActionLocalService objectActionLocalService,
@@ -140,8 +142,9 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 			}
 
 			_addInfoFieldValue(
-				dlAppLocalService, dlURLHelper, infoFieldValues,
-				listTypeEntryLocalService, objectEntryLocalService, objectField,
+				defaultLanguageId, dlAppLocalService, dlURLHelper,
+				infoFieldValues, listTypeEntryLocalService,
+				objectEntryLocalService, objectField,
 				objectFieldInfoFieldConverter,
 				ObjectField.class.getSimpleName(),
 				objectRelationshipLocalService, themeDisplay, value);
@@ -194,11 +197,11 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				}
 
 				_addInfoFieldValue(
-					dlAppLocalService, dlURLHelper, infoFieldValues,
-					listTypeEntryLocalService, objectEntryLocalService,
-					relatedObjectField, objectFieldInfoFieldConverter,
-					namespace, objectRelationshipLocalService, themeDisplay,
-					value);
+					defaultLanguageId, dlAppLocalService, dlURLHelper,
+					infoFieldValues, listTypeEntryLocalService,
+					objectEntryLocalService, relatedObjectField,
+					objectFieldInfoFieldConverter, namespace,
+					objectRelationshipLocalService, themeDisplay, value);
 
 				infoFieldValues.add(
 					new InfoFieldValue<>(
@@ -302,7 +305,8 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 	}
 
 	private static void _addInfoFieldValue(
-			DLAppLocalService dlAppLocalService, DLURLHelper dlURLHelper,
+			String defaultLanguageId, DLAppLocalService dlAppLocalService,
+			DLURLHelper dlURLHelper,
 			List<InfoFieldValue<Object>> infoFieldValues,
 			ListTypeEntryLocalService listTypeEntryLocalService,
 			ObjectEntryLocalService objectEntryLocalService,
@@ -334,9 +338,15 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 		if (objectField.isLocalized() && (value instanceof Map)) {
 			Map<String, Object> map = (Map<String, Object>)value;
 
+			Locale defaultLocale = null;
+
+			if (Validator.isNotNull(defaultLanguageId)) {
+				defaultLocale = LocaleUtil.fromLanguageId(defaultLanguageId);
+			}
+
 			infoFieldValue = InfoLocalizedValue.builder(
 			).defaultLocale(
-				LocaleUtil.fromLanguageId(objectField.getDefaultLanguageId())
+				defaultLocale
 			).value(
 				consumer -> {
 					for (Map.Entry<String, Object> entry : map.entrySet()) {

--- a/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
+++ b/modules/apps/object/object-info-api/src/main/java/com/liferay/object/info/item/provider/util/ObjectEntryInfoItemValuesProviderUtil.java
@@ -155,8 +155,6 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				continue;
 			}
 
-			Map<String, Object> properties = new HashMap<>();
-
 			ObjectRelationship objectRelationship =
 				objectRelationshipLocalService.
 					fetchObjectRelationshipByObjectFieldId2(
@@ -173,8 +171,13 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 					GetterUtil.getLong(values.get(objectField.getName()))),
 				themeDisplay);
 
+			Map<String, Object> properties = new HashMap<>();
+			String relatedObjectEntryDefaultLanguageId = defaultLanguageId;
+
 			if (objectEntry != null) {
 				properties = objectEntry.getProperties();
+				relatedObjectEntryDefaultLanguageId =
+					objectEntry.getDefaultLanguageId();
 			}
 
 			for (ObjectField relatedObjectField :
@@ -197,8 +200,8 @@ public class ObjectEntryInfoItemValuesProviderUtil {
 				}
 
 				_addInfoFieldValue(
-					defaultLanguageId, dlAppLocalService, dlURLHelper,
-					infoFieldValues, listTypeEntryLocalService,
+					relatedObjectEntryDefaultLanguageId, dlAppLocalService,
+					dlURLHelper, infoFieldValues, listTypeEntryLocalService,
 					objectEntryLocalService, relatedObjectField,
 					objectFieldInfoFieldConverter, namespace,
 					objectRelationshipLocalService, themeDisplay, value);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/site/provider/ObjectEntrySitemapURLProvider.java
@@ -243,7 +243,8 @@ public class ObjectEntrySitemapURLProvider implements SitemapURLProvider {
 			for (String alternateURL : alternateURLs.values()) {
 				_sitemapManager.addURLElement(
 					element, alternateURL, typeSettingsUnicodeProperties,
-					objectEntry.getModifiedDate(), canonicalURL, alternateURLs);
+					objectEntry.getModifiedDate(), canonicalURL, alternateURLs,
+					layout.getGroupId());
 			}
 		}
 	}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/info/item/provider/SystemObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/system/info/item/provider/SystemObjectEntryInfoItemFieldValuesProvider.java
@@ -226,11 +226,12 @@ public class SystemObjectEntryInfoItemFieldValuesProvider
 
 		infoFieldValues.addAll(
 			ObjectEntryInfoItemValuesProviderUtil.getInfoFieldValues(
-				_dlAppLocalService, _dlURLHelper, _friendlyURLEntryLocalService,
-				_listTypeEntryLocalService, _objectActionLocalService,
-				_objectDefinition, _objectDefinitionLocalService,
-				_objectEntryLocalService, _objectEntryManagerRegistry,
-				_objectFieldInfoFieldConverter, _objectFieldLocalService,
+				null, _dlAppLocalService, _dlURLHelper,
+				_friendlyURLEntryLocalService, _listTypeEntryLocalService,
+				_objectActionLocalService, _objectDefinition,
+				_objectDefinitionLocalService, _objectEntryLocalService,
+				_objectEntryManagerRegistry, _objectFieldInfoFieldConverter,
+				_objectFieldLocalService,
 				_objectFieldLocalService.getObjectFields(
 					_objectDefinition.getObjectDefinitionId()),
 				_objectRelationshipLocalService, _objectScopeProviderRegistry,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryFolderLocalServiceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.object.service.impl;
 
+import com.liferay.asset.categories.thread.local.AssetVocabularyThreadLocal;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
@@ -961,18 +962,38 @@ public class ObjectEntryFolderLocalServiceImpl
 			ObjectEntryFolder objectEntryFolder, ServiceContext serviceContext)
 		throws PortalException {
 
-		_assetEntryLocalService.updateEntry(
-			serviceContext.getUserId(), objectEntryFolder.getGroupId(),
-			objectEntryFolder.getCreateDate(),
-			objectEntryFolder.getModifiedDate(),
-			ObjectEntryFolder.class.getName(),
-			objectEntryFolder.getObjectEntryFolderId(),
-			objectEntryFolder.getUuid(), 0,
-			serviceContext.getAssetCategoryIds(),
-			serviceContext.getAssetTagNames(), true,
-			objectEntryFolder.getStatus() == WorkflowConstants.STATUS_APPROVED,
-			null, null, objectEntryFolder.getCreateDate(), null, null,
-			objectEntryFolder.getName(), null, null, null, null, 0, 0, null);
+		DepotEntry depotEntry = _depotEntryLocalService.fetchGroupDepotEntry(
+			objectEntryFolder.getGroupId());
+
+		boolean originalSkipRequiredCategoryValidation =
+			AssetVocabularyThreadLocal.isSkipRequiredCategoryValidation();
+
+		if ((depotEntry != null) &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
+
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
+		}
+
+		try {
+			_assetEntryLocalService.updateEntry(
+				serviceContext.getUserId(), objectEntryFolder.getGroupId(),
+				objectEntryFolder.getCreateDate(),
+				objectEntryFolder.getModifiedDate(),
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId(),
+				objectEntryFolder.getUuid(), 0,
+				serviceContext.getAssetCategoryIds(),
+				serviceContext.getAssetTagNames(), true,
+				objectEntryFolder.getStatus() ==
+					WorkflowConstants.STATUS_APPROVED,
+				null, null, objectEntryFolder.getCreateDate(), null, null,
+				objectEntryFolder.getName(), null, null, null, null, 0, 0,
+				null);
+		}
+		finally {
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(
+				originalSkipRequiredCategoryValidation);
+		}
 	}
 
 	private void _updateObjectEntryFolderName(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -6611,6 +6611,9 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
+		boolean originalSkipRequiredCategoryValidation =
+			AssetVocabularyThreadLocal.isSkipRequiredCategoryValidation();
+
 		if (!objectDefinition.isEnableCategorization()) {
 			assetCategoryIds = null;
 			assetTagNames = null;
@@ -6635,7 +6638,8 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 		finally {
-			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(false);
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(
+				originalSkipRequiredCategoryValidation);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -6579,6 +6579,8 @@ public class ObjectEntryLocalServiceImpl
 		if (!objectDefinition.isEnableCategorization()) {
 			assetCategoryIds = null;
 			assetTagNames = null;
+
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
 		}
 
 		String mimeType = ContentTypes.TEXT_PLAIN;
@@ -6616,19 +6618,24 @@ public class ObjectEntryLocalServiceImpl
 			}
 		}
 
-		AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
-			userId, objectEntry.getNonzeroGroupId(),
-			objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
-			objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
-			objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
-			objectEntry.isApproved(), null, null, null, null, mimeType, title,
-			String.valueOf(objectEntry.getObjectEntryId()), null, null, null, 0,
-			0, priority, serviceContext);
+		try {
+			AssetEntry assetEntry = _assetEntryLocalService.updateEntry(
+				userId, objectEntry.getNonzeroGroupId(),
+				objectEntry.getCreateDate(), objectEntry.getModifiedDate(),
+				objectDefinition.getClassName(), objectEntry.getObjectEntryId(),
+				objectEntry.getUuid(), 0, assetCategoryIds, assetTagNames, true,
+				objectEntry.isApproved(), null, null, null, null, mimeType,
+				title, String.valueOf(objectEntry.getObjectEntryId()), null,
+				null, null, 0, 0, priority, serviceContext);
 
-		if (assetLinkEntryIds != null) {
-			_assetLinkLocalService.updateLinks(
-				userId, assetEntry.getEntryId(), assetLinkEntryIds,
-				AssetLinkConstants.TYPE_RELATED);
+			if (assetLinkEntryIds != null) {
+				_assetLinkLocalService.updateLinks(
+					userId, assetEntry.getEntryId(), assetLinkEntryIds,
+					AssetLinkConstants.TYPE_RELATED);
+			}
+		}
+		finally {
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(false);
 		}
 	}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectEntryLocalServiceImpl.java
@@ -6576,13 +6576,6 @@ public class ObjectEntryLocalServiceImpl
 			_objectDefinitionPersistence.findByPrimaryKey(
 				objectEntry.getObjectDefinitionId());
 
-		if (!objectDefinition.isEnableCategorization()) {
-			assetCategoryIds = null;
-			assetTagNames = null;
-
-			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
-		}
-
 		String mimeType = ContentTypes.TEXT_PLAIN;
 		String title = StringPool.BLANK;
 
@@ -6616,6 +6609,13 @@ public class ObjectEntryLocalServiceImpl
 				serviceContext.setAttribute(
 					"assetTagScopeGroupId", group.getGroupId());
 			}
+		}
+
+		if (!objectDefinition.isEnableCategorization()) {
+			assetCategoryIds = null;
+			assetTagNames = null;
+
+			AssetVocabularyThreadLocal.setSkipRequiredCategoryValidation(true);
 		}
 
 		try {

--- a/modules/apps/object/object-test/build.gradle
+++ b/modules/apps/object/object-test/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-api")
 	testIntegrationImplementation project(":apps:asset:asset-display-page-api")
 	testIntegrationImplementation project(":apps:asset:asset-list-api")
+	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:batch-engine:batch-engine-api")
 	testIntegrationImplementation project(":apps:blogs:blogs-api")
 	testIntegrationImplementation project(":apps:commerce:commerce-api")

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryFolderLocalServiceTest.java
@@ -6,6 +6,9 @@
 package com.liferay.object.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.depot.constants.DepotConstants;
 import com.liferay.depot.constants.DepotRolesConstants;
 import com.liferay.depot.model.DepotEntry;
@@ -103,6 +106,16 @@ public class ObjectEntryFolderLocalServiceTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_depotEntry = _depotEntryLocalService.addDepotEntry(
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			HashMapBuilder.put(
+				LocaleUtil.getDefault(), RandomTestUtil.randomString()
+			).build(),
+			DepotConstants.TYPE_SPACE,
+			ServiceContextTestUtil.getServiceContext());
+
 		_group = GroupTestUtil.addGroup();
 
 		_objectDefinition = _addObjectDefinition();
@@ -251,6 +264,17 @@ public class ObjectEntryFolderLocalServiceTest {
 			_hasResourcePermission(
 				ObjectActionKeys.ADD_OBJECT_ENTRY_FOLDER, objectEntryFolder,
 				role));
+
+		AssetTestUtil.addVocabulary(
+			_depotEntry.getGroupId(), AssetCategoryConstants.ALL_CLASS_NAME_ID,
+			AssetCategoryConstants.ALL_CLASS_TYPE_PK, true);
+
+		_objectEntryFolderLocalService.addObjectEntryFolder(
+			StringUtil.randomString(), _depotEntry.getGroupId(),
+			TestPropsValues.getUserId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			RandomTestUtil.randomString(), null, StringUtil.randomString(),
+			new ServiceContext());
 	}
 
 	@FeatureFlag("LPD-17564")
@@ -1149,6 +1173,12 @@ public class ObjectEntryFolderLocalServiceTest {
 		return _objectEntryFolderLocalService.updateObjectEntryFolder(
 			objectEntryFolder);
 	}
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
+
+	@DeleteAfterTestRun
+	private DepotEntry _depotEntry;
 
 	@Inject
 	private DepotEntryLocalService _depotEntryLocalService;

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectEntryLocalServiceTest.java
@@ -9,10 +9,13 @@ import com.liferay.account.constants.AccountConstants;
 import com.liferay.account.model.AccountEntry;
 import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
+import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.commerce.currency.model.CommerceCurrency;
 import com.liferay.commerce.currency.test.util.CommerceCurrencyTestUtil;
 import com.liferay.commerce.model.CommerceOrder;
@@ -1787,6 +1790,38 @@ public class ObjectEntryLocalServiceTest {
 			0,
 			_counterLocalService.getCurrentId(
 				ObjectFieldUtil.getCounterName(objectField)));
+	}
+
+	@Test
+	public void testAddObjectEntryWithCategorization() throws Exception {
+		Group group = GroupTestUtil.addGroup();
+
+		AssetTestUtil.addVocabulary(
+			group.getGroupId(), AssetCategoryConstants.ALL_CLASS_NAME_ID,
+			AssetCategoryConstants.ALL_CLASS_TYPE_PK, true);
+
+		boolean originalEnableCategorization =
+			_siteObjectDefinition.isEnableCategorization();
+
+		_siteObjectDefinition = _enableCategorization(
+			true, _siteObjectDefinition);
+
+		AssertUtils.assertFailure(
+			PortalException.class, null,
+			() -> _addObjectEntry(
+				group.getGroupId(),
+				_siteObjectDefinition.getObjectDefinitionId(),
+				Collections.emptyMap()));
+
+		_siteObjectDefinition = _enableCategorization(
+			false, _siteObjectDefinition);
+
+		_addObjectEntry(
+			group.getGroupId(), _siteObjectDefinition.getObjectDefinitionId(),
+			Collections.emptyMap());
+
+		_siteObjectDefinition = _enableCategorization(
+			originalEnableCategorization, _siteObjectDefinition);
 	}
 
 	@Test
@@ -8006,6 +8041,15 @@ public class ObjectEntryLocalServiceTest {
 		return listTypeEntries;
 	}
 
+	private ObjectDefinition _enableCategorization(
+		boolean enable, ObjectDefinition objectDefinition) {
+
+		objectDefinition.setEnableCategorization(enable);
+
+		return _objectDefinitionLocalService.updateObjectDefinition(
+			objectDefinition);
+	}
+
 	private void _enableObjectEntryVersioning() {
 		_objectDefinition.setEnableObjectEntryVersioning(true);
 
@@ -9748,6 +9792,9 @@ public class ObjectEntryLocalServiceTest {
 
 	@Inject
 	private AssetTagLocalService _assetTagLocalService;
+
+	@Inject
+	private AssetVocabularyLocalService _assetVocabularyLocalService;
 
 	@Inject
 	private AttachmentManager _attachmentManager;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -255,7 +255,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 
 		objectEntryFieldValues.addAll(
 			ObjectEntryInfoItemValuesProviderUtil.getInfoFieldValues(
-				_dlAppLocalService, _dlURLHelper, _friendlyURLEntryLocalService,
+				objectEntry.getDefaultLanguageId(), _dlAppLocalService,
+				_dlURLHelper, _friendlyURLEntryLocalService,
 				_listTypeEntryLocalService, _objectActionLocalService,
 				_objectDefinition, _objectDefinitionLocalService,
 				_objectEntryLocalService, _objectEntryManagerRegistry,
@@ -367,7 +368,8 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				objectEntry.getReviewDate()));
 		objectEntryFieldValues.addAll(
 			ObjectEntryInfoItemValuesProviderUtil.getInfoFieldValues(
-				_dlAppLocalService, _dlURLHelper, _friendlyURLEntryLocalService,
+				objectEntry.getDefaultLanguageId(), _dlAppLocalService,
+				_dlURLHelper, _friendlyURLEntryLocalService,
 				_listTypeEntryLocalService, _objectActionLocalService,
 				_objectDefinition, _objectDefinitionLocalService,
 				_objectEntryLocalService, _objectEntryManagerRegistry,

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/pagination/BasePermissionFilteredPaginationTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/pagination/BasePermissionFilteredPaginationTestCase.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.test.util.pagination;
 
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.search.Document;
@@ -17,6 +18,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchResultPermissionFilter;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.search.configuration.DefaultSearchResultPermissionFilterConfiguration;
@@ -279,6 +281,9 @@ public abstract class BasePermissionFilteredPaginationTestCase
 			defaultSearchResultPermissionFilterConfiguration = Mockito.mock(
 				DefaultSearchResultPermissionFilterConfiguration.class);
 
+		ServiceTrackerMap<String, ModelResourcePermission<?>>
+			serviceTrackerMap = Mockito.mock(ServiceTrackerMap.class);
+
 		setUpSearchResultPermissionFilterMocks(
 			indexerRegistry, permissionChecker,
 			defaultSearchResultPermissionFilterConfiguration);
@@ -290,7 +295,8 @@ public abstract class BasePermissionFilteredPaginationTestCase
 			new FacetPostProcessorImpl(), indexerRegistry, permissionChecker,
 			relatedEntryIndexerRegistry, this::doSearch,
 			searchRequestBuilderFactory,
-			defaultSearchResultPermissionFilterConfiguration);
+			defaultSearchResultPermissionFilterConfiguration,
+			serviceTrackerMap);
 	}
 
 	protected void doAssertPagination(

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/pagination/BasePermissionFilteredPaginationTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/pagination/BasePermissionFilteredPaginationTestCase.java
@@ -292,11 +292,10 @@ public abstract class BasePermissionFilteredPaginationTestCase
 			_getSearchRequestBuilderFactory();
 
 		return new DefaultSearchResultPermissionFilter(
+			defaultSearchResultPermissionFilterConfiguration,
 			new FacetPostProcessorImpl(), indexerRegistry, permissionChecker,
 			relatedEntryIndexerRegistry, this::doSearch,
-			searchRequestBuilderFactory,
-			defaultSearchResultPermissionFilterConfiguration,
-			serviceTrackerMap);
+			searchRequestBuilderFactory, serviceTrackerMap);
 	}
 
 	protected void doAssertPagination(

--- a/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/pagination/BasePermissionFilteredPaginationTestCase.java
+++ b/modules/apps/portal-search/portal-search-test-util/src/main/java/com/liferay/portal/search/test/util/pagination/BasePermissionFilteredPaginationTestCase.java
@@ -281,15 +281,14 @@ public abstract class BasePermissionFilteredPaginationTestCase
 			defaultSearchResultPermissionFilterConfiguration = Mockito.mock(
 				DefaultSearchResultPermissionFilterConfiguration.class);
 
-		ServiceTrackerMap<String, ModelResourcePermission<?>>
-			serviceTrackerMap = Mockito.mock(ServiceTrackerMap.class);
-
 		setUpSearchResultPermissionFilterMocks(
 			indexerRegistry, permissionChecker,
 			defaultSearchResultPermissionFilterConfiguration);
 
 		SearchRequestBuilderFactory searchRequestBuilderFactory =
 			_getSearchRequestBuilderFactory();
+		ServiceTrackerMap<String, ModelResourcePermission<?>>
+			serviceTrackerMap = Mockito.mock(ServiceTrackerMap.class);
 
 		return new DefaultSearchResultPermissionFilter(
 			defaultSearchResultPermissionFilterConfiguration,

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -55,8 +55,10 @@ import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -134,6 +136,12 @@ public class DefaultSearchResultPermissionFilter
 			new SlidingWindowSearcher();
 
 		return slidingWindowSearcher.search(start, end, searchContext);
+	}
+
+	private boolean _classWithDynamicInheritanceChecking(
+		String entryClassName) {
+
+		return _classesWithDynamicInheritanceChecking.contains(entryClassName);
 	}
 
 	private int _filterHits(
@@ -291,12 +299,16 @@ public class DefaultSearchResultPermissionFilter
 
 		String entryClassName = document.get(Field.ENTRY_CLASS_NAME);
 
-		boolean hasCompanyScopeViewPermission =
-			companyScopeViewPermissions.computeIfAbsent(
-				entryClassName, this::_hasCompanyScopeViewPermission);
+		if (!_classWithDynamicInheritanceChecking(entryClassName) ||
+			!PropsValues.PERMISSIONS_VIEW_DYNAMIC_INHERITANCE) {
 
-		if (hasCompanyScopeViewPermission) {
-			return true;
+			boolean hasCompanyScopeViewPermission =
+				companyScopeViewPermissions.computeIfAbsent(
+					entryClassName, this::_hasCompanyScopeViewPermission);
+
+			if (hasCompanyScopeViewPermission) {
+				return true;
+			}
 		}
 
 		Indexer<?> indexer = _indexerRegistry.getIndexer(entryClassName);
@@ -389,6 +401,18 @@ public class DefaultSearchResultPermissionFilter
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultSearchResultPermissionFilter.class);
+
+	private static final Set<String> _classesWithDynamicInheritanceChecking =
+		new HashSet<>(
+			Arrays.asList(
+				"com.liferay.bookmarks.model.BookmarksEntry",
+				"com.liferay.bookmarks.model.BookmarksFolder",
+				"com.liferay.document.library.kernel.model.DLFileEntry",
+				"com.liferay.document.library.kernel.model.DLFolder",
+				"com.liferay.journal.model.JournalArticle",
+				"com.liferay.journal.model.JournalFolder",
+				"com.liferay.message.boards.model.impl.MBCategoryImpl",
+				"com.liferay.message.boards.model.impl.MBMessageImpl"));
 
 	private final int _accurateCountThreshold;
 	private final FacetPostProcessor _facetPostProcessor;

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.internal.permission;
 
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
@@ -12,6 +13,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
@@ -32,6 +34,7 @@ import com.liferay.portal.kernel.search.facet.collector.FacetCollector;
 import com.liferay.portal.kernel.search.facet.collector.TermCollector;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -55,10 +58,8 @@ import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchRequestBuilder;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -80,7 +81,10 @@ public class DefaultSearchResultPermissionFilter
 		Function<SearchContext, Hits> searchFunction,
 		SearchRequestBuilderFactory searchRequestBuilderFactory,
 		DefaultSearchResultPermissionFilterConfiguration
-			defaultSearchResultPermissionFilterConfiguration) {
+			defaultSearchResultPermissionFilterConfiguration,
+		ServiceTrackerMap
+			<String, ModelResourcePermission<? extends ClassedModel>>
+				serviceTrackerMap) {
 
 		_facetPostProcessor = facetPostProcessor;
 		_indexerRegistry = indexerRegistry;
@@ -88,6 +92,7 @@ public class DefaultSearchResultPermissionFilter
 		_relatedEntryIndexerRegistry = relatedEntryIndexerRegistry;
 		_searchFunction = searchFunction;
 		_searchRequestBuilderFactory = searchRequestBuilderFactory;
+		_serviceTrackerMap = serviceTrackerMap;
 
 		_accurateCountThreshold =
 			defaultSearchResultPermissionFilterConfiguration.
@@ -136,12 +141,6 @@ public class DefaultSearchResultPermissionFilter
 			new SlidingWindowSearcher();
 
 		return slidingWindowSearcher.search(start, end, searchContext);
-	}
-
-	private boolean _classWithDynamicInheritanceChecking(
-		String entryClassName) {
-
-		return _classesWithDynamicInheritanceChecking.contains(entryClassName);
 	}
 
 	private int _filterHits(
@@ -299,7 +298,7 @@ public class DefaultSearchResultPermissionFilter
 
 		String entryClassName = document.get(Field.ENTRY_CLASS_NAME);
 
-		if (!_classWithDynamicInheritanceChecking(entryClassName) ||
+		if (!_serviceTrackerMap.containsKey(entryClassName) ||
 			!PropsValues.PERMISSIONS_VIEW_DYNAMIC_INHERITANCE) {
 
 			boolean hasCompanyScopeViewPermission =
@@ -402,18 +401,6 @@ public class DefaultSearchResultPermissionFilter
 	private static final Log _log = LogFactoryUtil.getLog(
 		DefaultSearchResultPermissionFilter.class);
 
-	private static final Set<String> _classesWithDynamicInheritanceChecking =
-		new HashSet<>(
-			Arrays.asList(
-				"com.liferay.bookmarks.model.BookmarksEntry",
-				"com.liferay.bookmarks.model.BookmarksFolder",
-				"com.liferay.document.library.kernel.model.DLFileEntry",
-				"com.liferay.document.library.kernel.model.DLFolder",
-				"com.liferay.journal.model.JournalArticle",
-				"com.liferay.journal.model.JournalFolder",
-				"com.liferay.message.boards.model.impl.MBCategoryImpl",
-				"com.liferay.message.boards.model.impl.MBMessageImpl"));
-
 	private final int _accurateCountThreshold;
 	private final FacetPostProcessor _facetPostProcessor;
 	private final IndexerRegistry _indexerRegistry;
@@ -422,6 +409,9 @@ public class DefaultSearchResultPermissionFilter
 	private final Function<SearchContext, Hits> _searchFunction;
 	private final int _searchQueryResultWindowLimit;
 	private final SearchRequestBuilderFactory _searchRequestBuilderFactory;
+	private volatile ServiceTrackerMap
+		<String, ModelResourcePermission<? extends ClassedModel>>
+			_serviceTrackerMap;
 	private final long _timeLimit;
 
 	private class SlidingWindowSearcher {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilter.java
@@ -75,13 +75,13 @@ public class DefaultSearchResultPermissionFilter
 	implements SearchResultPermissionFilter {
 
 	public DefaultSearchResultPermissionFilter(
+		DefaultSearchResultPermissionFilterConfiguration
+			defaultSearchResultPermissionFilterConfiguration,
 		FacetPostProcessor facetPostProcessor, IndexerRegistry indexerRegistry,
 		PermissionChecker permissionChecker,
 		RelatedEntryIndexerRegistry relatedEntryIndexerRegistry,
 		Function<SearchContext, Hits> searchFunction,
 		SearchRequestBuilderFactory searchRequestBuilderFactory,
-		DefaultSearchResultPermissionFilterConfiguration
-			defaultSearchResultPermissionFilterConfiguration,
 		ServiceTrackerMap
 			<String, ModelResourcePermission<? extends ClassedModel>>
 				serviceTrackerMap) {

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
@@ -67,10 +67,6 @@ public class SearchResultPermissionFilterFactoryImpl
 				DefaultSearchResultPermissionFilterConfiguration.class,
 				properties);
 
-		if (_serviceTrackerMap != null) {
-			_serviceTrackerMap.close();
-		}
-
 		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
 			bundleContext,
 			(Class<ModelResourcePermission<? extends ClassedModel>>)
@@ -82,9 +78,7 @@ public class SearchResultPermissionFilterFactoryImpl
 
 	@Deactivate
 	protected void deactivate() {
-		if (_serviceTrackerMap != null) {
-			_serviceTrackerMap.close();
-		}
+		_serviceTrackerMap.close();
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
@@ -49,13 +49,12 @@ public class SearchResultPermissionFilterFactoryImpl
 		PermissionChecker permissionChecker) {
 
 		return new DefaultSearchResultPermissionFilter(
+			_defaultSearchResultPermissionFilterConfiguration,
 			facetPostProcessor, indexerRegistry, permissionChecker,
 			relatedEntryIndexerRegistry,
 			searchContext -> _search(
 				searchResultPermissionFilterSearcher, searchContext),
-			searchRequestBuilderFactory,
-			_defaultSearchResultPermissionFilterConfiguration,
-			_serviceTrackerMap);
+			searchRequestBuilderFactory, _serviceTrackerMap);
 	}
 
 	@Activate

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
@@ -78,6 +79,13 @@ public class SearchResultPermissionFilterFactoryImpl
 			"(permissions.view.dynamic.inheritance.checking=true)",
 			(serviceReference, emitter) -> emitter.emit(
 				(String)serviceReference.getProperty("model.class.name")));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceTrackerMap != null) {
+			_serviceTrackerMap.close();
+		}
 	}
 
 	@Reference

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/permission/SearchResultPermissionFilterFactoryImpl.java
@@ -5,7 +5,10 @@
 
 package com.liferay.portal.search.internal.permission;
 
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
@@ -16,11 +19,13 @@ import com.liferay.portal.kernel.search.SearchResultPermissionFilterFactory;
 import com.liferay.portal.kernel.search.SearchResultPermissionFilterSearcher;
 import com.liferay.portal.kernel.search.facet.FacetPostProcessor;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.search.configuration.DefaultSearchResultPermissionFilterConfiguration;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 
 import java.util.Map;
 
+import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Modified;
@@ -48,16 +53,31 @@ public class SearchResultPermissionFilterFactoryImpl
 			searchContext -> _search(
 				searchResultPermissionFilterSearcher, searchContext),
 			searchRequestBuilderFactory,
-			_defaultSearchResultPermissionFilterConfiguration);
+			_defaultSearchResultPermissionFilterConfiguration,
+			_serviceTrackerMap);
 	}
 
 	@Activate
 	@Modified
-	protected void activate(Map<String, Object> properties) {
+	protected void activate(
+		BundleContext bundleContext, Map<String, Object> properties) {
+
 		_defaultSearchResultPermissionFilterConfiguration =
 			ConfigurableUtil.createConfigurable(
 				DefaultSearchResultPermissionFilterConfiguration.class,
 				properties);
+
+		if (_serviceTrackerMap != null) {
+			_serviceTrackerMap.close();
+		}
+
+		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+			bundleContext,
+			(Class<ModelResourcePermission<? extends ClassedModel>>)
+				(Class<?>)ModelResourcePermission.class,
+			"(permissions.view.dynamic.inheritance.checking=true)",
+			(serviceReference, emitter) -> emitter.emit(
+				(String)serviceReference.getProperty("model.class.name")));
 	}
 
 	@Reference
@@ -87,5 +107,8 @@ public class SearchResultPermissionFilterFactoryImpl
 
 	private volatile DefaultSearchResultPermissionFilterConfiguration
 		_defaultSearchResultPermissionFilterConfiguration;
+	private volatile ServiceTrackerMap
+		<String, ModelResourcePermission<? extends ClassedModel>>
+			_serviceTrackerMap;
 
 }

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
@@ -129,6 +129,26 @@ public class DefaultSearchResultPermissionFilterTest {
 		_groupAdmin = false;
 		_permissionFilteredSearchResultAccurateCountThreshold = 0;
 
+		Mockito.when(
+			_indexer.hasPermission(
+				Mockito.any(), Mockito.anyString(), Mockito.anyLong(),
+				Mockito.eq(ActionKeys.VIEW))
+		).thenReturn(
+			false
+		);
+
+		Mockito.when(
+			_indexer.isFilterSearch()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_indexerRegistry.getIndexer(Mockito.anyString())
+		).thenReturn(
+			(Indexer)_indexer
+		);
+
 		ResourcePermissionLocalService resourcePermissionLocalService =
 			Mockito.mock(ResourcePermissionLocalService.class);
 
@@ -144,37 +164,16 @@ public class DefaultSearchResultPermissionFilterTest {
 			true
 		);
 
-		Mockito.when(
-			_indexer.isFilterSearch()
-		).thenReturn(
-			true
-		);
-
-		Mockito.when(
-			_indexer.hasPermission(
-				Mockito.any(), Mockito.anyString(), Mockito.anyLong(),
-				Mockito.eq(ActionKeys.VIEW))
-		).thenReturn(
-			false
-		);
-
-		Mockito.when(
-			_indexerRegistry.getIndexer(Mockito.anyString())
-		).thenReturn(
-			(Indexer)_indexer
-		);
-
 		DefaultSearchResultPermissionFilter
 			defaultSearchResultPermissionFilter =
-				_getDefaultSearchResultPermissionFilter(_indexerRegistry);
+				_getDefaultSearchResultPermissionFilter();
 
-		_assertResults(
-			defaultSearchResultPermissionFilter, 9, _getSearchContext(10),
-			false);
+		SearchContext searchContext = _getSearchContext(10);
 
-		_assertResults(
-			defaultSearchResultPermissionFilter, 0, _getSearchContext(10),
-			true);
+		_assertResultsCount(
+			searchContext, defaultSearchResultPermissionFilter, 9, false);
+		_assertResultsCount(
+			searchContext, defaultSearchResultPermissionFilter, 0, true);
 
 		ResourcePermissionLocalServiceUtil.setService(null);
 	}
@@ -203,18 +202,19 @@ public class DefaultSearchResultPermissionFilterTest {
 		Assert.assertEquals(Arrays.toString(docs), pageCount, docs.length);
 	}
 
-	private void _assertResults(
+	private void _assertResultsCount(
+		SearchContext searchContext,
 		DefaultSearchResultPermissionFilter defaultSearchResultPermissionFilter,
-		int expected, SearchContext searchContext, boolean serviceTracker) {
+		int expectedResultsCount, boolean serviceTrackerContainsKey) {
 
 		Mockito.when(
 			_serviceTrackerMap.containsKey(Mockito.anyString())
 		).thenReturn(
-			serviceTracker
+			serviceTrackerContainsKey
 		);
 
 		Assert.assertEquals(
-			expected,
+			expectedResultsCount,
 			defaultSearchResultPermissionFilter.search(
 				searchContext
 			).getLength());
@@ -223,14 +223,6 @@ public class DefaultSearchResultPermissionFilterTest {
 	private DefaultSearchResultPermissionFilter
 		_getDefaultSearchResultPermissionFilter() {
 
-		return _getDefaultSearchResultPermissionFilter(
-			Mockito.mock(IndexerRegistry.class));
-	}
-
-	private DefaultSearchResultPermissionFilter
-		_getDefaultSearchResultPermissionFilter(
-			IndexerRegistry indexerRegistry) {
-
 		_mockSearchResultPermissionFilterConfiguration();
 
 		SearchRequestBuilderFactory searchRequestBuilderFactory =
@@ -238,7 +230,7 @@ public class DefaultSearchResultPermissionFilterTest {
 
 		return new DefaultSearchResultPermissionFilter(
 			_defaultSearchResultPermissionFilterConfiguration,
-			Mockito.mock(FacetPostProcessor.class), indexerRegistry,
+			Mockito.mock(FacetPostProcessor.class), _indexerRegistry,
 			_permissionChecker, Mockito.mock(RelatedEntryIndexerRegistry.class),
 			_searchFunction, searchRequestBuilderFactory, _serviceTrackerMap);
 	}

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
@@ -144,64 +144,37 @@ public class DefaultSearchResultPermissionFilterTest {
 			true
 		);
 
-		Indexer<?> indexer = Mockito.mock(Indexer.class);
-
 		Mockito.when(
-			indexer.isFilterSearch()
+			_indexer.isFilterSearch()
 		).thenReturn(
 			true
 		);
 
 		Mockito.when(
-			indexer.hasPermission(
+			_indexer.hasPermission(
 				Mockito.any(), Mockito.anyString(), Mockito.anyLong(),
 				Mockito.eq(ActionKeys.VIEW))
 		).thenReturn(
 			false
 		);
 
-		IndexerRegistry indexerRegistry = Mockito.mock(IndexerRegistry.class);
-
 		Mockito.when(
-			indexerRegistry.getIndexer(Mockito.anyString())
+			_indexerRegistry.getIndexer(Mockito.anyString())
 		).thenReturn(
-			(Indexer)indexer
-		);
-
-		Mockito.when(
-			_serviceTrackerMap.containsKey(Mockito.anyString())
-		).thenReturn(
-			false
+			(Indexer)_indexer
 		);
 
 		DefaultSearchResultPermissionFilter
 			defaultSearchResultPermissionFilter =
-				_getDefaultSearchResultPermissionFilter(indexerRegistry);
+				_getDefaultSearchResultPermissionFilter(_indexerRegistry);
 
-		SearchContext searchContext = _getSearchContext(10);
+		_assertResults(
+			defaultSearchResultPermissionFilter, 9, _getSearchContext(10),
+			false);
 
-		Assert.assertEquals(
-			9,
-			defaultSearchResultPermissionFilter.search(
-				searchContext
-			).getLength());
-
-		Mockito.when(
-			_serviceTrackerMap.containsKey(Mockito.anyString())
-		).thenReturn(
-			true
-		);
-
-		defaultSearchResultPermissionFilter =
-			_getDefaultSearchResultPermissionFilter(indexerRegistry);
-
-		searchContext = _getSearchContext(10);
-
-		Assert.assertEquals(
-			0,
-			defaultSearchResultPermissionFilter.search(
-				searchContext
-			).getLength());
+		_assertResults(
+			defaultSearchResultPermissionFilter, 0, _getSearchContext(10),
+			true);
 
 		ResourcePermissionLocalServiceUtil.setService(null);
 	}
@@ -228,6 +201,23 @@ public class DefaultSearchResultPermissionFilterTest {
 		Assert.assertEquals(hits.toString(), totalCount, hits.getLength());
 
 		Assert.assertEquals(Arrays.toString(docs), pageCount, docs.length);
+	}
+
+	private void _assertResults(
+		DefaultSearchResultPermissionFilter defaultSearchResultPermissionFilter,
+		int expected, SearchContext searchContext, boolean serviceTracker) {
+
+		Mockito.when(
+			_serviceTrackerMap.containsKey(Mockito.anyString())
+		).thenReturn(
+			serviceTracker
+		);
+
+		Assert.assertEquals(
+			expected,
+			defaultSearchResultPermissionFilter.search(
+				searchContext
+			).getLength());
 	}
 
 	private DefaultSearchResultPermissionFilter
@@ -425,6 +415,9 @@ public class DefaultSearchResultPermissionFilterTest {
 			DefaultSearchResultPermissionFilterConfiguration.class);
 	private Document[] _documents;
 	private boolean _groupAdmin;
+	private final Indexer<?> _indexer = Mockito.mock(Indexer.class);
+	private final IndexerRegistry _indexerRegistry = Mockito.mock(
+		IndexerRegistry.class);
 	private final PermissionChecker _permissionChecker = Mockito.mock(
 		PermissionChecker.class);
 	private int _permissionFilteredSearchResultAccurateCountThreshold;

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
@@ -6,16 +6,21 @@
 package com.liferay.portal.search.internal.permission;
 
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.HitsImpl;
+import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.FacetPostProcessor;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
 import com.liferay.portal.search.configuration.DefaultSearchResultPermissionFilterConfiguration;
 import com.liferay.portal.search.hits.SearchHitsBuilder;
 import com.liferay.portal.search.internal.searcher.SearchResponseImpl;
@@ -120,6 +125,88 @@ public class DefaultSearchResultPermissionFilterTest {
 	}
 
 	@Test
+	public void testSearchWithDynamicInheritanceEnabled() throws Exception {
+		_groupAdmin = false;
+		_permissionFilteredSearchResultAccurateCountThreshold = 0;
+
+		ResourcePermissionLocalService resourcePermissionLocalService =
+			Mockito.mock(ResourcePermissionLocalService.class);
+
+		ResourcePermissionLocalServiceUtil.setService(
+			resourcePermissionLocalService);
+
+		Mockito.when(
+			resourcePermissionLocalService.hasResourcePermission(
+				Mockito.anyLong(), Mockito.anyString(),
+				Mockito.eq(ResourceConstants.SCOPE_COMPANY),
+				Mockito.anyString(), Mockito.any(), Mockito.eq(ActionKeys.VIEW))
+		).thenReturn(
+			true
+		);
+
+		Indexer<?> indexer = Mockito.mock(Indexer.class);
+
+		Mockito.when(
+			indexer.isFilterSearch()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			indexer.hasPermission(
+				Mockito.any(), Mockito.anyString(), Mockito.anyLong(),
+				Mockito.eq(ActionKeys.VIEW))
+		).thenReturn(
+			false
+		);
+
+		IndexerRegistry indexerRegistry = Mockito.mock(IndexerRegistry.class);
+
+		Mockito.when(
+			indexerRegistry.getIndexer(Mockito.anyString())
+		).thenReturn(
+			(Indexer)indexer
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.containsKey(Mockito.anyString())
+		).thenReturn(
+			false
+		);
+
+		DefaultSearchResultPermissionFilter
+			defaultSearchResultPermissionFilter =
+				_getDefaultSearchResultPermissionFilter(indexerRegistry);
+
+		SearchContext searchContext = _getSearchContext(10);
+
+		Assert.assertEquals(
+			9,
+			defaultSearchResultPermissionFilter.search(
+				searchContext
+			).getLength());
+
+		Mockito.when(
+			_serviceTrackerMap.containsKey(Mockito.anyString())
+		).thenReturn(
+			true
+		);
+
+		defaultSearchResultPermissionFilter =
+			_getDefaultSearchResultPermissionFilter(indexerRegistry);
+
+		searchContext = _getSearchContext(10);
+
+		Assert.assertEquals(
+			0,
+			defaultSearchResultPermissionFilter.search(
+				searchContext
+			).getLength());
+
+		ResourcePermissionLocalServiceUtil.setService(null);
+	}
+
+	@Test
 	public void testSearchWithSizeZero() {
 		_groupAdmin = false;
 		_permissionFilteredSearchResultAccurateCountThreshold = 0;
@@ -146,6 +233,14 @@ public class DefaultSearchResultPermissionFilterTest {
 	private DefaultSearchResultPermissionFilter
 		_getDefaultSearchResultPermissionFilter() {
 
+		return _getDefaultSearchResultPermissionFilter(
+			Mockito.mock(IndexerRegistry.class));
+	}
+
+	private DefaultSearchResultPermissionFilter
+		_getDefaultSearchResultPermissionFilter(
+			IndexerRegistry indexerRegistry) {
+
 		_mockSearchResultPermissionFilterConfiguration();
 
 		SearchRequestBuilderFactory searchRequestBuilderFactory =
@@ -153,10 +248,9 @@ public class DefaultSearchResultPermissionFilterTest {
 
 		return new DefaultSearchResultPermissionFilter(
 			_defaultSearchResultPermissionFilterConfiguration,
-			Mockito.mock(FacetPostProcessor.class),
-			Mockito.mock(IndexerRegistry.class), _permissionChecker,
-			Mockito.mock(RelatedEntryIndexerRegistry.class), _searchFunction,
-			searchRequestBuilderFactory, _serviceTrackerMap);
+			Mockito.mock(FacetPostProcessor.class), indexerRegistry,
+			_permissionChecker, Mockito.mock(RelatedEntryIndexerRegistry.class),
+			_searchFunction, searchRequestBuilderFactory, _serviceTrackerMap);
 	}
 
 	private Document _getDocument(String companyId, int index) {

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
@@ -152,12 +152,11 @@ public class DefaultSearchResultPermissionFilterTest {
 			_getSearchRequestBuilderFactory();
 
 		return new DefaultSearchResultPermissionFilter(
+			_defaultSearchResultPermissionFilterConfiguration,
 			Mockito.mock(FacetPostProcessor.class),
 			Mockito.mock(IndexerRegistry.class), _permissionChecker,
 			Mockito.mock(RelatedEntryIndexerRegistry.class), _searchFunction,
-			searchRequestBuilderFactory,
-			_defaultSearchResultPermissionFilterConfiguration,
-			_serviceTrackerMap);
+			searchRequestBuilderFactory, _serviceTrackerMap);
 	}
 
 	private Document _getDocument(String companyId, int index) {

--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/permission/DefaultSearchResultPermissionFilterTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.search.internal.permission;
 
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
@@ -14,6 +15,7 @@ import com.liferay.portal.kernel.search.RelatedEntryIndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.facet.FacetPostProcessor;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.search.configuration.DefaultSearchResultPermissionFilterConfiguration;
 import com.liferay.portal.search.hits.SearchHitsBuilder;
 import com.liferay.portal.search.internal.searcher.SearchResponseImpl;
@@ -154,7 +156,8 @@ public class DefaultSearchResultPermissionFilterTest {
 			Mockito.mock(IndexerRegistry.class), _permissionChecker,
 			Mockito.mock(RelatedEntryIndexerRegistry.class), _searchFunction,
 			searchRequestBuilderFactory,
-			_defaultSearchResultPermissionFilterConfiguration);
+			_defaultSearchResultPermissionFilterConfiguration,
+			_serviceTrackerMap);
 	}
 
 	private Document _getDocument(String companyId, int index) {
@@ -334,5 +337,7 @@ public class DefaultSearchResultPermissionFilterTest {
 	private int _permissionFilteredSearchResultAccurateCountThreshold;
 	private final Function<SearchContext, Hits> _searchFunction = Mockito.mock(
 		Function.class);
+	private final ServiceTrackerMap<String, ModelResourcePermission<?>>
+		_serviceTrackerMap = Mockito.mock(ServiceTrackerMap.class);
 
 }

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/AppModuleLicenseTest.java
@@ -31,7 +31,7 @@ import org.osgi.framework.BundleContext;
  * @author Kevin Lee
  */
 @RunWith(Arquillian.class)
-public class CMPModuleLicenseTest extends BaseLicenseTestCase {
+public class AppModuleLicenseTest extends BaseLicenseTestCase {
 
 	@BeforeClass
 	public static void setUpClass() {

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.license.test;
 
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -25,7 +24,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.module.framework.ModuleFrameworkUtil;
 import com.liferay.portal.test.log.LogCapture;
@@ -34,7 +32,6 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.util.LicenseUtil;
 
 import java.io.File;
-import java.io.InputStream;
 import java.io.Serializable;
 
 import java.lang.instrument.Instrumentation;
@@ -518,23 +515,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		return ReflectionsHolder._validateClass;
 	}
 
-	protected void assertPortalInvalidatedWithBrokenFile(
-			String fileName, String failMessage)
-		throws Exception {
-
-		String filePath = StringBundler.concat(
-			StringUtil.replace(
-				_licensePackageName, CharPool.PERIOD, CharPool.SLASH),
-			CharPool.SLASH, fileName);
-
-		_assertPortalInvalidatedWithBrokenFile(
-			filePath, null,
-			"java.lang.IllegalArgumentException: Null input buffer");
-
-		_assertPortalInvalidatedWithBrokenFile(
-			filePath, InputStream.nullInputStream(), failMessage);
-	}
-
 	protected void checkLicense(String productId) throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				_licensePackageName, LoggerTestUtil.ALL)) {
@@ -608,48 +588,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		).installOn(
 			ReflectionsHolder._instrumentation
 		);
-	}
-
-	private void _assertPortalInvalidatedWithBrokenFile(
-			String filePath, InputStream inputStream, String failMessage)
-		throws Exception {
-
-		ClassLoader classLoader = PortalClassLoaderUtil.getClassLoader();
-
-		PortalClassLoaderUtil.setClassLoader(
-			new ClassLoader(classLoader) {
-
-				@Override
-				public boolean equals(Object object) {
-					return classLoader.equals(object);
-				}
-
-				@Override
-				public InputStream getResourceAsStream(String name) {
-					if (name.equals(filePath)) {
-						return inputStream;
-					}
-
-					return classLoader.getResourceAsStream(name);
-				}
-
-				@Override
-				public int hashCode() {
-					return classLoader.hashCode();
-				}
-
-			});
-
-		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
-			assertPortalLicenseNotRegistered();
-
-			deployFreeTierPortalLicense(Time.HOUR);
-
-			assertPortalLicenseInvalid(failMessage);
-		}
-		finally {
-			PortalClassLoaderUtil.setClassLoader(classLoader);
-		}
 	}
 
 	private File _buildBinaryFile(

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/BaseLicenseTestCase.java
@@ -10,6 +10,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -171,18 +172,20 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		Assert.assertFalse(response.contains(_LICENSE_PAGE_KEY));
 	}
 
-	public File deployCMPLicense(long validityPeriod) throws Exception {
+	public File deployAppLicense(App app, long validityPeriod)
+		throws Exception {
+
 		long currentTimeMillis = System.currentTimeMillis();
 
 		StringBundler sb = new StringBundler(19);
 
 		sb.append("<?xml version=\"1.0\"?><license><product-id>");
-		sb.append(getCMPProductId());
+		sb.append(getProductId(app));
 		sb.append("</product-id><product-name>");
-		sb.append(_CMP_PRODUCT_NAME);
+		sb.append(app);
 		sb.append("</product-name><product-version>2026.Q1</product-version>");
 		sb.append("<license-type>");
-		sb.append(_CMP_LICENSE_TYPE);
+		sb.append(_APP_LICENSE_TYPE);
 		sb.append("</license-type><license-version>3</license-version>");
 		sb.append("<start-date>");
 		sb.append(_DATE_FORMAT.format(new Date(currentTimeMillis)));
@@ -212,8 +215,8 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		_registerLicense(sb.toString());
 
 		return _buildBinaryFile(
-			getCMPProductId(), StringPool.BLANK, _CMP_PRODUCT_NAME,
-			_CMP_LICENSE_TYPE);
+			getProductId(app), StringPool.BLANK, app.toString(),
+			_APP_LICENSE_TYPE);
 	}
 
 	public File deployEnterprisePortalLicense(long validityPeriod)
@@ -305,12 +308,23 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 	public void resetCheckInterval() throws Exception {
 		for (Field field : _lifecycleActionClass.getDeclaredFields()) {
+			field.setAccessible(true);
+
 			if (!Modifier.isFinal(field.getModifiers()) &&
 				Objects.equals(field.getType(), long.class)) {
 
-				field.setAccessible(true);
-
 				field.set(_lifecycleAction, 0L);
+			}
+			else if (Objects.equals(field.getType(), Map.class)) {
+				Map<?, ?> map = (Map<?, ?>)field.get(_lifecycleAction);
+
+				for (Object object : map.values()) {
+					if (Long.class.isAssignableFrom(object.getClass())) {
+						map.clear();
+
+						break;
+					}
+				}
 			}
 		}
 	}
@@ -327,7 +341,10 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		}
 
 		checkLicense(getPortalProductId());
-		checkLicense(getCMPProductId());
+
+		for (App app : App.values()) {
+			checkLicense(getProductId(app));
+		}
 
 		resetLifecycleAction();
 
@@ -349,7 +366,10 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 			try {
 				checkLicense(getPortalProductId());
-				checkLicense(getCMPProductId());
+
+				for (App app : App.values()) {
+					checkLicense(getProductId(app));
+				}
 
 				resetLifecycleAction();
 			}
@@ -378,14 +398,32 @@ public abstract class BaseLicenseTestCase implements Serializable {
 						if (Map.class.isAssignableFrom(field.getType())) {
 							field.setAccessible(true);
 
-							Object bundleData = field.get(_lifecycleAction);
+							if (!Modifier.isFinal(field.getModifiers())) {
+								Object bundleData = field.get(_lifecycleAction);
 
-							if (bundleData != null) {
-								method.invoke(
-									_lifecycleAction,
-									SystemBundleUtil.getBundleContext(),
-									bundleData,
-									ModuleFrameworkUtil.getFramework());
+								if (bundleData != null) {
+									method.invoke(
+										_lifecycleAction,
+										SystemBundleUtil.getBundleContext(),
+										bundleData,
+										ModuleFrameworkUtil.getFramework());
+								}
+							}
+							else {
+								Map<?, ?> map = (Map<?, ?>)field.get(
+									_lifecycleAction);
+
+								for (Object object : map.values()) {
+									if (Map.class.isAssignableFrom(
+											object.getClass())) {
+
+										method.invoke(
+											_lifecycleAction,
+											SystemBundleUtil.getBundleContext(),
+											object,
+											ModuleFrameworkUtil.getFramework());
+									}
+								}
 							}
 						}
 					}
@@ -395,9 +433,9 @@ public abstract class BaseLicenseTestCase implements Serializable {
 			}
 
 			for (Field field : _lifecycleActionClass.getDeclaredFields()) {
-				if (!Modifier.isFinal(field.getModifiers())) {
-					field.setAccessible(true);
+				field.setAccessible(true);
 
+				if (!Modifier.isFinal(field.getModifiers())) {
 					if (Objects.equals(field.getType(), long.class)) {
 						field.set(_lifecycleAction, 0L);
 					}
@@ -407,6 +445,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 					else {
 						field.set(_lifecycleAction, null);
 					}
+				}
+				else if (Objects.equals(field.getType(), Map.class)) {
+					Map<?, ?> map = (Map<?, ?>)field.get(_lifecycleAction);
+
+					map.clear();
 				}
 			}
 
@@ -502,10 +545,6 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		}
 	}
 
-	protected String getCMPProductId() {
-		return getProperty("product.id.cmp");
-	}
-
 	protected String getCurrentVersion() throws Exception {
 		Method versionMethod = ReflectionsHolder._versionMethod;
 
@@ -524,6 +563,11 @@ public abstract class BaseLicenseTestCase implements Serializable {
 
 	protected String getPortalProductId() {
 		return getProperty("product.id.portal");
+	}
+
+	protected String getProductId(App app) {
+		return getProperty(
+			"product.id." + StringUtil.toLowerCase(app.toString()));
 	}
 
 	protected String hitHomePage(String host, int port) throws Exception {
@@ -667,13 +711,10 @@ public abstract class BaseLicenseTestCase implements Serializable {
 		}
 	}
 
+	private static final String _APP_LICENSE_TYPE = "production";
+
 	private static final String _BUNDLE_START_STOP_LOGGER =
 		"com.liferay.portal.bootstrap.log.BundleStartStopLogger";
-
-	private static final String _CMP_LICENSE_TYPE = "production";
-
-	private static final String _CMP_PRODUCT_NAME =
-		"Liferay Content Marketing Platform";
 
 	private static final DateFormat _DATE_FORMAT = new SimpleDateFormat(
 		"EEEE, MMMM d, yyyy hh:mm:ss a z", LocaleUtil.US);

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CKEditorLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CKEditorLicenseTest.java
@@ -90,12 +90,6 @@ public class CKEditorLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
-	public void testBrokenCKEditorFile() throws Exception {
-		assertPortalInvalidatedWithBrokenFile(
-			"CKEditor", "CKEditor key is corrupted");
-	}
-
-	@Test
 	public void testCustomKey() throws Exception {
 		_testLicenseKey(RandomTestUtil.randomString(), false);
 	}

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CMPModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CMPModuleLicenseTest.java
@@ -7,8 +7,10 @@ package com.liferay.portal.license.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Time;
 
 import java.io.File;
@@ -16,9 +18,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,10 +45,21 @@ public class CMPModuleLicenseTest extends BaseLicenseTestCase {
 		_setVersionSafeCloseable.close();
 	}
 
-	@Before
-	public void setUp() throws Exception {
-		_safeCloseable = resetLicenseDataWithSafeCloseble();
+	@Test
+	public void testEnterpriseLicense() throws Exception {
+		for (App app : App.values()) {
+			_testEnterpriseLicense(app);
+		}
+	}
 
+	@Test
+	public void testFreeTierLicense() throws Exception {
+		for (App app : App.values()) {
+			_testFreeTierLicense(app);
+		}
+	}
+
+	private String[] _getAppSymbolicNames(App app) {
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
 
 		List<String> symbolicNames = new ArrayList<>();
@@ -55,107 +67,109 @@ public class CMPModuleLicenseTest extends BaseLicenseTestCase {
 		for (Bundle bundle : bundleContext.getBundles()) {
 			String symbolicName = bundle.getSymbolicName();
 
-			if (symbolicName.contains(".cmp.")) {
+			if (symbolicName.contains(
+					"." + StringUtil.toLowerCase(app.toString()) + ".")) {
+
 				symbolicNames.add(symbolicName);
 			}
 		}
 
-		_cmpSymbolicNames = ArrayUtil.toStringArray(symbolicNames);
+		return ArrayUtil.toStringArray(symbolicNames);
 	}
 
-	@After
-	public void tearDown() {
-		_safeCloseable.close();
+	private void _testEnterpriseLicense(App app) throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			String[] appSymbolicNames = _getAppSymbolicNames(app);
+
+			Assert.assertFalse(
+				appSymbolicNames.toString(),
+				ArrayUtil.isEmpty(appSymbolicNames));
+
+			assertLicensePropertiesNotExisted(getProductId(app));
+
+			assertBundlesExisted(appSymbolicNames);
+
+			assertPortalLicenseNotRegistered();
+
+			assertBundlesExisted(appSymbolicNames);
+
+			deployEnterprisePortalLicense(Time.HOUR);
+
+			assertLicensePropertiesNotExisted(getProductId(app));
+
+			assertPortalLicenseRegistered();
+
+			assertBundlesNotExisted(appSymbolicNames);
+
+			File binaryFile = deployAppLicense(app, Time.HOUR);
+
+			assertLicensePropertiesExisted(getProductId(app));
+
+			assertPortalLicenseRegistered();
+
+			assertBundlesExisted(appSymbolicNames);
+
+			binaryFile.delete();
+
+			checkLicense(getProductId(app));
+
+			assertLicensePropertiesNotExisted(getProductId(app));
+
+			resetLifecycleAction();
+
+			assertPortalLicenseRegistered();
+
+			assertBundlesNotExisted(appSymbolicNames);
+		}
 	}
 
-	@Test
-	public void testBrokenCMPFile() throws Exception {
-		assertPortalInvalidatedWithBrokenFile(
-			"CMP", "CMP bundle list is corrupted");
+	private void _testFreeTierLicense(App app) throws Exception {
+		try (SafeCloseable safeCloseable = resetLicenseDataWithSafeCloseble()) {
+			String[] appSymbolicNames = _getAppSymbolicNames(app);
+
+			Assert.assertFalse(
+				appSymbolicNames.toString(),
+				ArrayUtil.isEmpty(appSymbolicNames));
+
+			assertLicensePropertiesNotExisted(getProductId(app));
+
+			assertBundlesExisted(appSymbolicNames);
+
+			assertPortalLicenseNotRegistered();
+
+			assertBundlesExisted(appSymbolicNames);
+
+			deployFreeTierPortalLicense(Time.HOUR);
+
+			assertLicensePropertiesNotExisted(getProductId(app));
+
+			assertPortalLicenseRegistered();
+
+			assertBundlesNotExisted(appSymbolicNames);
+
+			File binaryFile = deployAppLicense(app, Time.HOUR);
+
+			assertLicensePropertiesExisted(getProductId(app));
+
+			assertPortalLicenseRegistered();
+
+			assertBundlesNotExisted(appSymbolicNames);
+
+			binaryFile.delete();
+
+			checkLicense(getProductId(app));
+
+			assertLicensePropertiesNotExisted(getProductId(app));
+
+			resetLifecycleAction();
+
+			assertPortalLicenseRegistered();
+
+			assertBundlesNotExisted(appSymbolicNames);
+		}
 	}
 
-	@Test
-	public void testEnterpriseLicense() throws Exception {
-		assertLicensePropertiesNotExisted(getCMPProductId());
-
-		assertBundlesExisted(_cmpSymbolicNames);
-
-		assertPortalLicenseNotRegistered();
-
-		assertBundlesExisted(_cmpSymbolicNames);
-
-		deployEnterprisePortalLicense(Time.HOUR);
-
-		assertLicensePropertiesNotExisted(getCMPProductId());
-
-		assertPortalLicenseRegistered();
-
-		assertBundlesNotExisted(_cmpSymbolicNames);
-
-		File binaryFile = deployCMPLicense(Time.HOUR);
-
-		assertLicensePropertiesExisted(getCMPProductId());
-
-		assertPortalLicenseRegistered();
-
-		assertBundlesExisted(_cmpSymbolicNames);
-
-		binaryFile.delete();
-
-		checkLicense(getCMPProductId());
-
-		assertLicensePropertiesNotExisted(getCMPProductId());
-
-		resetLifecycleAction();
-
-		assertPortalLicenseRegistered();
-
-		assertBundlesNotExisted(_cmpSymbolicNames);
-	}
-
-	@Test
-	public void testFreeTierLicense() throws Exception {
-		assertLicensePropertiesNotExisted(getCMPProductId());
-
-		assertBundlesExisted(_cmpSymbolicNames);
-
-		assertPortalLicenseNotRegistered();
-
-		assertBundlesExisted(_cmpSymbolicNames);
-
-		deployFreeTierPortalLicense(Time.HOUR);
-
-		assertLicensePropertiesNotExisted(getCMPProductId());
-
-		assertPortalLicenseRegistered();
-
-		assertBundlesNotExisted(_cmpSymbolicNames);
-
-		File binaryFile = deployCMPLicense(Time.HOUR);
-
-		assertLicensePropertiesExisted(getCMPProductId());
-
-		assertPortalLicenseRegistered();
-
-		assertBundlesNotExisted(_cmpSymbolicNames);
-
-		binaryFile.delete();
-
-		checkLicense(getCMPProductId());
-
-		assertLicensePropertiesNotExisted(getCMPProductId());
-
-		resetLifecycleAction();
-
-		assertPortalLicenseRegistered();
-
-		assertBundlesNotExisted(_cmpSymbolicNames);
-	}
-
-	private static String[] _cmpSymbolicNames;
 	private static SafeCloseable _disableKeyValidatorSafeCloseable;
 	private static SafeCloseable _setVersionSafeCloseable;
-
-	private SafeCloseable _safeCloseable;
 
 }

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CheckLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/CheckLicenseTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.license.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
@@ -68,15 +69,9 @@ public class CheckLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
-	public void testCheckLicenseForCMP() throws Exception {
-		try (SafeCloseable safeCloseable = disableValidateWithSafeCloseable()) {
-			assertLicensePropertiesNotExisted(getCMPProductId());
-
-			deployCMPLicense(Time.HOUR);
-
-			assertLicensePropertiesExisted(getCMPProductId());
-
-			Assert.assertTrue(LicenseManagerUtil.isCMPEnabled());
+	public void testCheckLicenseForApp() throws Exception {
+		for (App app : App.values()) {
+			_testCheckLicenseForApp(app);
 		}
 	}
 
@@ -135,6 +130,20 @@ public class CheckLicenseTest extends BaseLicenseTestCase {
 		assertLicensePropertiesExisted(getPortalProductId());
 
 		assertPortalLicenseRegistered();
+	}
+
+	private void _testCheckLicenseForApp(App app) throws Exception {
+		try (SafeCloseable safeCloseable1 = disableValidateWithSafeCloseable();
+			SafeCloseable safeCloseable2 = resetLicenseDataWithSafeCloseble()) {
+
+			assertLicensePropertiesNotExisted(getProductId(app));
+
+			deployAppLicense(app, Time.HOUR);
+
+			assertLicensePropertiesExisted(getProductId(app));
+
+			Assert.assertTrue(LicenseManagerUtil.isAppEnabled(app));
+		}
 	}
 
 	private static SafeCloseable _setVersionSafeCloseable;

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/DXPModuleLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/DXPModuleLicenseTest.java
@@ -71,12 +71,6 @@ public class DXPModuleLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
-	public void testBrokenBundlesFile() throws Exception {
-		assertPortalInvalidatedWithBrokenFile(
-			"bundles", "Bundle list is corrupted");
-	}
-
-	@Test
 	public void testFreeTierLicense() throws Exception {
 		assertLicensePropertiesNotExisted(getPortalProductId());
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ExpiredLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/ExpiredLicenseTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.license.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.util.Time;
 
@@ -47,20 +48,10 @@ public class ExpiredLicenseTest extends BaseLicenseTestCase {
 	}
 
 	@Test
-	public void testCMPLicenseExpired() throws Exception {
-		assertLicensePropertiesNotExisted(getCMPProductId());
-
-		deployCMPLicense(_GRACE_PEIROD + _VALIDTY_PERIOD);
-
-		assertLicensePropertiesExisted(getCMPProductId());
-
-		Assert.assertTrue(LicenseManagerUtil.isCMPEnabled());
-
-		Thread.sleep(_VALIDTY_PERIOD);
-
-		assertLicensePropertiesExisted(getCMPProductId());
-
-		Assert.assertFalse(LicenseManagerUtil.isCMPEnabled());
+	public void testAppLicenseExpired() throws Exception {
+		for (App app : App.values()) {
+			_testAppLicenseExpired(app);
+		}
 	}
 
 	@Test
@@ -138,6 +129,22 @@ public class ExpiredLicenseTest extends BaseLicenseTestCase {
 		assertLicensePropertiesExisted(getPortalProductId());
 
 		assertPortalLicenseExpired();
+	}
+
+	private void _testAppLicenseExpired(App app) throws Exception {
+		assertLicensePropertiesNotExisted(getProductId(app));
+
+		deployAppLicense(app, _GRACE_PEIROD + _VALIDTY_PERIOD);
+
+		assertLicensePropertiesExisted(getProductId(app));
+
+		Assert.assertTrue(LicenseManagerUtil.isAppEnabled(app));
+
+		Thread.sleep(_VALIDTY_PERIOD);
+
+		assertLicensePropertiesExisted(getProductId(app));
+
+		Assert.assertFalse(LicenseManagerUtil.isAppEnabled(app));
 	}
 
 	private static final long _GRACE_PEIROD = -2 * Time.DAY;

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/FreeTierVersionLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/FreeTierVersionLicenseTest.java
@@ -8,11 +8,11 @@ package com.liferay.portal.license.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -20,6 +20,7 @@ import java.lang.reflect.Field;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Properties;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -50,7 +51,7 @@ public class FreeTierVersionLicenseTest extends BaseLicenseTestCase {
 	public static void setUpClass() throws Exception {
 		_disableKeyValidatorSafeCloseable = disableValidateWithSafeCloseable();
 
-		_ignoredVersionField = findField("ignored.version.filed");
+		_propertiesField = findField("properties.field");
 	}
 
 	@AfterClass
@@ -68,7 +69,7 @@ public class FreeTierVersionLicenseTest extends BaseLicenseTestCase {
 	public void testIgnoredVersion() throws Exception {
 		String ignoredVersion = _getIgnoredVersion();
 
-		if (!Objects.equals(ignoredVersion, StringPool.NEW_LINE)) {
+		if (Validator.isNotNull(ignoredVersion)) {
 			Assert.assertEquals(ignoredVersion, getCurrentVersion());
 		}
 	}
@@ -103,7 +104,9 @@ public class FreeTierVersionLicenseTest extends BaseLicenseTestCase {
 	}
 
 	private String _getIgnoredVersion() throws Exception {
-		return (String)_ignoredVersionField.get(null);
+		Properties properties = (Properties)_propertiesField.get(null);
+
+		return properties.getProperty("license.free.tier.ignored.version");
 	}
 
 	private void _testVersion(
@@ -165,6 +168,6 @@ public class FreeTierVersionLicenseTest extends BaseLicenseTestCase {
 	}
 
 	private static SafeCloseable _disableKeyValidatorSafeCloseable;
-	private static Field _ignoredVersionField;
+	private static Field _propertiesField;
 
 }

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/LogEntriesException.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/LogEntriesException.java
@@ -36,7 +36,7 @@ public class LogEntriesException extends Exception {
 	public String toString() {
 		StringBundler sb = new StringBundler();
 
-		sb.append("Total Log Entries is ");
+		sb.append("Log Entries: ");
 		sb.append(_logEntries.size());
 		sb.append(StringPool.NEW_LINE);
 

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/LogEntriesException.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/LogEntriesException.java
@@ -5,7 +5,12 @@
 
 package com.liferay.portal.license.test;
 
+import com.liferay.petra.io.unsync.UnsyncStringWriter;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.test.log.LogEntry;
+
+import java.io.PrintWriter;
 
 import java.util.List;
 
@@ -25,6 +30,42 @@ public class LogEntriesException extends Exception {
 
 	public String getPayload() {
 		return _payload;
+	}
+
+	@Override
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("Total Log Entries is ");
+		sb.append(_logEntries.size());
+		sb.append(StringPool.NEW_LINE);
+
+		for (int i = 0; i < _logEntries.size(); i++) {
+			sb.append("Log Entry ");
+			sb.append(i + 1);
+			sb.append(":");
+
+			LogEntry logEntry = _logEntries.get(i);
+
+			sb.append(logEntry.getMessage());
+
+			Throwable throwable = logEntry.getThrowable();
+
+			if (throwable != null) {
+				UnsyncStringWriter unsyncStringWriter =
+					new UnsyncStringWriter();
+
+				try (PrintWriter printWriter = new PrintWriter(
+						unsyncStringWriter)) {
+
+					throwable.printStackTrace(printWriter);
+				}
+
+				sb.append(unsyncStringWriter.toString());
+			}
+		}
+
+		return sb.toString();
 	}
 
 	private final List<LogEntry> _logEntries;

--- a/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/PropertiesUtilLicenseTest.java
+++ b/modules/apps/portal/portal-license-test/src/testIntegration/java/com/liferay/portal/license/test/PropertiesUtilLicenseTest.java
@@ -1,0 +1,73 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.license.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.license.util.App;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Tina Tian
+ */
+@RunWith(Arquillian.class)
+public class PropertiesUtilLicenseTest extends BaseLicenseTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule());
+
+	public static void assume() {
+		Assume.assumeTrue(isReleaseBundle());
+	}
+
+	@Test
+	public void test() throws Exception {
+		Field propertiesField = findField("properties.field");
+
+		Class<?> clazz = propertiesField.getDeclaringClass();
+
+		Set<String> keys = new HashSet<>();
+
+		for (Field field : clazz.getDeclaredFields()) {
+			if (Modifier.isPublic(field.getModifiers())) {
+				String key = (String)field.get(null);
+
+				if (key.contains(".app.product.")) {
+					for (App app : App.values()) {
+						keys.add(key + StringPool.PERIOD + app.toString());
+					}
+				}
+				else {
+					keys.add(key);
+				}
+			}
+		}
+
+		Properties properties = (Properties)propertiesField.get(null);
+
+		Assert.assertEquals(keys, properties.stringPropertyNames());
+	}
+
+}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -73,6 +73,10 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -346,23 +350,27 @@ public class UpgradeReport {
 							"\"rootDir\" was not set";
 					}
 
-					_dlSize = 0;
+					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
+						() -> FileUtils.sizeOfDirectory(new File(_rootDir)));
 
 					try {
-						_dlSizeThread.start();
-						_dlSizeThread.join(
-							PropsValues.UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT *
-								Time.SECOND);
-					}
-					catch (Exception exception) {
-						_log.error(
-							"Unable to determine the document library size",
-							exception);
+						Thread dlSizeThread = new Thread(
+							dlSizeFutureTask, "Liferay DL Size Thread");
 
-						return "Unable to determine";
-					}
+						dlSizeThread.setDaemon(true);
 
-					if (_dlSizeThread.isAlive()) {
+						dlSizeThread.start();
+
+						long dlSize = dlSizeFutureTask.get(
+							PropsValues.UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT,
+							TimeUnit.SECONDS);
+
+						return LanguageUtil.formatStorageSize(
+							dlSize, LocaleUtil.US);
+					}
+					catch (TimeoutException timeoutException) {
+						dlSizeFutureTask.cancel(true);
+
 						if (_log.isInfoEnabled()) {
 							_log.info(
 								"Unable to determine the document library " +
@@ -370,11 +378,22 @@ public class UpgradeReport {
 										"manually.");
 						}
 
-						return "Unable to determine";
+						if (_log.isDebugEnabled()) {
+							_log.debug(timeoutException);
+						}
+					}
+					catch (ExecutionException executionException) {
+						_log.error(
+							"Unable to determine the document library size",
+							executionException.getCause());
+					}
+					catch (Exception exception) {
+						_log.error(
+							"Unable to determine the document library size",
+							exception);
 					}
 
-					return LanguageUtil.formatStorageSize(
-						_dlSize, LocaleUtil.US);
+					return "Unable to determine";
 				}
 			).build()
 		).put(
@@ -1007,22 +1026,11 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
-	private double _dlSize;
-	private final Thread _dlSizeThread = new DLSizeThread();
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;
 	private Map<String, Long> _initialTableCounts;
 	private String _rootDir;
-
-	private class DLSizeThread extends Thread {
-
-		@Override
-		public void run() {
-			_dlSize = FileUtils.sizeOfDirectory(new File(_rootDir));
-		}
-
-	}
 
 	private class MessagesPrinter {
 

--- a/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
@@ -6,15 +6,22 @@
 package com.liferay.portal.upgrade.internal.report;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.DuplicateUniqueFinderRowsCleaner;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.internal.recorder.UpgradeRecorder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
@@ -48,11 +55,57 @@ public class UpgradeReportTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Before
-	public void setUp() {
+	public void setUp() throws Exception {
 		_dataAccessMockedStatic = Mockito.mockStatic(DataAccess.class);
+		_dbManagerUtilMockedStatic = Mockito.mockStatic(DBManagerUtil.class);
 		_dbUpgraderMockedStatic = Mockito.mockStatic(DBUpgrader.class);
+
 		_portalUpgradeProcessMockedStatic = Mockito.mockStatic(
 			PortalUpgradeProcess.class);
+
+		Connection connection = Mockito.mock(Connection.class);
+		DatabaseMetaData databaseMetaData = Mockito.mock(
+			DatabaseMetaData.class);
+		ResultSet tablesResultSet = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			connection.getMetaData()
+		).thenReturn(
+			databaseMetaData
+		);
+
+		Mockito.when(
+			databaseMetaData.getTables(
+				Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
+		).thenReturn(
+			tablesResultSet
+		);
+
+		Mockito.when(
+			tablesResultSet.next()
+		).thenReturn(
+			false
+		);
+
+		_dataAccessMockedStatic.when(
+			DataAccess::getConnection
+		).thenReturn(
+			connection
+		);
+
+		DB db = Mockito.mock(DB.class);
+
+		_dbManagerUtilMockedStatic.when(
+			DBManagerUtil::getDB
+		).thenReturn(
+			db
+		);
+
+		Mockito.when(
+			db.getDBType()
+		).thenReturn(
+			DBType.MYSQL
+		);
 
 		MockitoAnnotations.initMocks(this);
 	}
@@ -60,6 +113,7 @@ public class UpgradeReportTest {
 	@After
 	public void tearDown() {
 		_dataAccessMockedStatic.close();
+		_dbManagerUtilMockedStatic.close();
 		_dbUpgraderMockedStatic.close();
 		_portalUpgradeProcessMockedStatic.close();
 	}
@@ -158,6 +212,36 @@ public class UpgradeReportTest {
 	}
 
 	@Test
+	public void testGetReportDataWhenDLRootDirIsInvalid() throws Exception {
+		Path tempFilePath = Files.createTempFile(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		try {
+			UpgradeReport upgradeReport = new UpgradeReport();
+
+			ReflectionTestUtil.setFieldValue(
+				upgradeReport, "_rootDir",
+				tempFilePath.toAbsolutePath(
+				).toString());
+
+			Map<String, Object> reportData = ReflectionTestUtil.invoke(
+				upgradeReport, "_getReportData",
+				new Class<?>[] {UpgradeRecorder.class}, _upgradeRecorder);
+
+			Map<String, Object> documentLibrary =
+				(Map<String, Object>)reportData.get("document.library");
+
+			Assert.assertNotNull(documentLibrary);
+
+			Assert.assertEquals(
+				"Unable to determine", documentLibrary.get("storage.size"));
+		}
+		finally {
+			Files.deleteIfExists(tempFilePath);
+		}
+	}
+
+	@Test
 	public void testGetTableCounts() throws Exception {
 		Connection connection = Mockito.mock(Connection.class);
 		ResultSet countResultSet = Mockito.mock(ResultSet.class);
@@ -232,6 +316,7 @@ public class UpgradeReportTest {
 	}
 
 	private MockedStatic<DataAccess> _dataAccessMockedStatic;
+	private MockedStatic<DBManagerUtil> _dbManagerUtilMockedStatic;
 	private MockedStatic<DBUpgrader> _dbUpgraderMockedStatic;
 	private MockedStatic<PortalUpgradeProcess>
 		_portalUpgradeProcessMockedStatic;

--- a/modules/apps/site-initializer/site-initializer-cms/src/main/resources/com/liferay/site/initializer/cms/internal/batch/02-object-definition.batch-engine-data.json
+++ b/modules/apps/site-initializer/site-initializer-cms/src/main/resources/com/liferay/site/initializer/cms/internal/batch/02-object-definition.batch-engine-data.json
@@ -1020,7 +1020,7 @@
 		},
 		{
 			"className": "com.liferay.object.model.ObjectDefinition#P4T1",
-			"enableCategorization": true,
+			"enableCategorization": false,
 			"enableFormContainer": false,
 			"externalReferenceCode": "L_CMS_BULK_ACTION_TASK",
 			"label": {

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/manager/SitemapManager.java
@@ -25,10 +25,20 @@ public interface SitemapManager {
 
 	public static final int MAXIMUM_ENTRIES = 50000;
 
+	public default void addURLElement(
+		Element element, String url,
+		UnicodeProperties typeSettingsUnicodeProperties, Date modifiedDate,
+		String canonicalURL, Map<Locale, String> alternateURLs) {
+
+		addURLElement(
+			element, url, typeSettingsUnicodeProperties, modifiedDate,
+			canonicalURL, alternateURLs, 0);
+	}
+
 	public void addURLElement(
 		Element element, String url,
 		UnicodeProperties typeSettingsUnicodeProperties, Date modifiedDate,
-		String canonicalURL, Map<Locale, String> alternateURLs);
+		String canonicalURL, Map<Locale, String> alternateURLs, long groupId);
 
 	public String encodeXML(String input);
 

--- a/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/feature/flag/CMPFeatureFlagListener.java
+++ b/modules/apps/site/site-cmp-site-initializer/src/main/java/com/liferay/site/cmp/site/initializer/internal/feature/flag/CMPFeatureFlagListener.java
@@ -9,6 +9,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -36,7 +37,7 @@ public class CMPFeatureFlagListener implements FeatureFlagListener {
 		long companyId, String featureFlagKey, boolean enabled) {
 
 		if (!enabled || !Objects.equals(featureFlagKey, "LPD-58677") ||
-			!LicenseManagerUtil.isCMPEnabled()) {
+			!LicenseManagerUtil.isAppEnabled(App.CMP)) {
 
 			return;
 		}

--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/service/CMSObjectEntryFolderDepotEntryLocalServiceWrapper.java
@@ -101,7 +101,10 @@ public class CMSObjectEntryFolderDepotEntryLocalServiceWrapper
 	public DepotEntry deleteDepotEntry(DepotEntry depotEntry)
 		throws PortalException {
 
-		if (depotEntry.getType() == DepotConstants.TYPE_SPACE) {
+		if (FeatureFlagManagerUtil.isEnabled(
+				depotEntry.getCompanyId(), "LPD-17564") &&
+			(depotEntry.getType() == DepotConstants.TYPE_SPACE)) {
+
 			ObjectEntryFolderUtil.deleteObjectEntryFolders(depotEntry);
 
 			_deleteCMSDefaultPermissions(depotEntry.getGroup());

--- a/modules/apps/site/site-impl/build.gradle
+++ b/modules/apps/site/site-impl/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-seo-api")
 	compileOnly project(":apps:portal-background-task:portal-background-task-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:redirect:redirect-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:xstream:xstream-configurator-api")

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -431,10 +431,6 @@ public class SitemapManagerImpl implements SitemapManager {
 			_getLayoutSets(groupId, layoutUuid, privateLayout, themeDisplay),
 			layoutUuid, rootElement, themeDisplay);
 
-		if (!rootElement.hasContent()) {
-			return StringPool.BLANK;
-		}
-
 		_removeEntriesAndSize(rootElement);
 
 		return document.asXML();

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -21,12 +21,14 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypeController;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -41,6 +43,7 @@ import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.util.LayoutTypeControllerTracker;
+import com.liferay.redirect.provider.RedirectProvider;
 import com.liferay.site.configuration.manager.SitemapConfigurationManager;
 import com.liferay.site.manager.SitemapManager;
 import com.liferay.site.provider.SitemapURLProvider;
@@ -55,6 +58,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -73,7 +77,33 @@ public class SitemapManagerImpl implements SitemapManager {
 	public void addURLElement(
 		Element element, String url,
 		UnicodeProperties typeSettingsUnicodeProperties, Date modifiedDate,
-		String canonicalURL, Map<Locale, String> alternateURLs) {
+		String canonicalURL, Map<Locale, String> alternateURLs, long groupId) {
+
+		String path = HttpComponentsUtil.getPath(url);
+		String contextPath = _portal.getPathContext();
+
+		if (Validator.isNotNull(contextPath) && path.startsWith(contextPath)) {
+			path = path.substring(contextPath.length());
+		}
+
+		String fullURL = path;
+
+		if (fullURL.startsWith(StringPool.SLASH)) {
+			fullURL = fullURL.substring(1);
+		}
+
+		String friendlyURL = _getFriendlyURL(path, groupId);
+
+		if (friendlyURL.startsWith(StringPool.SLASH)) {
+			friendlyURL = friendlyURL.substring(1);
+		}
+
+		RedirectProvider.Redirect redirect = _redirectProvider.getRedirect(
+			groupId, friendlyURL, fullURL, null);
+
+		if (redirect != null) {
+			return;
+		}
 
 		Element urlElement = element.addElement("url");
 
@@ -223,6 +253,67 @@ public class SitemapManagerImpl implements SitemapManager {
 	@Deactivate
 	protected void deactivate() {
 		_serviceTrackerMap.close();
+	}
+
+	private String _getFriendlyURL(String path, long groupId) {
+		int[] groupFriendlyURLIndex = _portal.getGroupFriendlyURLIndex(path);
+
+		if (groupFriendlyURLIndex != null) {
+			if (groupFriendlyURLIndex[1] < path.length()) {
+				return path.substring(groupFriendlyURLIndex[1]);
+			}
+
+			return StringPool.BLANK;
+		}
+
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		if (companyId == 0) {
+			companyId = _companyIds.computeIfAbsent(
+				groupId,
+				key -> {
+					try {
+						Group group = _groupLocalService.getGroup(key);
+
+						return group.getCompanyId();
+					}
+					catch (PortalException portalException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(portalException);
+						}
+
+						return 0L;
+					}
+				});
+		}
+
+		for (Locale availableLocale :
+				_language.getAvailableLocales(companyId)) {
+
+			String i18nPath =
+				StringPool.SLASH + LocaleUtil.toLanguageId(availableLocale);
+
+			if (path.startsWith(i18nPath + StringPool.SLASH) ||
+				path.equals(i18nPath)) {
+
+				String pathWithoutLocale = path.substring(i18nPath.length());
+
+				int[] tempIndices = _portal.getGroupFriendlyURLIndex(
+					pathWithoutLocale);
+
+				if (tempIndices != null) {
+					if (tempIndices[1] < pathWithoutLocale.length()) {
+						return pathWithoutLocale.substring(tempIndices[1]);
+					}
+
+					return StringPool.BLANK;
+				}
+
+				return pathWithoutLocale;
+			}
+		}
+
+		return path;
 	}
 
 	private String _getIndexSitemap(
@@ -566,6 +657,8 @@ public class SitemapManagerImpl implements SitemapManager {
 	private static final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
 
+	private final Map<Long, Long> _companyIds = new ConcurrentHashMap<>();
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
@@ -580,6 +673,9 @@ public class SitemapManagerImpl implements SitemapManager {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private RedirectProvider _redirectProvider;
 
 	@Reference
 	private SAXReader _saxReader;

--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/manager/SitemapManagerImpl.java
@@ -86,16 +86,16 @@ public class SitemapManagerImpl implements SitemapManager {
 			path = path.substring(contextPath.length());
 		}
 
-		String fullURL = path;
-
-		if (fullURL.startsWith(StringPool.SLASH)) {
-			fullURL = fullURL.substring(1);
-		}
-
 		String friendlyURL = _getFriendlyURL(path, groupId);
 
 		if (friendlyURL.startsWith(StringPool.SLASH)) {
 			friendlyURL = friendlyURL.substring(1);
+		}
+
+		String fullURL = path;
+
+		if (fullURL.startsWith(StringPool.SLASH)) {
+			fullURL = fullURL.substring(1);
 		}
 
 		RedirectProvider.Redirect redirect = _redirectProvider.getRedirect(
@@ -296,20 +296,20 @@ public class SitemapManagerImpl implements SitemapManager {
 			if (path.startsWith(i18nPath + StringPool.SLASH) ||
 				path.equals(i18nPath)) {
 
-				String pathWithoutLocale = path.substring(i18nPath.length());
+				path = path.substring(i18nPath.length());
 
-				int[] tempIndices = _portal.getGroupFriendlyURLIndex(
-					pathWithoutLocale);
+				int[] groupFriendlyURLIndex = _portal.getGroupFriendlyURLIndex(
+					path);
 
-				if (tempIndices != null) {
-					if (tempIndices[1] < pathWithoutLocale.length()) {
-						return pathWithoutLocale.substring(tempIndices[1]);
+				if (groupFriendlyURLIndex != null) {
+					if (groupFriendlyURLIndex[1] < path.length()) {
+						return path.substring(groupFriendlyURLIndex[1]);
 					}
 
 					return StringPool.BLANK;
 				}
 
-				return pathWithoutLocale;
+				return path;
 			}
 		}
 

--- a/modules/apps/site/site-test/build.gradle
+++ b/modules/apps/site/site-test/build.gradle
@@ -21,6 +21,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal:portal-local-service-tree-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-verify-test-util")
+	testIntegrationImplementation project(":apps:redirect:redirect-api")
 	testIntegrationImplementation project(":apps:site:site-api")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -322,7 +322,7 @@ public class SitemapManagerTest {
 
 			_setUpAssetCategoryDisplayPage();
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -356,7 +356,7 @@ public class SitemapManagerTest {
 
 			_setUpAssetCategoryDisplayPage();
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -390,7 +390,7 @@ public class SitemapManagerTest {
 
 			_setUpAssetCategoryDisplayPage();
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -554,7 +554,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -586,7 +586,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -618,7 +618,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -725,7 +725,7 @@ public class SitemapManagerTest {
 
 			_addRedirectEntry(sourceURL.substring(1));
 
-			_assertEmptySitemap(_layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), _layout.getUuid());
 		}
 	}
 
@@ -781,7 +781,7 @@ public class SitemapManagerTest {
 
 			_addRedirectEntry(sourceURL.substring(1));
 
-			_assertEmptySitemap(childLayout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), childLayout.getUuid());
 		}
 	}
 
@@ -821,7 +821,7 @@ public class SitemapManagerTest {
 			Layout layout = _layoutLocalService.getLayout(
 				assetDisplayPageEntry.getPlid());
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -861,7 +861,7 @@ public class SitemapManagerTest {
 			Layout layout = _layoutLocalService.getLayout(
 				assetDisplayPageEntry.getPlid());
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -901,7 +901,7 @@ public class SitemapManagerTest {
 			Layout layout = _layoutLocalService.getLayout(
 				assetDisplayPageEntry.getPlid());
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -1007,7 +1007,7 @@ public class SitemapManagerTest {
 
 			_addRedirectEntry(sourceURL.substring(1));
 
-			_assertEmptySitemap(layout.getUuid());
+			_assertEmptySitemap(_group.getGroupId(), layout.getUuid());
 		}
 	}
 
@@ -1071,11 +1071,19 @@ public class SitemapManagerTest {
 		_redirectEntryLocalService.addRedirectEntry(redirectEntry);
 	}
 
-	private void _assertEmptySitemap(String uuid) throws Exception {
-		Assert.assertEquals(
-			StringPool.BLANK,
-			_sitemapManager.getSitemap(
-				uuid, _group.getGroupId(), false, _themeDisplay));
+	private void _assertEmptySitemap(long groupId, String uuid)
+		throws Exception {
+
+		String xml = _sitemapManager.getSitemap(
+			uuid, groupId, false, _themeDisplay);
+
+		Document document = _saxReader.read(xml);
+
+		Element rootElement = document.getRootElement();
+
+		Assert.assertTrue(
+			rootElement.elements(
+			).isEmpty());
 	}
 
 	private void _assertSitemap(
@@ -1338,10 +1346,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			Assert.assertEquals(
-				StringPool.BLANK,
-				_sitemapManager.getSitemap(
-					null, guestGroupId, false, _themeDisplay));
+			_assertEmptySitemap(guestGroupId, null);
 		}
 	}
 
@@ -1373,7 +1378,7 @@ public class SitemapManagerTest {
 							"includeWebContent", false
 						).build())) {
 
-			_assertEmptySitemap(uuid);
+			_assertEmptySitemap(_group.getGroupId(), uuid);
 		}
 	}
 

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -18,6 +18,7 @@ import com.liferay.asset.kernel.service.AssetVocabularyService;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.commerce.product.constants.CPPortletKeys;
 import com.liferay.commerce.product.url.CPFriendlyURL;
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.friendly.url.model.FriendlyURLEntry;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
 import com.liferay.info.item.InfoItemServiceRegistry;
@@ -58,11 +59,13 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
@@ -70,6 +73,8 @@ import com.liferay.portal.kernel.xml.SAXReader;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.redirect.model.RedirectEntry;
+import com.liferay.redirect.service.RedirectEntryLocalService;
 import com.liferay.site.manager.SitemapManager;
 import com.liferay.translation.info.item.provider.InfoItemLanguagesProvider;
 
@@ -628,6 +633,62 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIncludePagesWithRedirect() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build())) {
+
+			String canonicalURL = _portal.getCanonicalURL(
+				_portal.getLayoutFullURL(_layout, _themeDisplay), _themeDisplay,
+				_layout);
+
+			_assertSitemap(
+				true, _group.getGroupId(), _layout.getUuid(), canonicalURL);
+
+			String sourceURL = HttpComponentsUtil.getPath(canonicalURL);
+
+			if (sourceURL.startsWith(StringPool.SLASH)) {
+				sourceURL = sourceURL.substring(1);
+			}
+
+			RedirectEntry redirectEntry =
+				_redirectEntryLocalService.createRedirectEntry(
+					CounterLocalServiceUtil.increment());
+
+			redirectEntry.setUuid(PortalUUIDUtil.generate());
+			redirectEntry.setGroupId(_group.getGroupId());
+			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
+			redirectEntry.setDestinationURL("https://liferay.com");
+			redirectEntry.setPermanent(true);
+			redirectEntry.setSourceURL(sourceURL);
+
+			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+
+			_assertEmptySitemap(_layout.getUuid());
+		}
+	}
+
+	@Test
 	public void testSitemapIncludeWebContentCompanyDisabledGroupDisabled()
 		throws Exception {
 
@@ -794,6 +855,74 @@ public class SitemapManagerTest {
 							URL_SEPARATOR_JOURNAL_ARTICLE,
 						journalArticle.getUrlTitle()),
 					_themeDisplay, _layout));
+		}
+	}
+
+	@Test
+	public void testSitemapIncludeWebContentWithRedirect() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", false
+						).put(
+							"includeWebContent", true
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", false
+						).put(
+							"includeWebContent", true
+						).build())) {
+
+			JournalArticle journalArticle = _addJournalArticle();
+
+			AssetDisplayPageEntry assetDisplayPageEntry =
+				_addJournalArticleAssetDisplayPageEntry(journalArticle);
+
+			Layout layout = _layoutLocalService.getLayout(
+				assetDisplayPageEntry.getPlid());
+
+			_assertSitemap(
+				true, _group.getGroupId(), layout.getUuid(),
+				_portal.getCanonicalURL(
+					StringBundler.concat(
+						_portal.getGroupFriendlyURL(
+							_layout.getLayoutSet(), _themeDisplay, false,
+							false),
+						FriendlyURLResolverConstants.
+							URL_SEPARATOR_JOURNAL_ARTICLE,
+						journalArticle.getUrlTitle()),
+					_themeDisplay, _layout));
+
+			RedirectEntry redirectEntry =
+				_redirectEntryLocalService.createRedirectEntry(
+					CounterLocalServiceUtil.increment());
+
+			redirectEntry.setUuid(PortalUUIDUtil.generate());
+			redirectEntry.setGroupId(_group.getGroupId());
+			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
+			redirectEntry.setDestinationURL("https://liferay.com");
+			redirectEntry.setPermanent(true);
+
+			String sourceURL =
+				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE +
+					journalArticle.getUrlTitle();
+
+			redirectEntry.setSourceURL(sourceURL.substring(1));
+
+			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+
+			_assertEmptySitemap(layout.getUuid());
 		}
 	}
 
@@ -1240,6 +1369,9 @@ public class SitemapManagerTest {
 
 	@Inject
 	private Portal _portal;
+
+	@Inject
+	private RedirectEntryLocalService _redirectEntryLocalService;
 
 	@Inject
 	private SAXReader _saxReader;

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/manager/test/SitemapManagerTest.java
@@ -62,6 +62,7 @@ import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.TreeMapBuilder;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -633,6 +634,61 @@ public class SitemapManagerTest {
 	}
 
 	@Test
+	public void testSitemapIncludePagesWithLocaleAndRedirect()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build())) {
+
+			_layout.setTitle("Spanish Title", LocaleUtil.SPAIN);
+
+			_layout = _layoutLocalService.updateLayout(_layout);
+
+			String canonicalURL = _portal.getCanonicalURL(
+				_portal.getLayoutFullURL(_layout, _themeDisplay), _themeDisplay,
+				_layout);
+
+			Map<Locale, String> alternateURLs =
+				_sitemapManager.getAlternateURLs(
+					canonicalURL, _themeDisplay, _layout);
+
+			String spanishURL = alternateURLs.get(LocaleUtil.SPAIN);
+
+			_assertSitemap(
+				true, _group.getGroupId(), _layout.getUuid(), canonicalURL,
+				spanishURL);
+
+			String sourceURL = HttpComponentsUtil.getPath(spanishURL);
+
+			_addRedirectEntry(sourceURL.substring(1));
+
+			_assertSitemap(
+				true, _group.getGroupId(), _layout.getUuid(), canonicalURL);
+		}
+	}
+
+	@Test
 	public void testSitemapIncludePagesWithRedirect() throws Exception {
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -667,24 +723,65 @@ public class SitemapManagerTest {
 
 			String sourceURL = HttpComponentsUtil.getPath(canonicalURL);
 
-			if (sourceURL.startsWith(StringPool.SLASH)) {
-				sourceURL = sourceURL.substring(1);
-			}
-
-			RedirectEntry redirectEntry =
-				_redirectEntryLocalService.createRedirectEntry(
-					CounterLocalServiceUtil.increment());
-
-			redirectEntry.setUuid(PortalUUIDUtil.generate());
-			redirectEntry.setGroupId(_group.getGroupId());
-			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
-			redirectEntry.setDestinationURL("https://liferay.com");
-			redirectEntry.setPermanent(true);
-			redirectEntry.setSourceURL(sourceURL);
-
-			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+			_addRedirectEntry(sourceURL.substring(1));
 
 			_assertEmptySitemap(_layout.getUuid());
+		}
+	}
+
+	@Test
+	public void testSitemapIncludePagesWithVirtualHostAndRedirect()
+		throws Exception {
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						_PID_SITEMAP_COMPANY_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build());
+			GroupConfigurationTemporarySwapper
+				groupConfigurationTemporarySwapper =
+					new GroupConfigurationTemporarySwapper(
+						_group.getGroupId(), _PID_SITEMAP_GROUP_CONFIGURATION,
+						HashMapDictionaryBuilder.<String, Object>put(
+							"includeCategories", false
+						).put(
+							"includePages", true
+						).put(
+							"includeWebContent", false
+						).build())) {
+
+			String virtualHostname = StringUtil.randomString(8);
+
+			_layoutSetLocalService.updateVirtualHosts(
+				_group.getGroupId(), false,
+				TreeMapBuilder.put(
+					virtualHostname, _layout.getDefaultLanguageId()
+				).build());
+
+			Layout childLayout = LayoutTestUtil.addTypePortletLayout(
+				_group.getGroupId(), _layout.getPlid());
+
+			_setUpThemeDisplay(_group, childLayout, virtualHostname);
+
+			String canonicalURL = _portal.getCanonicalURL(
+				_portal.getLayoutFullURL(childLayout, _themeDisplay),
+				_themeDisplay, childLayout);
+
+			_assertSitemap(
+				true, _group.getGroupId(), childLayout.getUuid(), canonicalURL);
+
+			String sourceURL = HttpComponentsUtil.getPath(canonicalURL);
+
+			_addRedirectEntry(sourceURL.substring(1));
+
+			_assertEmptySitemap(childLayout.getUuid());
 		}
 	}
 
@@ -904,23 +1001,11 @@ public class SitemapManagerTest {
 						journalArticle.getUrlTitle()),
 					_themeDisplay, _layout));
 
-			RedirectEntry redirectEntry =
-				_redirectEntryLocalService.createRedirectEntry(
-					CounterLocalServiceUtil.increment());
-
-			redirectEntry.setUuid(PortalUUIDUtil.generate());
-			redirectEntry.setGroupId(_group.getGroupId());
-			redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
-			redirectEntry.setDestinationURL("https://liferay.com");
-			redirectEntry.setPermanent(true);
-
 			String sourceURL =
 				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE +
 					journalArticle.getUrlTitle();
 
-			redirectEntry.setSourceURL(sourceURL.substring(1));
-
-			_redirectEntryLocalService.addRedirectEntry(redirectEntry);
+			_addRedirectEntry(sourceURL.substring(1));
 
 			_assertEmptySitemap(layout.getUuid());
 		}
@@ -969,6 +1054,21 @@ public class SitemapManagerTest {
 			journalArticle.getResourcePrimKey(),
 			journalArticle.getDDMStructureKey(),
 			AssetDisplayPageConstants.TYPE_SPECIFIC);
+	}
+
+	private void _addRedirectEntry(String sourceURL) throws Exception {
+		RedirectEntry redirectEntry =
+			_redirectEntryLocalService.createRedirectEntry(
+				CounterLocalServiceUtil.increment());
+
+		redirectEntry.setUuid(PortalUUIDUtil.generate());
+		redirectEntry.setGroupId(_group.getGroupId());
+		redirectEntry.setCompanyId(TestPropsValues.getCompanyId());
+		redirectEntry.setDestinationURL("https://liferay.com");
+		redirectEntry.setPermanent(true);
+		redirectEntry.setSourceURL(sourceURL);
+
+		_redirectEntryLocalService.addRedirectEntry(redirectEntry);
 	}
 
 	private void _assertEmptySitemap(String uuid) throws Exception {

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
@@ -114,8 +114,13 @@ public class InfoItemHelper {
 				return stringValue;
 			}
 
-			return (String)infoLocalizedValue.getValue(
-				infoLocalizedValue.getDefaultLocale());
+			Locale defaultLocale = infoLocalizedValue.getDefaultLocale();
+
+			if (defaultLocale == null) {
+				return null;
+			}
+
+			return (String)infoLocalizedValue.getValue(defaultLocale);
 		}
 
 		return (String)value;

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/helper/InfoItemHelper.java
@@ -11,12 +11,14 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 
@@ -97,6 +99,28 @@ public class InfoItemHelper {
 				StringPool.CLOSE_PARENTHESIS));
 	}
 
+	private String _getStringValue(
+		InfoFieldValue<Object> infoFieldValue, Locale locale) {
+
+		Object value = infoFieldValue.getValue();
+
+		if (value instanceof InfoLocalizedValue) {
+			InfoLocalizedValue<Object> infoLocalizedValue =
+				(InfoLocalizedValue<Object>)value;
+
+			String stringValue = (String)infoLocalizedValue.getValue(locale);
+
+			if (Validator.isNotNull(stringValue)) {
+				return stringValue;
+			}
+
+			return (String)infoLocalizedValue.getValue(
+				infoLocalizedValue.getDefaultLocale());
+		}
+
+		return (String)value;
+	}
+
 	private String _getTitle(String className, Object object, Locale locale) {
 		InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
 			_infoItemServiceRegistry.getFirstInfoItemService(
@@ -106,13 +130,21 @@ public class InfoItemHelper {
 			infoItemFieldValuesProvider.getInfoFieldValue(object, "title");
 
 		if (titleInfoFieldValue != null) {
-			return (String)titleInfoFieldValue.getValue(locale);
+			String value = _getStringValue(titleInfoFieldValue, locale);
+
+			if (Validator.isNotNull(value)) {
+				return value;
+			}
 		}
 
 		InfoFieldValue<Object> nameInfoFieldValue =
 			infoItemFieldValuesProvider.getInfoFieldValue(object, "name");
 
-		return (String)nameInfoFieldValue.getValue(locale);
+		if (nameInfoFieldValue != null) {
+			return _getStringValue(nameInfoFieldValue, locale);
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(InfoItemHelper.class);

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/manager/TranslationManagerImpl.java
@@ -220,7 +220,7 @@ public class TranslationManagerImpl implements TranslationManager {
 
 		String title = getTitle(className, classPK, locale);
 
-		if (title == null) {
+		if (Validator.isNull(title)) {
 			title =
 				_language.get(locale, "model.resource." + className) +
 					StringPool.SPACE + classPK;

--- a/modules/apps/translation/translation-test/build.gradle
+++ b/modules/apps/translation/translation-test/build.gradle
@@ -8,6 +8,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
+	testIntegrationImplementation project(":apps:object:object-api")
+	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:segments:segments-api")
 	testIntegrationImplementation project(":apps:translation:translation-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
+++ b/modules/apps/translation/translation-test/src/testIntegration/java/com/liferay/translation/manager/test/TranslationManagerTest.java
@@ -10,12 +10,25 @@ import com.liferay.dynamic.data.mapping.io.DDMFormDeserializer;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.field.builder.TextObjectFieldBuilder;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -29,10 +42,13 @@ import com.liferay.translation.test.util.TranslationTestUtil;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.io.Serializable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -92,6 +108,45 @@ public class TranslationManagerTest {
 
 		_testGetXLIFFFile("test-journal-article-v12.xlf", _MIMETYPE_XLIFF_1_2);
 		_testGetXLIFFFile("test-journal-article.xlf", _MIMETYPE_XLIFF_2_0);
+	}
+
+	@Test
+	@TestInfo("LPD-85323")
+	public void testObjectEntryGetTitle() throws Exception {
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(
+					new TextObjectFieldBuilder(
+					).labelMap(
+						Collections.singletonMap(
+							LocaleUtil.getDefault(), "Title")
+					).localized(
+						true
+					).name(
+						"title"
+					).build()),
+				ObjectDefinitionConstants.SCOPE_SITE);
+
+		String spanishTitle = RandomTestUtil.randomString();
+
+		Map<String, String> titles = HashMapBuilder.put(
+			"es_ES", spanishTitle
+		).build();
+
+		_testObjectEntryGetTitle(
+			"es_ES", spanishTitle, LocaleUtil.US, objectDefinition, titles);
+		_testObjectEntryGetTitle(
+			"es_ES", spanishTitle, LocaleUtil.SPAIN, objectDefinition, titles);
+
+		String englishTitle = RandomTestUtil.randomString();
+
+		titles.put("en_US", englishTitle);
+
+		_testObjectEntryGetTitle(
+			"es_ES", englishTitle, LocaleUtil.US, objectDefinition, titles);
+
+		_testObjectEntryGetTitle(
+			"es_ES", spanishTitle, LocaleUtil.SPAIN, objectDefinition, titles);
 	}
 
 	@Test
@@ -198,6 +253,38 @@ public class TranslationManagerTest {
 		}
 	}
 
+	private void _testObjectEntryGetTitle(
+			String defaultLangueId, String expectedTitle, Locale locale,
+			ObjectDefinition objectDefinition, Map<String, String> titles)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
+			_group.getGroupId(), TestPropsValues.getUserId(),
+			objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			defaultLangueId,
+			HashMapBuilder.put(
+				"title_i18n", (Serializable)titles
+			).build(),
+			serviceContext);
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		try {
+			Assert.assertEquals(
+				expectedTitle,
+				_translationManager.getTitle(
+					objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId(), locale));
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
+	}
+
 	private void _testProcessXLIFFTranslationFailureWithSingleFile(
 			File xliffFile)
 		throws Exception {
@@ -297,6 +384,9 @@ public class TranslationManagerTest {
 	private Group _group;
 
 	private JournalArticle _journalArticle;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Inject
 	private TranslationManager _translationManager;

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/cloud/configs/portal-all.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/cloud/configs/portal-all.properties
@@ -5,9 +5,8 @@ company.default.name=Liferay AC
 company.default.web.id=liferay.com
 terms.of.use.required=false
 passwords.default.policy.change.required=false
+feature.flag.LPD-34594=true
+feature.flag.LPS-164563=true
 retry.jdbc.on.startup.delay=5
 retry.jdbc.on.startup.max.retries=5
 dl.store.antivirus.enabled=true
-
-liferay.feature.flag.LPD-34594=true
-liferay.feature.flag.LPS-164563=true

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/common/resources/portal-ext.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-docker/local/common/resources/portal-ext.properties
@@ -21,6 +21,8 @@ layout.template.cache.enabled=false
 browser.launcher.url=
 combo.check.timestamp=true
 direct.servlet.context.reload=true
+feature.flag.LPD-34594=true
+feature.flag.LPS-164563=true
 module.framework.properties.lpkg.index.validator.enabled=false
 module.framework.properties.osgi.console=0.0.0.0:11311
 scheduler.group.name.max.length=100
@@ -44,7 +46,5 @@ dl.file.entry.thumbnail.enabled=false
 portlet.css.enabled=false
 sites.control.panel.members.visible=false
 
-liferay.feature.flag.LPD-34594=true
-liferay.feature.flag.LPS-164563=true
 redirect.url.domains.allowed=localhost,SERVER_IP
 redirect.url.security.mode=domain

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/package.json
@@ -178,7 +178,7 @@
 		"format": "eslint --fix \"src/main/js/**/*.+(js|ts)?(x)\"",
 		"lint": "eslint \"src/main/js/**/*.+(js|ts)?(x)\"",
 		"start": "cross-env FARO_ENVIRONMENT_NAME=local webpack-dev-server --config webpack.dev.js",
-		"test": "cross-env TZ=Etc/GMT LC_ALL=en-US jest --coverage=false --maxWorkers=4",
+		"test": "cross-env LC_ALL=en-US TZ=Etc/GMT jest --coverage=false --maxWorkers=4",
 		"webpack": "webpack --config webpack.prod.js",
 		"webpack:dev": "webpack --config webpack.dev.js"
 	},

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountController.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/contacts/AccountController.java
@@ -91,14 +91,14 @@ public class AccountController extends BaseFaroController {
 			@QueryParam("channelId") String channelId,
 			@QueryParam("filter") String filterString,
 			@QueryParam("page") int page, @QueryParam("pageSize") int pageSize,
-			@QueryParam("query") String query,
+			@QueryParam("search") String search,
 			@DefaultValue(StringPool.BLANK) @QueryParam("sort") String
 				sortString)
 		throws Exception {
 
 		Results<Account> results = contactsEngineClient.getAccounts(
 			faroProjectLocalService.getFaroProjectByGroupId(groupId), channelId,
-			filterString, query, page, pageSize, sortString);
+			filterString, search, page, pageSize, sortString);
 
 		Function<Account, AccountDisplay> function = AccountDisplay::new;
 

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/contacts/pages/account/List.tsx
@@ -214,7 +214,7 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 										{
 											apiURL: `/o/faro/contacts/${groupId}/account/fds_field_values?channelId=${channelId}&fieldMappingFieldName=industry`,
 											entityFieldType: 'string',
-											id: 'name',
+											id: 'industry',
 											itemKey: 'name',
 											itemLabel: 'name',
 											label: Liferay.Language.get(
@@ -226,7 +226,7 @@ const List: React.FC<IListProps> = ({channelId, groupId}) => {
 										{
 											apiURL: `/o/faro/contacts/${groupId}/account/fds_field_values?channelId=${channelId}&fieldMappingFieldName=country`,
 											entityFieldType: 'string',
-											id: 'name',
+											id: 'country',
 											itemKey: 'name',
 											itemLabel: 'name',
 											label: Liferay.Language.get(

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/demandbase/DemandbaseEntities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/demandbase/DemandbaseEntities.tsx
@@ -19,55 +19,51 @@ const DemandbaseEntities: React.FC<IDemandbaseEntities> = ({
 }) => (
 	<div className='pt-1'>
 		<ClayList className='mb-0'>
-			<>
-				<ClayList.Item flex>
-					<ClayList.ItemField>
-						<ClaySticker displayType='unstyled'>
-							<ClayIcon
-								className='text-secondary'
-								symbol='briefcase'
-							/>
-						</ClaySticker>
-					</ClayList.ItemField>
+			<ClayList.Item flex>
+				<ClayList.ItemField>
+					<ClaySticker displayType='unstyled'>
+						<ClayIcon
+							className='text-secondary'
+							symbol='briefcase'
+						/>
+					</ClaySticker>
+				</ClayList.ItemField>
 
-					<ClayList.ItemField expand>
-						<ClayList.ItemTitle>
-							{Liferay.Language.get('accounts')}
-						</ClayList.ItemTitle>
+				<ClayList.ItemField expand>
+					<ClayList.ItemTitle>
+						{Liferay.Language.get('accounts')}
+					</ClayList.ItemTitle>
 
-						<ClayList.ItemText>
-							{Liferay.Language.get(
-								'represents-fields-from-the-account-object-within-demandbase'
-							)}
-						</ClayList.ItemText>
-
-						{accountsSyncedCount >= 0 && (
-							<ClayList.ItemText>
-								{sub(Liferay.Language.get('x-items-synced'), [
-									accountsSyncedCount
-								])}
-							</ClayList.ItemText>
+					<ClayList.ItemText>
+						{Liferay.Language.get(
+							'represents-fields-from-the-account-object-within-demandbase'
 						)}
-					</ClayList.ItemField>
-					<ClayList.ItemField
-						className='justify-content-center'
-						expand
+					</ClayList.ItemText>
+
+					{accountsSyncedCount >= 0 && (
+						<ClayList.ItemText>
+							{sub(Liferay.Language.get('x-items-synced'), [
+								accountsSyncedCount
+							])}
+						</ClayList.ItemText>
+					)}
+				</ClayList.ItemField>
+
+				<ClayList.ItemField className='justify-content-center' expand>
+					<Label
+						className='ml-auto'
+						displayType={
+							accountConnectionStatus === 'connected'
+								? 'success'
+								: 'secondary'
+						}
 					>
-						<Label
-							className='ml-auto'
-							displayType={
-								accountConnectionStatus === 'connected'
-									? 'success'
-									: 'secondary'
-							}
-						>
-							{accountConnectionStatus === 'connected'
-								? Liferay.Language.get('connected')
-								: Liferay.Language.get('disconnected')}
-						</Label>
-					</ClayList.ItemField>
-				</ClayList.Item>
-			</>
+						{accountConnectionStatus === 'connected'
+							? Liferay.Language.get('connected')
+							: Liferay.Language.get('disconnected')}
+					</Label>
+				</ClayList.ItemField>
+			</ClayList.Item>
 		</ClayList>
 	</div>
 );

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/demandbase/DemandbaseEntities.tsx
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/js/settings/components/demandbase/DemandbaseEntities.tsx
@@ -49,9 +49,8 @@ const DemandbaseEntities: React.FC<IDemandbaseEntities> = ({
 					)}
 				</ClayList.ItemField>
 
-				<ClayList.ItemField className='justify-content-center' expand>
+				<ClayList.ItemField className='justify-content-center'>
 					<Label
-						className='ml-auto'
 						displayType={
 							accountConnectionStatus === 'connected'
 								? 'success'

--- a/modules/sdk/ant-secure-property/build.gradle
+++ b/modules/sdk/ant-secure-property/build.gradle
@@ -8,7 +8,7 @@ clean {
 }
 
 dependencies {
-	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1791"
+	compileOnly group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1792"
 	compileOnly group: "org.apache.ant", name: "ant", transitive: false, version: "1.10.14"
 }
 

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.1792
+Bundle-Version: 1.0.1793

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -881,14 +881,13 @@ public abstract class BaseWorkspaceGitRepository
 		else {
 			sb.append("git clone --depth ");
 
+			LocalGitBranch localGitBranch = getLocalGitBranch();
 			RemoteGitBranch remoteGitBranch =
 				gitWorkingDirectory.getUpstreamRemoteGitBranch();
 
 			int commitCount = 0;
 
 			if (remoteGitBranch != null) {
-				LocalGitBranch localGitBranch = getLocalGitBranch();
-
 				commitCount = gitWorkingDirectory.getCommitCountBetweenBranches(
 					remoteGitBranch.getSHA(), localGitBranch.getSHA());
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -881,13 +881,29 @@ public abstract class BaseWorkspaceGitRepository
 		else {
 			sb.append("git clone --depth ");
 
-			LocalGitBranch localGitBranch = getLocalGitBranch();
+			RemoteGitBranch remoteGitBranch =
+				gitWorkingDirectory.getUpstreamRemoteGitBranch();
 
-			int commitCount = gitWorkingDirectory.getCommitCountBetweenBranches(
-				gitWorkingDirectory.getMergeBaseCommitSHA(
-					localGitBranch.getName(), _getSenderBranchHeadName(),
-					getUpstreamBranchName()),
-				localGitBranch.getName());
+			int commitCount = 0;
+
+			if (remoteGitBranch != null) {
+				LocalGitBranch localGitBranch = getLocalGitBranch();
+
+				commitCount = gitWorkingDirectory.getCommitCountBetweenBranches(
+					remoteGitBranch.getSHA(), localGitBranch.getSHA());
+
+				String senderBranchSHA = getSenderBranchSHA();
+
+				if ((senderBranchSHA != null) &&
+					!senderBranchSHA.equals(localGitBranch.getSHA())) {
+
+					int senderCommitCount =
+						gitWorkingDirectory.getCommitCountBetweenBranches(
+							remoteGitBranch.getSHA(), senderBranchSHA);
+
+					commitCount = Math.max(commitCount, senderCommitCount);
+				}
+			}
 
 			sb.append(commitCount + 1);
 

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/BaseWorkspaceGitRepository.java
@@ -881,11 +881,12 @@ public abstract class BaseWorkspaceGitRepository
 		else {
 			sb.append("git clone --depth ");
 
+			int commitCount = 0;
+
 			LocalGitBranch localGitBranch = getLocalGitBranch();
+
 			RemoteGitBranch remoteGitBranch =
 				gitWorkingDirectory.getUpstreamRemoteGitBranch();
-
-			int commitCount = 0;
 
 			if (remoteGitBranch != null) {
 				commitCount = gitWorkingDirectory.getCommitCountBetweenBranches(

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -4276,6 +4276,30 @@ public class JenkinsResultsParserUtil {
 		return _topLevelJobNames.contains(jobName);
 	}
 
+	public static boolean isUnifiedBuilderSupported(String upstreamBranchName) {
+		if (Objects.equals(upstreamBranchName, "master")) {
+			return true;
+		}
+
+		if (upstreamBranchName == null) {
+			return false;
+		}
+
+		Matcher matcher = _quarterlyrReleaseYearPattern.matcher(
+			upstreamBranchName);
+
+		if (matcher.matches()) {
+			int year = Integer.parseInt(matcher.group(1));
+			int quarter = Integer.parseInt(matcher.group(2));
+
+			if ((year > 2026) || ((year == 2026) && (quarter >= 2))) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	public static boolean isURL(String urlString) {
 		if (isNullOrEmpty(urlString) || !urlString.matches("https?://.+")) {
 			return false;
@@ -7511,6 +7535,8 @@ public class JenkinsResultsParserUtil {
 		"\\$\\{([^\\}]+)\\}");
 	private static final Pattern _poshiFileNamePattern = Pattern.compile(
 		".*\\.(function|macro|path|prose|testcase)");
+	private static final Pattern _quarterlyrReleaseYearPattern =
+		Pattern.compile("release-(\\d{4})\\.q(\\d+).*");
 	private static final Set<String> _redactTokens = new HashSet<>();
 	private static final Pattern _remoteURLAuthorityPattern1 = Pattern.compile(
 		"https://(test-[0-9]+-[0])-aws.liferay.com/");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/JenkinsResultsParserUtil.java
@@ -4285,7 +4285,7 @@ public class JenkinsResultsParserUtil {
 			return false;
 		}
 
-		Matcher matcher = _quarterlyrReleaseYearPattern.matcher(
+		Matcher matcher = _quarterlyReleaseYearPattern.matcher(
 			upstreamBranchName);
 
 		if (matcher.matches()) {
@@ -7535,8 +7535,8 @@ public class JenkinsResultsParserUtil {
 		"\\$\\{([^\\}]+)\\}");
 	private static final Pattern _poshiFileNamePattern = Pattern.compile(
 		".*\\.(function|macro|path|prose|testcase)");
-	private static final Pattern _quarterlyrReleaseYearPattern =
-		Pattern.compile("release-(\\d{4})\\.q(\\d+).*");
+	private static final Pattern _quarterlyReleaseYearPattern = Pattern.compile(
+		"release-(\\d{4})\\.q(\\d+).*");
 	private static final Set<String> _redactTokens = new HashSet<>();
 	private static final Pattern _remoteURLAuthorityPattern1 = Pattern.compile(
 		"https://(test-[0-9]+-[0])-aws.liferay.com/");

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/ServiceBuilderAntTargetTestClass.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/ServiceBuilderAntTargetTestClass.java
@@ -7,6 +7,7 @@ package com.liferay.jenkins.results.parser.test.clazz;
 
 import com.liferay.jenkins.results.parser.DownstreamBuildReport;
 import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
 import com.liferay.jenkins.results.parser.TestClassReport;
 import com.liferay.jenkins.results.parser.test.clazz.group.BatchTestClassGroup;
 
@@ -67,9 +68,19 @@ public class ServiceBuilderAntTargetTestClass extends BaseTestClass {
 
 		super(batchTestClassGroup, testClassFile);
 
-		addTestClassMethod("build-service-counter");
-		addTestClassMethod("build-service-portal");
-		addTestClassMethod("build-service-portlets");
+		PortalGitWorkingDirectory portalGitWorkingDirectory =
+			batchTestClassGroup.getPortalGitWorkingDirectory();
+
+		if (JenkinsResultsParserUtil.isUnifiedBuilderSupported(
+				portalGitWorkingDirectory.getUpstreamBranchName())) {
+
+			addTestClassMethod("build-services");
+		}
+		else {
+			addTestClassMethod("build-service-counter");
+			addTestClassMethod("build-service-portal");
+			addTestClassMethod("build-service-portlets");
+		}
 
 		File testPropertiesBaseDir = getTestPropertiesBaseDir(
 			getTestClassFile());

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesBatchTestClassGroup.java
@@ -95,6 +95,19 @@ public class ServiceBuilderModulesBatchTestClassGroup
 		PortalGitWorkingDirectory portalGitWorkingDirectory =
 			getPortalGitWorkingDirectory();
 
+		File portalImplBuildFile = new File(
+			portalGitWorkingDirectory.getWorkingDirectory(),
+			"portal-impl/build.xml");
+
+		if (JenkinsResultsParserUtil.isUnifiedBuilderSupported(
+				portalGitWorkingDirectory.getUpstreamBranchName())) {
+
+			addTestClass(
+				TestClassFactory.newTestClass(this, portalImplBuildFile));
+
+			return;
+		}
+
 		File portalModulesBaseDir = new File(
 			portalGitWorkingDirectory.getWorkingDirectory(), "modules");
 
@@ -158,10 +171,6 @@ public class ServiceBuilderModulesBatchTestClassGroup
 		}
 
 		if (_buildType != null) {
-			File portalImplBuildFile = new File(
-				portalGitWorkingDirectory.getWorkingDirectory(),
-				"portal-impl/build.xml");
-
 			addTestClass(
 				TestClassFactory.newTestClass(this, portalImplBuildFile));
 		}

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesSegmentTestClassGroup.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/test/clazz/group/ServiceBuilderModulesSegmentTestClassGroup.java
@@ -5,6 +5,9 @@
 
 package com.liferay.jenkins.results.parser.test.clazz.group;
 
+import com.liferay.jenkins.results.parser.JenkinsResultsParserUtil;
+import com.liferay.jenkins.results.parser.PortalGitWorkingDirectory;
+
 import org.json.JSONObject;
 
 /**
@@ -18,6 +21,16 @@ public class ServiceBuilderModulesSegmentTestClassGroup
 		StringBuilder sb = new StringBuilder();
 
 		sb.append(super.getTestCasePropertiesContent());
+
+		PortalGitWorkingDirectory portalGitWorkingDirectory =
+			_serviceBuilderModulesBatchTestClassGroup.
+				getPortalGitWorkingDirectory();
+
+		if (JenkinsResultsParserUtil.isUnifiedBuilderSupported(
+				portalGitWorkingDirectory.getUpstreamBranchName())) {
+
+			return sb.toString();
+		}
 
 		ServiceBuilderModulesBatchTestClassGroup.BuildType buildType =
 			_serviceBuilderModulesBatchTestClassGroup.getBuildType();

--- a/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
+++ b/modules/test/playwright/pages/users-admin-web/EditUserPage.ts
@@ -337,16 +337,17 @@ export class EditUserPage {
 		});
 		this.customField = async (fieldName: string) => {
 			await page
+				.locator(
+					'[id="_com_liferay_users_admin_web_portlet_UsersAdminPortlet_fm"]'
+				)
 				.getByText('Custom Fields', {exact: true})
 				.waitFor({timeout: 15 * 1000});
 
 			const customField = page.getByText(fieldName);
 
-			if (await customField.isVisible()) {
-				return customField;
-			}
+			await expect(customField).toBeVisible();
 
-			throw new Error(`Cannot locate Custom Field ${fieldName}`);
+			return customField;
 		};
 		this.displaySettingsLink = page.getByRole('link', {
 			exact: true,

--- a/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
+++ b/modules/test/playwright/tests/site-cms-site-initializer/main/categorization/categories.spec.ts
@@ -600,3 +600,68 @@ test.describe('Subcategory tests', () => {
 		}
 	);
 });
+
+test(
+	'Content can be saved when all asset subtypes are required in a vocabulary',
+	{tag: '@LPD-83651'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const categoryName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{
+				name: categoryName,
+				vocabularyId,
+			}
+		);
+
+		await contentsPage.goto();
+
+		await contentsPage.createContent('Basic Web Content');
+
+		const title = getRandomString();
+
+		await contentsPage.fillData([{label: 'Title', value: title}]);
+
+		await contentsPage.openSidePanel('Categorization');
+
+		const categoriesAutocomplete = page.getByPlaceholder('Add category');
+
+		await categoriesAutocomplete.fill(categoryName);
+
+		const option = page.getByRole('option', {name: categoryName});
+
+		await option.waitFor();
+		await option.click();
+
+		await contentsPage.saveContent();
+
+		await expect(
+			page.getByRole('link', {exact: true, name: `${title}`})
+		).toBeVisible();
+	}
+);
+
+test(
+	'Folder can be saved when all asset subtypes are required in a vocabulary',
+	{tag: '@LPD-83651'},
+	async ({apiHelpers, contentsPage, page}) => {
+		const categoryName = getRandomString();
+
+		await apiHelpers.headlessAdminTaxonomy.postTaxonomyVocabularyTaxonomyCategory(
+			{
+				name: categoryName,
+				vocabularyId,
+			}
+		);
+
+		await contentsPage.goto();
+
+		const folderName = getRandomString();
+
+		await contentsPage.createFolder(folderName, 'Default');
+
+		await expect(
+			page.getByRole('link', {exact: true, name: `${folderName}`})
+		).toBeVisible();
+	}
+);

--- a/modules/util.gradle
+++ b/modules/util.gradle
@@ -15,7 +15,7 @@ buildscript {
 	apply from: file("build-buildscript.gradle"), to: buildscript
 
 	dependencies {
-		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1791"
+		classpath group: "com.liferay", name: "com.liferay.jenkins.results.parser", version: "1.0.1792"
 	}
 }
 

--- a/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/license/util/DefaultLicenseManagerImpl.java
@@ -8,6 +8,7 @@ package com.liferay.portal.license.util;
 import com.liferay.portal.json.JSONObjectImpl;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.license.LicenseInfo;
+import com.liferay.portal.kernel.license.util.App;
 import com.liferay.portal.kernel.license.util.LicenseManager;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -149,7 +150,7 @@ public class DefaultLicenseManagerImpl implements LicenseManager {
 	}
 
 	@Override
-	public boolean isCMPEnabled() {
+	public boolean isAppEnabled(App app) {
 		return true;
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/license/util/App.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/license/util/App.java
@@ -10,6 +10,6 @@ package com.liferay.portal.kernel.license.util;
  */
 public enum App {
 
-	CMP
+	CMP, DSR
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/license/util/App.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/license/util/App.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.license.util;
+
+/**
+ * @author Tina Tian
+ */
+public enum App {
+
+	CMP
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManager.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManager.java
@@ -50,7 +50,7 @@ public interface LicenseManager {
 
 	public Set<String> getMacAddresses();
 
-	public boolean isCMPEnabled();
+	public boolean isAppEnabled(App app);
 
 	public boolean isFreeTier();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManagerUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/license/util/LicenseManagerUtil.java
@@ -69,8 +69,8 @@ public class LicenseManagerUtil {
 		return _licenseManager.getMacAddresses();
 	}
 
-	public static boolean isCMPEnabled() {
-		return _licenseManager.isCMPEnabled();
+	public static boolean isAppEnabled(App app) {
+		return _licenseManager.isAppEnabled(app);
 	}
 
 	public static boolean isFreeTier() {

--- a/release.properties
+++ b/release.properties
@@ -152,7 +152,7 @@
 ##
 
     release.tool.dir=ext/7.4.x
-    release.tool.sha=d4e99e8725ca78660cbe7c4481dfb8021c5da71a
+    release.tool.sha=58445df1c2d76acdc4b7a14d8f9372c35cd38c55
 
 ##
 ## Sonatype

--- a/test.properties
+++ b/test.properties
@@ -2875,7 +2875,22 @@
     playwright.test.project[playwright-js-tomcat101-*][bpm]=\
         calendar-web.main,\
         dynamic-data-mapping-form-web.main,\
-        object.playwright.projects,\
+        notification-web.main,\
+        object-web.action,\
+        object-web.client-extension,\
+        object-web.entry,\
+        object-web.field,\
+        object-web.folder,\
+        object-web.forms-integration,\
+        object-web.hierarchy,\
+        object-web.layout,\
+        object-web.list-type-definition,\
+        object-web.main,\
+        object-web.relationship,\
+        object-web.salesforce,\
+        object-web.validation,\
+        object-web.view,\
+        object-web.workflow,\
         portal-workflow-kaleo-designer-web.main,\
         portal-workflow-kaleo-forms-web.main,\
         portal-workflow-metrics-web.main,\


### PR DESCRIPTION
## Summary
- Fix `FileNotFoundException` at the end of the upgrade process reporting by running the DL size calculation as a cancellable `FutureTask` with a timeout, instead of an unmanaged `Thread`.
- Add test coverage for `getReportData` when the DL directory is not readable.

Original work by @dmcisneroslf. Replaces #3471 — same content, leading space removed from the commit message (which was causing Source Formatter issues), rebased on master.

## Test plan
- [ ] `ant format-source-current-branch` from `portal-impl`
- [ ] `UpgradeReportTest`