### PR TITLE
LPD-84144 Only use useBulkCopyForBatchInsert for SQL Server driver >= 12.4.0

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryUtil.java
@@ -494,8 +494,7 @@ public class DataSourceFactoryUtil {
 			catch (SQLException sqlException) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Could not determine SQL Server driver version to " +
-							"apply useBulkCopyForBatchInsert",
+						"Unable to determine SQL Server driver version",
 						sqlException);
 				}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryUtil.java
@@ -42,6 +42,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 
@@ -472,6 +473,35 @@ public class DataSourceFactoryUtil {
 		}
 
 		if (url.startsWith("jdbc:sqlserver://")) {
+			try {
+				Driver driver = DriverManager.getDriver(url);
+
+				int majorVersion = driver.getMajorVersion();
+				int minorVersion = driver.getMinorVersion();
+
+				if ((majorVersion < 12) ||
+					((majorVersion == 12) && (minorVersion < 4))) {
+
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Update SQL Server driver version to >= 12.4.0 " +
+								"to support useBulkCopyForBatchInsert");
+					}
+
+					return url;
+				}
+			}
+			catch (SQLException sqlException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Could not determine SQL Server driver version to " +
+							"apply useBulkCopyForBatchInsert",
+						sqlException);
+				}
+
+				return url;
+			}
+
 			return _rewriteJDBCURL(
 				HashMapBuilder.put(
 					"useBulkCopyForBatchInsert", "true"

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
@@ -22,6 +22,9 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 
 import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.SQLException;
 
 import java.util.Properties;
 
@@ -38,6 +41,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
 /**
  * @author Tina Tian
  * @author Eric Yan
@@ -52,6 +58,10 @@ public class DataSourceFactoryTest {
 
 	@After
 	public void tearDown() throws Exception {
+		if (_path == null) {
+			return;
+		}
+
 		Files.walkFileTree(
 			_path,
 			new SimpleFileVisitor<Path>() {
@@ -180,7 +190,51 @@ public class DataSourceFactoryTest {
 			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
 				"useBulkCopyForBatchInsert=true",
 			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3"));
+				"jdbc:sqlserver://localhost;databaseName=lportal3", 12, 4));
+
+		Assert.assertEquals(
+			"jdbc:sqlserver://localhost;databaseName=lportal3",
+			_rewriteJDBCURL(
+				"jdbc:sqlserver://localhost;databaseName=lportal3", 11, 4));
+
+		Assert.assertEquals(
+			"jdbc:sqlserver://localhost;databaseName=lportal3",
+			_rewriteJDBCURL(
+				"jdbc:sqlserver://localhost;databaseName=lportal3", 12, 3));
+
+		Assert.assertEquals(
+			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
+				"useBulkCopyForBatchInsert=true",
+			_rewriteJDBCURL(
+				"jdbc:sqlserver://localhost;databaseName=lportal3", 12, 5));
+
+		Assert.assertEquals(
+			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
+				"useBulkCopyForBatchInsert=true",
+			_rewriteJDBCURL(
+				"jdbc:sqlserver://localhost;databaseName=lportal3", 13, 0));
+	}
+
+	@Test
+	public void testRewriteJDBCURLForSQLServerWithUnregisteredDriver()
+		throws Exception {
+
+		SQLException sqlException = new SQLException("No suitable driver");
+
+		try (MockedStatic<DriverManager> driverManagerMockedStatic =
+				Mockito.mockStatic(DriverManager.class)) {
+
+			driverManagerMockedStatic.when(
+				() -> DriverManager.getDriver(Mockito.anyString())
+			).thenThrow(
+				sqlException
+			);
+
+			Assert.assertEquals(
+				"jdbc:sqlserver://localhost;databaseName=lportal3",
+				_rewriteJDBCURL(
+					"jdbc:sqlserver://localhost;databaseName=lportal3"));
+		}
 	}
 
 	@Test
@@ -205,11 +259,23 @@ public class DataSourceFactoryTest {
 
 		String rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
 			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"customParam=customValue");
+				"customParam=customValue",
+			12, 4);
 
 		Assert.assertTrue(
 			rewrittenSQLServerJDBCURL.contains("customParam=customValue"));
 		Assert.assertTrue(
+			rewrittenSQLServerJDBCURL.contains(
+				"useBulkCopyForBatchInsert=true"));
+
+		rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
+			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
+				"customParam=customValue",
+			11, 4);
+
+		Assert.assertTrue(
+			rewrittenSQLServerJDBCURL.contains("customParam=customValue"));
+		Assert.assertFalse(
 			rewrittenSQLServerJDBCURL.contains(
 				"useBulkCopyForBatchInsert=true"));
 	}
@@ -239,7 +305,16 @@ public class DataSourceFactoryTest {
 				"useBulkCopyForBatchInsert=false",
 			_rewriteJDBCURL(
 				"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-					"useBulkCopyForBatchInsert=false"));
+					"useBulkCopyForBatchInsert=false",
+				12, 4));
+
+		Assert.assertEquals(
+			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
+				"useBulkCopyForBatchInsert=false",
+			_rewriteJDBCURL(
+				"jdbc:sqlserver://localhost;databaseName=lportal3;" +
+					"useBulkCopyForBatchInsert=false",
+				11, 4));
 	}
 
 	@Test
@@ -260,10 +335,20 @@ public class DataSourceFactoryTest {
 			rewrittenPostgreSQLJDBCURL.contains("reWriteBatchedInserts=true"));
 
 		String rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;malformedParam");
+			"jdbc:sqlserver://localhost;databaseName=lportal3;malformedParam",
+			12, 4);
 
 		Assert.assertTrue(rewrittenSQLServerJDBCURL.contains("malformedParam"));
 		Assert.assertTrue(
+			rewrittenSQLServerJDBCURL.contains(
+				"useBulkCopyForBatchInsert=true"));
+
+		rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
+			"jdbc:sqlserver://localhost;databaseName=lportal3;malformedParam",
+			11, 4);
+
+		Assert.assertTrue(rewrittenSQLServerJDBCURL.contains("malformedParam"));
+		Assert.assertFalse(
 			rewrittenSQLServerJDBCURL.contains(
 				"useBulkCopyForBatchInsert=true"));
 	}
@@ -272,6 +357,37 @@ public class DataSourceFactoryTest {
 		return ReflectionTestUtil.invoke(
 			DataSourceFactoryUtil.class, "_rewriteJDBCURL",
 			new Class<?>[] {String.class}, jdbcURL);
+	}
+
+	private String _rewriteJDBCURL(
+			String jdbcURL, int majorVersion, int minorVersion)
+		throws Exception {
+
+		try (MockedStatic<DriverManager> driverManagerMockedStatic =
+				Mockito.mockStatic(DriverManager.class)) {
+
+			Driver mockDriver = Mockito.mock(Driver.class);
+
+			driverManagerMockedStatic.when(
+				() -> DriverManager.getDriver(Mockito.anyString())
+			).thenReturn(
+				mockDriver
+			);
+
+			Mockito.when(
+				mockDriver.getMajorVersion()
+			).thenReturn(
+				majorVersion
+			);
+
+			Mockito.when(
+				mockDriver.getMinorVersion()
+			).thenReturn(
+				minorVersion
+			);
+
+			return _rewriteJDBCURL(jdbcURL);
+		}
 	}
 
 	private Path _path;

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
@@ -3,23 +3,23 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.dao.jdbc;
+package com.liferay.portal.kernel.dao.jdbc;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.jdbc.DataSourceFactoryUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
-import com.liferay.portal.test.rule.LiferayUnitTestRule;
-import com.liferay.portal.util.FastDateFormatFactoryImpl;
-import com.liferay.portal.util.FileImpl;
 
-import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import java.sql.Connection;
 
@@ -36,8 +36,6 @@ import javax.sql.DataSource;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -46,29 +44,39 @@ import org.junit.Test;
  */
 public class DataSourceFactoryTest {
 
-	@ClassRule
-	@Rule
-	public static final LiferayUnitTestRule liferayUnitTestRule =
-		LiferayUnitTestRule.INSTANCE;
-
 	@Before
 	public void setUp() throws Exception {
-		FastDateFormatFactoryUtil fastDateFormatFactoryUtil =
-			new FastDateFormatFactoryUtil();
-
-		fastDateFormatFactoryUtil.setFastDateFormatFactory(
-			new FastDateFormatFactoryImpl());
-
-		FileUtil fileUtil = new FileUtil();
-
-		fileUtil.setFile(new FileImpl());
-
-		_tempDir = FileUtil.createTempFolder();
+		_path = Files.createTempDirectory(
+			DataSourceFactoryTest.class.getName());
 	}
 
 	@After
-	public void tearDown() {
-		FileUtil.deltree(_tempDir);
+	public void tearDown() throws Exception {
+		Files.walkFileTree(
+			_path,
+			new SimpleFileVisitor<Path>() {
+
+				@Override
+				public FileVisitResult postVisitDirectory(
+						Path path, IOException ioException)
+					throws IOException {
+
+					Files.delete(path);
+
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+						Path path, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Files.delete(path);
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
 	}
 
 	@Test
@@ -78,7 +86,7 @@ public class DataSourceFactoryTest {
 
 		DataSource dataSource1 = DataSourceFactoryUtil.initDataSource(
 			"org.hsqldb.jdbc.JDBCDriver",
-			"jdbc:hsqldb:" + _tempDir.getAbsolutePath() + "/lportal;", "sa",
+			"jdbc:hsqldb:" + _path.toAbsolutePath() + "/lportal;", "sa",
 			StringPool.BLANK, StringPool.BLANK);
 
 		NamingManager.setInitialContextFactoryBuilder(
@@ -266,6 +274,6 @@ public class DataSourceFactoryTest {
 			new Class<?>[] {String.class}, jdbcURL);
 	}
 
-	private File _tempDir;
+	private Path _path;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -10,6 +10,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 
@@ -166,48 +167,36 @@ public class DataSourceFactoryTest {
 
 	@Test
 	public void testRewriteJDBCURL() throws Exception {
-		Assert.assertEquals(
-			StringBundler.concat(
-				"jdbc:mysql://localhost/lportal1?cachePrepStmts=",
-				"true&characterEncoding=UTF-8&dontTrackOpenResources=true",
-				"&holdResultsOpenOverStatementClose=true&prepStmtCacheSize=",
-				"1000&prepStmtCacheSqlLimit=2048&rewriteBatchedStatements=",
-				"true&serverTimezone=GMT&useFastDateParsing=false",
-				"&useLocalSessionState=true&useLocalTransactionState=true",
-				"&useUnicode=true"),
-			_rewriteJDBCURL("jdbc:mysql://localhost/lportal1"));
+		_assertRewrittenJDBCURL(
+			_MYSQL_JDBC_URL, _MYSQL_JDBC_URL + "?" + _MYSQL_DEFAULT_PARAMETERS);
 
-		Assert.assertEquals(
-			"jdbc:postgresql://localhost/lportal2?reWriteBatchedInserts=true",
-			_rewriteJDBCURL("jdbc:postgresql://localhost/lportal2"));
+		_assertRewrittenJDBCURL(
+			_POSTGRESQL_JDBC_URL,
+			_POSTGRESQL_JDBC_URL + "?" + _POSTGRESQL_DEFAULT_PARAMETERS);
 
-		Assert.assertEquals(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"useBulkCopyForBatchInsert=true",
-			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3", 12, 4));
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL,
+			_SQLSERVER_JDBC_URL + ";" + _SQLSERVER_DEFAULT_PARAMETERS, 12, 4);
+	}
 
-		Assert.assertEquals(
-			"jdbc:sqlserver://localhost;databaseName=lportal3",
-			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3", 11, 4));
+	@Test
+	public void testRewriteJDBCURLForSQLServerWithDriverVersion()
+		throws Exception {
 
-		Assert.assertEquals(
-			"jdbc:sqlserver://localhost;databaseName=lportal3",
-			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3", 12, 3));
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL, _SQLSERVER_JDBC_URL, 11, 4);
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL, _SQLSERVER_JDBC_URL, 12, 3);
 
-		Assert.assertEquals(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"useBulkCopyForBatchInsert=true",
-			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3", 12, 5));
+		String sqlServerJDBCURLWithBulkCopy =
+			_SQLSERVER_JDBC_URL + ";" + _SQLSERVER_DEFAULT_PARAMETERS;
 
-		Assert.assertEquals(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"useBulkCopyForBatchInsert=true",
-			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3", 13, 0));
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL, sqlServerJDBCURLWithBulkCopy, 12, 4);
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL, sqlServerJDBCURLWithBulkCopy, 12, 5);
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL, sqlServerJDBCURLWithBulkCopy, 13, 0);
 	}
 
 	@Test
@@ -226,126 +215,93 @@ public class DataSourceFactoryTest {
 			);
 
 			Assert.assertEquals(
-				"jdbc:sqlserver://localhost;databaseName=lportal3",
-				_rewriteJDBCURL(
-					"jdbc:sqlserver://localhost;databaseName=lportal3"));
+				_SQLSERVER_JDBC_URL, _rewriteJDBCURL(_SQLSERVER_JDBC_URL));
 		}
 	}
 
 	@Test
 	public void testRewriteJDBCURLWithCustomParameters() throws Exception {
-		String rewrittenMySQLJDBCURL = _rewriteJDBCURL(
-			"jdbc:mysql://localhost/lportal1?customParam=customValue");
+		String userParameter = "userParameter=userValue";
 
-		Assert.assertTrue(
-			rewrittenMySQLJDBCURL.contains("cachePrepStmts=true"));
-		Assert.assertTrue(
-			rewrittenMySQLJDBCURL.contains("characterEncoding=UTF-8"));
-		Assert.assertTrue(
-			rewrittenMySQLJDBCURL.contains("customParam=customValue"));
+		_assertRewrittenJDBCURL(
+			_MYSQL_JDBC_URL + "?" + userParameter,
+			StringBundler.concat(
+				_MYSQL_JDBC_URL, "?", _MYSQL_DEFAULT_PARAMETERS, "&",
+				userParameter));
 
-		String rewrittenPostgreSQLJDBCURL = _rewriteJDBCURL(
-			"jdbc:postgresql://localhost/lportal2?customParam=customValue");
+		_assertRewrittenJDBCURL(
+			_POSTGRESQL_JDBC_URL + "?" + userParameter,
+			StringBundler.concat(
+				_POSTGRESQL_JDBC_URL, "?", _POSTGRESQL_DEFAULT_PARAMETERS, "&",
+				userParameter));
 
-		Assert.assertTrue(
-			rewrittenPostgreSQLJDBCURL.contains("customParam=customValue"));
-		Assert.assertTrue(
-			rewrittenPostgreSQLJDBCURL.contains("reWriteBatchedInserts=true"));
-
-		String rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"customParam=customValue",
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL + ";" + userParameter,
+			StringBundler.concat(
+				_SQLSERVER_JDBC_URL, ";", _SQLSERVER_DEFAULT_PARAMETERS, ";",
+				userParameter),
 			12, 4);
-
-		Assert.assertTrue(
-			rewrittenSQLServerJDBCURL.contains("customParam=customValue"));
-		Assert.assertTrue(
-			rewrittenSQLServerJDBCURL.contains(
-				"useBulkCopyForBatchInsert=true"));
-
-		rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"customParam=customValue",
-			11, 4);
-
-		Assert.assertTrue(
-			rewrittenSQLServerJDBCURL.contains("customParam=customValue"));
-		Assert.assertFalse(
-			rewrittenSQLServerJDBCURL.contains(
-				"useBulkCopyForBatchInsert=true"));
 	}
 
 	@Test
 	public void testRewriteJDBCURLWithExistingDefaultParameters()
 		throws Exception {
 
-		String rewrittenMySQLJDBCURL = _rewriteJDBCURL(
-			"jdbc:mysql://localhost/lportal1?cachePrepStmts=false");
+		String expectedMySQLParameters = StringUtil.removeSubstring(
+			_MYSQL_DEFAULT_PARAMETERS, "cachePrepStmts=true&");
+		String mysqlJDBCURL = _MYSQL_JDBC_URL + "?cachePrepStmts=false";
 
-		Assert.assertTrue(
-			rewrittenMySQLJDBCURL.contains("cachePrepStmts=false"));
-		Assert.assertFalse(
-			rewrittenMySQLJDBCURL.contains("cachePrepStmts=true"));
-		Assert.assertTrue(
-			rewrittenMySQLJDBCURL.contains("characterEncoding=UTF-8"));
+		_assertRewrittenJDBCURL(
+			mysqlJDBCURL, mysqlJDBCURL + "&" + expectedMySQLParameters);
 
-		Assert.assertEquals(
-			"jdbc:postgresql://localhost/lportal2?reWriteBatchedInserts=false",
-			_rewriteJDBCURL(
-				"jdbc:postgresql://localhost/lportal2?reWriteBatchedInserts=" +
-					"false"));
+		String postgresqlJDBCURL =
+			_POSTGRESQL_JDBC_URL + "?reWriteBatchedInserts=false";
 
-		Assert.assertEquals(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"useBulkCopyForBatchInsert=false",
-			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-					"useBulkCopyForBatchInsert=false",
-				12, 4));
+		_assertRewrittenJDBCURL(postgresqlJDBCURL, postgresqlJDBCURL);
 
-		Assert.assertEquals(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-				"useBulkCopyForBatchInsert=false",
-			_rewriteJDBCURL(
-				"jdbc:sqlserver://localhost;databaseName=lportal3;" +
-					"useBulkCopyForBatchInsert=false",
-				11, 4));
+		String sqlserverJDBCURL =
+			_SQLSERVER_JDBC_URL + ";useBulkCopyForBatchInsert=false";
+
+		_assertRewrittenJDBCURL(sqlserverJDBCURL, sqlserverJDBCURL, 12, 4);
 	}
 
 	@Test
 	public void testRewriteJDBCURLWithMalformedParameters() throws Exception {
-		String rewrittenMySQLJDBCURL = _rewriteJDBCURL(
-			"jdbc:mysql://localhost/lportal1?malformedParam");
+		String valuelessParameter = "valuelessParameter";
 
-		Assert.assertTrue(
-			rewrittenMySQLJDBCURL.contains("cachePrepStmts=true"));
-		Assert.assertTrue(rewrittenMySQLJDBCURL.contains("malformedParam"));
+		_assertRewrittenJDBCURL(
+			_MYSQL_JDBC_URL + "?" + valuelessParameter,
+			StringBundler.concat(
+				_MYSQL_JDBC_URL, "?", _MYSQL_DEFAULT_PARAMETERS, "&",
+				valuelessParameter));
 
-		String rewrittenPostgreSQLJDBCURL = _rewriteJDBCURL(
-			"jdbc:postgresql://localhost/lportal2?malformedParam");
+		_assertRewrittenJDBCURL(
+			_POSTGRESQL_JDBC_URL + "?" + valuelessParameter,
+			StringBundler.concat(
+				_POSTGRESQL_JDBC_URL, "?", _POSTGRESQL_DEFAULT_PARAMETERS, "&",
+				valuelessParameter));
 
-		Assert.assertTrue(
-			rewrittenPostgreSQLJDBCURL.contains("malformedParam"));
-		Assert.assertTrue(
-			rewrittenPostgreSQLJDBCURL.contains("reWriteBatchedInserts=true"));
-
-		String rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;malformedParam",
+		_assertRewrittenJDBCURL(
+			_SQLSERVER_JDBC_URL + ";" + valuelessParameter,
+			StringBundler.concat(
+				_SQLSERVER_JDBC_URL, ";", _SQLSERVER_DEFAULT_PARAMETERS, ";",
+				valuelessParameter),
 			12, 4);
+	}
 
-		Assert.assertTrue(rewrittenSQLServerJDBCURL.contains("malformedParam"));
-		Assert.assertTrue(
-			rewrittenSQLServerJDBCURL.contains(
-				"useBulkCopyForBatchInsert=true"));
+	private void _assertRewrittenJDBCURL(String jdbcURL, String expectedURL)
+		throws Exception {
 
-		rewrittenSQLServerJDBCURL = _rewriteJDBCURL(
-			"jdbc:sqlserver://localhost;databaseName=lportal3;malformedParam",
-			11, 4);
+		Assert.assertEquals(expectedURL, _rewriteJDBCURL(jdbcURL));
+	}
 
-		Assert.assertTrue(rewrittenSQLServerJDBCURL.contains("malformedParam"));
-		Assert.assertFalse(
-			rewrittenSQLServerJDBCURL.contains(
-				"useBulkCopyForBatchInsert=true"));
+	private void _assertRewrittenJDBCURL(
+			String jdbcURL, String expectedURL, int majorVersion,
+			int minorVersion)
+		throws Exception {
+
+		Assert.assertEquals(
+			expectedURL, _rewriteJDBCURL(jdbcURL, majorVersion, minorVersion));
 	}
 
 	private String _rewriteJDBCURL(String jdbcURL) throws Exception {
@@ -384,6 +340,31 @@ public class DataSourceFactoryTest {
 			return _rewriteJDBCURL(jdbcURL);
 		}
 	}
+
+	private static final String _MYSQL_DEFAULT_PARAMETERS =
+		StringBundler.concat(
+			"cachePrepStmts=true&characterEncoding=UTF-8&",
+			"dontTrackOpenResources=true&",
+			"holdResultsOpenOverStatementClose=true&",
+			"prepStmtCacheSize=1000&prepStmtCacheSqlLimit=2048&",
+			"rewriteBatchedStatements=true&serverTimezone=GMT&",
+			"useFastDateParsing=false&useLocalSessionState=true&",
+			"useLocalTransactionState=true&useUnicode=true");
+
+	private static final String _MYSQL_JDBC_URL =
+		"jdbc:mysql://localhost/lportal1";
+
+	private static final String _POSTGRESQL_DEFAULT_PARAMETERS =
+		"reWriteBatchedInserts=true";
+
+	private static final String _POSTGRESQL_JDBC_URL =
+		"jdbc:postgresql://localhost/lportal2";
+
+	private static final String _SQLSERVER_DEFAULT_PARAMETERS =
+		"useBulkCopyForBatchInsert=true";
+
+	private static final String _SQLSERVER_JDBC_URL =
+		"jdbc:sqlserver://localhost;databaseName=lportal3";
 
 	private Path _path;
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
@@ -91,9 +91,6 @@ public class DataSourceFactoryTest {
 
 	@Test
 	public void testDestroyDataSource() throws Exception {
-
-		// Destroy JDNI data source
-
 		DataSource dataSource1 = DataSourceFactoryUtil.initDataSource(
 			"org.hsqldb.jdbc.JDBCDriver",
 			"jdbc:hsqldb:" + _path.toAbsolutePath() + "/lportal;", "sa",
@@ -123,8 +120,6 @@ public class DataSourceFactoryTest {
 			Assert.assertFalse(connection.isClosed());
 		}
 
-		// Destroy other data source
-
 		DataSourceFactoryUtil.destroyDataSource(dataSource1);
 
 		try (Connection connection = dataSource1.getConnection()) {
@@ -139,7 +134,7 @@ public class DataSourceFactoryTest {
 	}
 
 	@Test
-	public void testJNDIDataSourceFailure() throws Exception {
+	public void testInitDataSource() throws Exception {
 		PropsUtil.set(
 			PropsKeys.JNDI_ENVIRONMENT + Context.INITIAL_CONTEXT_FACTORY,
 			"org.apache.naming.java.javaURLContextFactory");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84144

Skips useBulkCopyForBatchInsert rewrite for SQL Server drivers older than 12.4.0, with warnings to guide the user. Tests refactored around a single `_assertRewrittenJDBCURL(input, expected)` helper, per-vendor URL / default-parameter constants, and fixture parameters (`userParameter`, `valuelessParameter`) named to sort last so expected URLs compose as `base + defaults + extra` across every vendor without `String.replace` surgery.

Incorporates review feedback from brianchandotcom/liferay-portal#173389, brianchandotcom/liferay-portal#173406, and the overlay PR marianoalvarosaiz/liferay-portal#1483, plus Checkstyle / source-formatter fixes (`JavaMultiPlusConcatCheck`, `OperatorOperandCheck`) and the Liferay convention of full `parameter(s)` spelling in identifiers.

Previous PRs on this target: liferay-database-infra/liferay-portal#3494, #3492, #3491, #3473 (all closed).