### PR TITLE
LPD-86832 Update PRODUCT_MENU_BODY locator to match sideNavigation

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/productmenu/ProductMenu.path
@@ -37,7 +37,7 @@
 </tr>
 <tr>
 	<td>PRODUCT_MENU_BODY</td>
-	<td>//*[@data-qa-id='productMenuBody']</td>
+	<td>//*[@data-qa-id='productMenuBody'] | //*[@data-qa-id='sideNavigation']</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86832

**What is being fixed:** `Smoke.runSmoke` fails at `ProductMenuHelper.openProductMenu` with `Element is not present at "//*[@data-qa-id='productMenuBody']"`, blocking `DBMigrationImport#CanImportDatabaseToPostgreSQL` and `DatabasePartitioning#ExportNonPartitionedCompanyAndAddDBPartition` (LPD-86832), and the same failure shows up on the WorkflowMetrics test set tracked in LPD-85634.

**Root cause:** The new Global Menu side-navigation render was made unconditional in **LPD-86396** (commit `6947315c`), which removed the `LPD-36105` feature-flag gate from `application-list-taglib/.../application_content/page.jsp`. Before that commit the JSP only emitted `data-qa-id='sideNavigation'` when the flag was on; after it, the legacy `data-qa-id='productMenuBody'` DOM is no longer reachable on standard pages and `sideNavigation` is the only render path. The flag is gone, so the precedent escape hatch other teams used (toggling `LPD-36105` in test setup, e.g. LPD-84526 / LPD-85822 / LPD-85897) is no longer available.

**How it is being fixed:** Teach the global `PRODUCT_MENU_BODY` locator both DOM shapes by OR-ing the new `data-qa-id='sideNavigation'` selector with the existing `data-qa-id='productMenuBody'` one. This is the locator-side cleanup that LPD-86396 should have included: `ProductMenuHelper.openProductMenu` and the 400+ call sites that depend on it now resolve under either render, fixing the LPD-86832 tests and almost certainly resolving LPD-85634 once this lands. The OR keeps the locator backward-compatible in case any branch or component still emits the legacy markup.