### PR TITLE
LPD-84025 Implement locked query detection for remaining dialects

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.dao.db.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -17,9 +18,11 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -27,11 +30,14 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -637,6 +643,110 @@ public class DBTest {
 			Assert.assertEquals(
 				dbInspector.normalizeName(INDEX_NAME),
 				indexMetadata.getIndexName());
+		}
+	}
+
+	@Test
+	public void testGetLockedQueries() throws Exception {
+		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L)) {
+
+			try {
+				db.runSQL(
+					"create table testTable (id int primary key, data " +
+						"varchar(50))");
+
+				db.runSQL("insert into testTable (id, data) values (1, '')");
+
+				try (Connection lockingConnection =
+						DataAccess.getConnection()) {
+
+					lockingConnection.setAutoCommit(false);
+
+					FutureTask<Void> futureTask = null;
+
+					try (Statement statement1 =
+							lockingConnection.createStatement()) {
+
+						statement1.executeUpdate(
+							"update testTable set data='locked' where id=1");
+
+						futureTask = new FutureTask<>(
+							() -> {
+								try (Statement statement2 =
+										connection.createStatement()) {
+
+									statement2.executeUpdate(
+										"update testTable set data='waiting' " +
+											"where id=1");
+								}
+
+								return null;
+							});
+
+						Thread thread = new Thread(futureTask);
+
+						thread.setDaemon(true);
+						thread.start();
+
+						boolean locked = false;
+
+						long endTime = System.currentTimeMillis() + 5000;
+
+						while (!locked &&
+							   (System.currentTimeMillis() < endTime)) {
+
+							List<DB.RunningQuery> lockedQueries =
+								db.getLockedQueries(lockingConnection);
+
+							for (DB.RunningQuery lockedQuery : lockedQueries) {
+								String query = lockedQuery.getQuery();
+
+								if ((query != null) &&
+									query.contains("waiting")) {
+
+									locked = true;
+
+									Assert.assertNotNull(lockedQuery.getId());
+									Assert.assertNotNull(
+										lockedQuery.getSchema());
+									Assert.assertTrue(
+										lockedQuery.getDuration() >= 0);
+
+									String actualState = lockedQuery.getState();
+
+									Assert.assertNotNull(actualState);
+									Assert.assertTrue(
+										actualState,
+										StringUtil.containsIgnoreCase(
+											actualState, "LOCK WAIT"));
+
+									break;
+								}
+							}
+
+							if (!locked) {
+								Thread.sleep(200);
+							}
+						}
+
+						Assert.assertTrue(locked);
+					}
+					finally {
+						lockingConnection.rollback();
+
+						if (futureTask != null) {
+							futureTask.get(5, TimeUnit.SECONDS);
+						}
+					}
+				}
+			}
+			finally {
+				db.runSQL("drop table if exists testTable");
+			}
 		}
 	}
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.SyncThrowableThread;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
@@ -36,8 +37,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -666,7 +665,7 @@ public class DBTest {
 
 					lockingConnection.setAutoCommit(false);
 
-					FutureTask<Void> futureTask = null;
+					SyncThrowableThread<Void> syncThrowableThread = null;
 
 					try (Statement statement1 =
 							lockingConnection.createStatement()) {
@@ -674,7 +673,7 @@ public class DBTest {
 						statement1.executeUpdate(
 							"update testTable set data='locked' where id=1");
 
-						futureTask = new FutureTask<>(
+						syncThrowableThread = new SyncThrowableThread<>(
 							() -> {
 								try (Statement statement2 =
 										connection.createStatement()) {
@@ -687,10 +686,8 @@ public class DBTest {
 								return null;
 							});
 
-						Thread thread = new Thread(futureTask);
-
-						thread.setDaemon(true);
-						thread.start();
+						syncThrowableThread.setDaemon(true);
+						syncThrowableThread.start();
 
 						boolean locked = false;
 
@@ -738,8 +735,8 @@ public class DBTest {
 					finally {
 						lockingConnection.rollback();
 
-						if (futureTask != null) {
-							futureTask.get(5, TimeUnit.SECONDS);
+						if (syncThrowableThread != null) {
+							syncThrowableThread.sync();
 						}
 					}
 				}

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -648,7 +648,7 @@ public class DBTest {
 
 	@Test
 	public void testGetLockedQueries() throws Exception {
-		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+		Assume.assumeTrue(db.getDBType() != DBType.HYPERSONIC);
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -722,7 +722,7 @@ public class DBTest {
 									Assert.assertTrue(
 										actualState,
 										StringUtil.containsIgnoreCase(
-											actualState, "LOCK WAIT"));
+											actualState, "lock"));
 
 									break;
 								}
@@ -745,7 +745,7 @@ public class DBTest {
 				}
 			}
 			finally {
-				db.runSQL("drop table if exists testTable");
+				db.runSQL("DROP_TABLE_IF_EXISTS(testTable)");
 			}
 		}
 	}

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -37,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author Alexander Chow
@@ -226,39 +224,8 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
-	public List<RunningQuery> getLockedQueries(Connection connection)
-		throws SQLException {
-
-		List<RunningQuery> lockedQueries = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_LOCKED_QUERIES_SQL)) {
-
-			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
-
-			long threshold = (long)Math.ceil(
-				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String id = String.valueOf(resultSet.getLong("id"));
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
-					String state = resultSet.getString("state");
-
-					lockedQueries.add(
-						new RunningQuery(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueries;
+	public String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
 	}
 
 	@Override
@@ -709,8 +676,6 @@ public class DB2DB extends BaseDB {
 		"act.application_handle where a.appl_status = 'LOCKWAIT' and ",
 		"a.agent_id != mon_get_application_handle() and timestampdiff(2, ",
 		"char(current timestamp - u.uow_start_time)) >= ?");
-
-	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final int _SQL_STRING_SIZE = 4000;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Alexander Chow
@@ -221,6 +223,42 @@ public class DB2DB extends BaseDB {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_LOCKED_QUERIES_SQL)) {
+
+			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
 	}
 
 	@Override
@@ -659,6 +697,20 @@ public class DB2DB extends BaseDB {
 		" double", " integer", " bigint", " varchar(4000)", " clob(2G)",
 		" varchar", " generated always as identity", "commit"
 	};
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select a.agent_id as id, a.db_name as schemaName, timestampdiff(2, ",
+		"char(current timestamp - u.uow_start_time)) as duration, ",
+		"a.appl_status as state, cast(act.stmt_text as varchar(1000)) as ",
+		"query from sysibmadm.applications a join ",
+		"table(sysproc.mon_get_unit_of_work(null, -2)) as u on a.agent_id = ",
+		"u.application_handle left join ",
+		"table(sysproc.mon_get_activity(null, -2)) as act on a.agent_id = ",
+		"act.application_handle where a.appl_status = 'LOCKWAIT' and ",
+		"a.agent_id != mon_get_application_handle() and timestampdiff(2, ",
+		"char(current timestamp - u.uow_start_time)) >= ?");
+
+	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final int _SQL_STRING_SIZE = 4000;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -36,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -198,39 +196,8 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
-	public List<RunningQuery> getLockedQueries(Connection connection)
-		throws SQLException {
-
-		List<RunningQuery> lockedQueries = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_LOCKED_QUERIES_SQL)) {
-
-			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
-
-			long threshold = (long)Math.ceil(
-				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String id = String.valueOf(resultSet.getLong("id"));
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
-					String state = resultSet.getString("state");
-
-					lockedQueries.add(
-						new RunningQuery(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueries;
+	public String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
 	}
 
 	@Override
@@ -581,8 +548,6 @@ public class OracleDB extends BaseDB {
 		"where s.status = 'ACTIVE' and s.type = 'USER' and s.audsid != ",
 		"sys_context('USERENV', 'SESSIONID') and (s.event like 'enq:%' or ",
 		"s.event like '%library cache%') and s.last_call_et >= ?");
-
-	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _ORACLE = {
 		"--", "1", "0",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -193,6 +195,42 @@ public class OracleDB extends BaseDB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, true);
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_LOCKED_QUERIES_SQL)) {
+
+			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
 	}
 
 	@Override
@@ -535,6 +573,16 @@ public class OracleDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select s.sid as id, s.schemaname as schemaName, s.last_call_et as ",
+		"duration, s.event as state, cast(q.sql_fulltext as varchar2(1000)) ",
+		"as query from v$session s left join v$sql q on s.sql_id = q.sql_id ",
+		"where s.status = 'ACTIVE' and s.type = 'USER' and s.audsid != ",
+		"sys_context('USERENV', 'SESSIONID') and (s.event like 'enq:%' or ",
+		"s.event like '%library cache%') and s.last_call_et >= ?");
+
+	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _ORACLE = {
 		"--", "1", "0",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -587,6 +587,8 @@ public class SQLServerDB extends BaseDB {
 				defaultConstraintName));
 	}
 
+	// SQL Server reserves session_id < 50 for internal sessions.
+
 	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
 		"select r.session_id as id, db_name(r.database_id) as schemaName, ",
 		"r.total_elapsed_time / 1000 as duration, 'LOCK WAIT: ' + ",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -30,6 +31,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -163,6 +165,42 @@ public class SQLServerDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_LOCKED_QUERIES_SQL)) {
+
+			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
 	}
 
 	@Override
@@ -581,6 +619,16 @@ public class SQLServerDB extends BaseDB {
 				"alter table ", tableName, " drop constraint ",
 				defaultConstraintName));
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select r.session_id as id, db_name(r.database_id) as schemaName, ",
+		"r.total_elapsed_time / 1000 as duration, 'LOCK WAIT: ' + ",
+		"r.wait_type as state, t.text as query from sys.dm_exec_requests r ",
+		"cross apply sys.dm_exec_sql_text(r.sql_handle) t where ",
+		"r.session_id <> @@spid and r.session_id >= 50 and r.wait_type ",
+		"like 'LCK[_]%' and r.total_elapsed_time / 1000 >= ?");
+
+	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _SQL_SERVER = {
 		"--", "1", "0", "'19700101'", "GetDate()", " image", " image",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -31,7 +30,6 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -168,39 +166,8 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
-	public List<RunningQuery> getLockedQueries(Connection connection)
-		throws SQLException {
-
-		List<RunningQuery> lockedQueries = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_LOCKED_QUERIES_SQL)) {
-
-			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
-
-			long threshold = (long)Math.ceil(
-				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String id = String.valueOf(resultSet.getLong("id"));
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
-					String state = resultSet.getString("state");
-
-					lockedQueries.add(
-						new RunningQuery(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueries;
+	public String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
 	}
 
 	@Override
@@ -627,8 +594,6 @@ public class SQLServerDB extends BaseDB {
 		"cross apply sys.dm_exec_sql_text(r.sql_handle) t where ",
 		"r.session_id <> @@spid and r.session_id >= 50 and r.wait_type ",
 		"like 'LCK[_]%' and r.total_elapsed_time / 1000 >= ?");
-
-	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _SQL_SERVER = {
 		"--", "1", "0", "'19700101'", "GetDate()", " image", " image",

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,6 +29,7 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -148,6 +149,42 @@ public class MySQLDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_LOCKED_QUERIES_SQL)) {
+
+			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
 	}
 
 	@Override
@@ -314,6 +351,17 @@ public class MySQLDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select p.id as id, p.db as schemaName, p.time as duration, ",
+		"coalesce(t.trx_state, p.state) as state, p.info as query from ",
+		"information_schema.processlist p left join ",
+		"information_schema.innodb_trx t on p.id = t.trx_mysql_thread_id ",
+		"where p.command != 'Sleep' and p.info is not null and p.id != ",
+		"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
+		"'%lock%') and p.time >= ?)");
+
+	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _MYSQL = {
 		"##", "1", "0", "'1970-01-01'", "now()", " longblob", " longblob",

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,7 +29,6 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -152,39 +151,8 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
-	public List<RunningQuery> getLockedQueries(Connection connection)
-		throws SQLException {
-
-		List<RunningQuery> lockedQueries = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_LOCKED_QUERIES_SQL)) {
-
-			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
-
-			long threshold = (long)Math.ceil(
-				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String id = String.valueOf(resultSet.getLong("id"));
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
-					String state = resultSet.getString("state");
-
-					lockedQueries.add(
-						new RunningQuery(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueries;
+	public String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
 	}
 
 	@Override
@@ -360,8 +328,6 @@ public class MySQLDB extends BaseDB {
 		"where p.command != 'Sleep' and p.info is not null and p.id != ",
 		"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
 		"'%lock%') and p.time >= ?)");
-
-	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _MYSQL = {
 		"##", "1", "0", "'1970-01-01'", "now()", " longblob", " longblob",

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -12,6 +12,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -127,6 +129,42 @@ public class PostgreSQLDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_LOCKED_QUERIES_SQL)) {
+
+			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
 	}
 
 	@Override
@@ -507,6 +545,16 @@ public class PostgreSQLDB extends BaseDB {
 
 		runSQL(connection, sb.toString());
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select pid as id, datname as schemaName, cast(extract(epoch from ",
+		"(now() - query_start)) as bigint) as duration, wait_event_type || ",
+		"': ' || coalesce(wait_event, '-') as state, query from ",
+		"pg_stat_activity where state != 'idle' and pid != pg_backend_pid() ",
+		"and wait_event_type = 'Lock' and extract(epoch from (now() - ",
+		"query_start)) >= ?");
+
+	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _POSTGRESQL = {
 		"--", "true", "false", "'01/01/1970'", "current_timestamp", " oid",

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -12,7 +12,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -28,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -132,39 +130,8 @@ public class PostgreSQLDB extends BaseDB {
 	}
 
 	@Override
-	public List<RunningQuery> getLockedQueries(Connection connection)
-		throws SQLException {
-
-		List<RunningQuery> lockedQueries = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_LOCKED_QUERIES_SQL)) {
-
-			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
-
-			long threshold = (long)Math.ceil(
-				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String id = String.valueOf(resultSet.getLong("id"));
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
-					String state = resultSet.getString("state");
-
-					lockedQueries.add(
-						new RunningQuery(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueries;
+	public String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
 	}
 
 	@Override
@@ -553,8 +520,6 @@ public class PostgreSQLDB extends BaseDB {
 		"pg_stat_activity where state != 'idle' and pid != pg_backend_pid() ",
 		"and wait_event_type = 'Lock' and extract(epoch from (now() - ",
 		"query_start)) >= ?");
-
-	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _POSTGRESQL = {
 		"--", "true", "false", "'01/01/1970'", "current_timestamp", " oid",

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -205,6 +205,15 @@
     upgrade.log.context.enabled=false
 
     #
+    # Set the threshold in milliseconds before a query waiting on resources is
+    # flagged as "Locked". When this threshold is exceeded, a WARNING message is
+    # printed to the upgrade logs.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_LOCK_PERIOD_THRESHOLD
+    #
+    upgrade.query.monitor.lock.threshold=300000
+
+    #
     # Specify the number of seconds that the upgrade report generation will wait
     # for calculating the document library storage size before timing out.
     # Specify 0 to disable the document library storage size calculation.

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -15,6 +15,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -98,6 +99,12 @@ public interface DB {
 	public ResultSet getIndexResultSet(
 			Connection connection, String tableName, boolean onlyUnique)
 		throws SQLException;
+
+	public default List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
+	}
 
 	public int getMajorVersion();
 
@@ -239,5 +246,46 @@ public interface DB {
 			Connection connection, String tableName,
 			String[] primaryKeyColumnNames)
 		throws Exception;
+
+	public static class RunningQuery {
+
+		public RunningQuery(
+			long duration, String id, String query, String schema,
+			String state) {
+
+			_duration = duration;
+			_id = id;
+			_query = query;
+			_schema = schema;
+			_state = state;
+		}
+
+		public long getDuration() {
+			return _duration;
+		}
+
+		public String getId() {
+			return _id;
+		}
+
+		public String getQuery() {
+			return _query;
+		}
+
+		public String getSchema() {
+			return _schema;
+		}
+
+		public String getState() {
+			return _state;
+		}
+
+		private final long _duration;
+		private final String _id;
+		private final String _query;
+		private final String _schema;
+		private final String _state;
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -8,16 +8,21 @@ package com.liferay.portal.kernel.dao.db;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.IOException;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import javax.naming.NamingException;
 
@@ -28,6 +33,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DB {
+
+	public static final int MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	public static final int SQL_SIZE_NONE = -1;
 
@@ -103,7 +110,46 @@ public interface DB {
 	public default List<RunningQuery> getLockedQueries(Connection connection)
 		throws SQLException {
 
-		return Collections.emptyList();
+		String sql = getLockedQueriesSQL();
+
+		if (Validator.isNull(sql)) {
+			return Collections.emptyList();
+		}
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
+	}
+
+	public default String getLockedQueriesSQL() {
+		return null;
 	}
 
 	public int getMajorVersion();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2721,6 +2721,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_CONTEXT_ENABLED =
 		"upgrade.log.context.enabled";
 
+	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		"upgrade.query.monitor.lock.threshold";
+
 	public static final String UPGRADE_REPORT_DIR = "upgrade.report.dir";
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2383,6 +2383,11 @@ public class PropsValues {
 		GetterUtil.getBoolean(
 			PropsUtil.get(PropsKeys.UPGRADE_LOG_CONTEXT_ENABLED));
 
+	public static final long UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),
+			300000L);
+
 	public static final String UPGRADE_REPORT_DIR = GetterUtil.getString(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIR));
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84025

**Stacks on #3488** (LPD-84024 + LPD-84025 MySQL). Until that PR merges, the diff here will include those earlier commits.

**What is being fixed:** The initial `getLockedQueries` implementation on #3488 only covered MySQL. Liferay supports additional databases that need the same visibility into lock-waits during upgrades.

**How it is being fixed:** Added `getLockedQueries(Connection)` overrides for PostgreSQL (`portal-impl`), Oracle, SQL Server, and DB2 (DXP `portal-dao-db` module). Each dialect uses its vendor-specific system views with the same pattern as MySQL: a parameterized duration threshold pushed into SQL, a 10s query timeout, and results mapped to the shared `RunningQuery` record.

- **PostgreSQL:** `pg_stat_activity` filtered by `wait_event_type = 'Lock'`.
- **Oracle:** `v\$session` joined to `v\$sql`, filtered by `event` matching `enq:%` or `%library cache%`.
- **SQL Server:** `sys.dm_exec_requests` + `sys.dm_exec_sql_text`, filtered by `wait_type LIKE 'LCK[_]%'`; state prefixed with `LOCK WAIT:` for consistency.
- **DB2:** `SYSIBMADM.APPLICATIONS` joined to `MON_GET_UNIT_OF_WORK` / `MON_GET_ACTIVITY`, filtered by `APPL_STATUS = 'LOCKWAIT'`.
- **MariaDB:** Inherits the MySQL override via `MariaDBDB extends MySQLDB`.
- **Hypersonic:** Keeps the default empty-list implementation and is skipped in the test.

The integration test `testGetLockedQueries` no longer assumes MySQL; it now runs against every dialect except Hypersonic. The lock-wait assertion was relaxed from the MySQL-specific `LOCK WAIT` substring to a dialect-agnostic case-insensitive `lock` match, and the table cleanup uses `DROP_TABLE_IF_EXISTS(...)` for cross-dialect portability.