### PR TITLE
LPD-85305 Suppress expected WARN in UpgradeRecorderTest

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/UpgradeRecorderTest.java
@@ -24,6 +24,9 @@ import com.liferay.portal.kernel.upgrade.ReleaseManager;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.version.Version;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.tools.DBUpgrader;
@@ -344,7 +347,24 @@ public class UpgradeRecorderTest {
 
 		unrelatedErrorUpgradeProcess.doUpgrade();
 
-		_stopUpgrade();
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.upgrade.internal.recorder.UpgradeRecorder",
+				LoggerTestUtil.WARN)) {
+
+			_stopUpgrade();
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+			LogEntry logEntry = logEntries.get(0);
+
+			Assert.assertEquals(LoggerTestUtil.WARN, logEntry.getPriority());
+			Assert.assertEquals(
+				"Verify if the errors during the execution are related to " +
+					"the upgrade",
+				logEntry.getMessage());
+		}
 
 		Assert.assertEquals("success", _getResult());
 		Assert.assertEquals("no upgrade", _getType());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85305

**What is being fixed:** `UpgradeRecorderTest.testSuccessResultWithUnrelatedError` injects a fake entry into `UpgradeRecorder._errorMessages` via reflection and then calls `_stopUpgrade()`, which drives `UpgradeRecorder.stop()` to emit the WARN "Verify if the errors during the execution are related to the upgrade". The test itself passes, but that WARN ends up in the log4j XML that `PortalLogAssertorTest.testScanXMLLog` later scans, turning the build UNSTABLE. The WARN is an expected, by-design side effect of the test, not a real upgrade problem.

**How it is being fixed:** Wrap the `_stopUpgrade()` call with a `LogCapture` on the `UpgradeRecorder` logger at WARN level. `LoggerTestUtil.configureLog4JLogger` sets `additive=false` on that logger for the lifetime of the try-with-resources block, so the WARN is captured into the `LogCapture`'s internal list instead of propagating to the root logger's XML appender — the scanner no longer sees it. The WARN path is also verified: the test now asserts exactly one WARN was captured with the expected message text, so if `UpgradeRecorder`'s WARN path is ever broken or its message changes, this test will fail loudly instead of silently regressing.