### PR TITLE
[Experiment] Revert LPD-79715 behavior to confirm DatabasePartitioningUpgrade flake root cause

### DIFF
--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/instance/lifecycle/AddCompanyGroupPortalInstanceLifecycleListener.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/instance/lifecycle/AddCompanyGroupPortalInstanceLifecycleListener.java
@@ -9,6 +9,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.instance.lifecycle.BasePortalInstanceLifecycleListener;
 import com.liferay.portal.instance.lifecycle.PortalInstanceLifecycleListener;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -18,10 +20,15 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.staging.StagingGroupHelper;
 import com.liferay.staging.internal.constants.CompanyGroupConstants;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -34,12 +41,35 @@ public class AddCompanyGroupPortalInstanceLifecycleListener
 
 	@Override
 	public void portalInstanceRegistered(Company company) {
-		_addCompanyGroup(company.getCompanyId());
+		if (FeatureFlagManagerUtil.isEnabled(
+				company.getCompanyId(), "LPD-35914")) {
+
+			_addCompanyGroup(company.getCompanyId());
+		}
 	}
 
 	@Override
 	public void portalInstanceUnregistered(Company company) {
 		_deleteCompanyGroup(company.getCompanyId());
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceRegistration = bundleContext.registerService(
+			FeatureFlagListener.class,
+			(companyId, featureFlagKey, enabled) -> {
+				if (enabled) {
+					_addCompanyGroup(companyId);
+				}
+			},
+			MapUtil.singletonDictionary("feature.flag.key", "LPD-35914"));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
 	}
 
 	private void _addCompanyGroup(long companyId) {
@@ -87,6 +117,8 @@ public class AddCompanyGroupPortalInstanceLifecycleListener
 
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;
+
+	private volatile ServiceRegistration<?> _serviceRegistration;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
## Context

Draft / not for merge. For Database Infrastructure team review.

The Poshi test `LocalFile.DatabasePartitioningUpgrade#ExportAndAddDBPartitionWithUpgradedDB` has been failing intermittently since **Feb 23, 2026** with the same xpath:

```
ElementNotFoundPoshiRunnerException: Element is not present at "//tr[contains(.,'testN')]/td[3]/a"
```

CI bisect on the Feb 22–23 window narrowed 127 candidate commits to one — `8c52863` (LPD-79715 "Removing promote content ff from code"). That commit removed the `LPD-35914` feature-flag gate around `_addCompanyGroup(...)` in `AddCompanyGroupPortalInstanceLifecycleListener.portalInstanceRegistered`. As a result, every partition registration now synchronously runs `GroupLocalService.addGroup(...)` plus its ES index update during the post-commit callback chain of `CompanyLocalServiceImpl._addDBPartitionCompany`.

## What this PR does

Narrow, single-file revert of the behavior change from `8c52863` — restoring the FF gate plus the `FeatureFlagListener` hook. Nothing else from that commit is touched (the remaining ~70 files are incidental: translation keys, cleanup in unrelated modules).

## Hypothesis being tested

`8c52863` did not introduce the race; it widened the window of a pre-existing one. The real race is in the import completion signal:

1. `ImportPortalInstanceOperation.activate` → `_addDBPartitionCompany` → post-commit callback fires `PortalInstances.initCompany` (lifecycle listeners) and `_synchronizePortalInstances()`.
2. `_synchronizePortalInstances` (CompanyLocalServiceImpl.java:2534-2541) calls `ClusterExecutorUtil.execute(...)` with `setFireAndForget(true)` — no ack awaited. The non-master node at 9080 has no other discovery path.
3. `BasePortalInstanceOperation.onPortalInstance` deletes the OSGi config file in a `finally` block even on exception — Poshi's `waitForOSGiConfigDeleted` greens regardless.

The added synchronous group-create from `8c52863` widens the gap between "config file deleted (Poshi proceeds)" and "partition ready to serve" enough to flake ~50% on the 2-node cluster.

## Expected result

With this revert applied, the Feb 23 flake rate should drop to ~0 when running `ExportAndAddDBPartitionWithUpgradedDB` in a loop on the 2-node / MySQL 8.4 / ES 8.19 / `feature.flag.LPD-11342=true` setup. If flake persists, a second commit in the Feb 22–23 window is contributing and the bisect needs to widen.

## Not the proposed fix

If the hypothesis holds, the real fix is three changes (separate PR, off master):

1. `CompanyLocalServiceImpl._synchronizePortalInstances` — drop `setFireAndForget(true)`, capture `FutureClusterResponses`, `get(60, SECONDS)` with warn-and-proceed on timeout (precedent: `LicenseUtil.java:110`).
2. `BasePortalInstanceOperation.onPortalInstance` — remove the `finally { _deleteConfiguration }` block so import exceptions stop silently greening the macro.
3. `DatabasePartitioningUpgrade.testcase:218` — change `SearchAdministration.executeReindex()` to `executeReindex(executionScope = "All Instances")` so partitions `42638` and `44913` are reindexed, not just the default instance.

Leaving `8c52863` in place once those three land is intentional: the FF cleanup is correct, it just needs the race fixed underneath it.

## Test plan

- [ ] Deploy `modules/apps/staging/staging-impl` to a 2-node cluster matching the CI topology.
- [ ] Run `LocalFile.DatabasePartitioningUpgrade#ExportAndAddDBPartitionWithUpgradedDB` 20× consecutively.
- [ ] Record pass/fail rate against the ~50% baseline.
- [ ] Run sibling `CanUpgradePartitionedDatabase7413U33` as a control.