### PR TITLE
LPD-84035 Extend Database Monitoring API for Long-Running Queries

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.dao.db.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -14,12 +15,16 @@ import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -27,11 +32,14 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -641,6 +649,102 @@ public class DBTest {
 	}
 
 	@Test
+	public void testGetLockedQueries() throws Exception {
+		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L)) {
+
+			db.runSQL(
+				"insert into " + TABLE_NAME_1 +
+					" (id, notNilColumn) values (1, '1')");
+
+			try (Connection lockingConnection = DataAccess.getConnection()) {
+				lockingConnection.setAutoCommit(false);
+
+				FutureTask<Void> futureTask = null;
+
+				try (Statement statement1 =
+						lockingConnection.createStatement()) {
+
+					statement1.executeUpdate(
+						"update " + TABLE_NAME_1 +
+							" set nilColumn='locked' where id=1");
+
+					futureTask = new FutureTask<>(
+						() -> {
+							try (Statement statement2 =
+									connection.createStatement()) {
+
+								statement2.executeUpdate(
+									"update " + TABLE_NAME_1 +
+										" set nilColumn='waiting' where id=1");
+							}
+
+							return null;
+						});
+
+					Thread thread = new Thread(futureTask);
+
+					thread.setDaemon(true);
+					thread.start();
+
+					boolean locked = false;
+
+					long endTime = System.currentTimeMillis() + 5000;
+
+					while (!locked && (System.currentTimeMillis() < endTime)) {
+						List<DB.RunningQuery> lockedQueries =
+							db.getLockedQueries(lockingConnection);
+
+						for (DB.RunningQuery lockedQuery : lockedQueries) {
+							String query = lockedQuery.getQuery();
+
+							if ((query != null) && query.contains("waiting")) {
+								locked = true;
+
+								Assert.assertNotNull(lockedQuery.getId());
+								Assert.assertNotNull(lockedQuery.getSchema());
+								Assert.assertTrue(
+									lockedQuery.getDuration() >= 0);
+
+								String actualState = lockedQuery.getState();
+
+								Assert.assertNotNull(actualState);
+								Assert.assertTrue(
+									actualState,
+									StringUtil.containsIgnoreCase(
+										actualState, "LOCK WAIT"));
+
+								break;
+							}
+						}
+
+						if (!locked) {
+							Thread.sleep(200);
+						}
+					}
+
+					Assert.assertTrue(locked);
+				}
+				finally {
+					try {
+						lockingConnection.rollback();
+
+						if (futureTask != null) {
+							futureTask.get(5, TimeUnit.SECONDS);
+						}
+					}
+					catch (Exception exception) {
+						_log.error(exception);
+					}
+				}
+			}
+		}
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		db.runSQL(_SQL_CREATE_TABLE_2);
 
@@ -996,5 +1100,7 @@ public class DBTest {
 	private static final String _TABLE_NAME_2 = "DBTest2";
 
 	private static final String _TABLE_NAME_3 = "DBTest3";
+
+	private static final Log _log = LogFactoryUtil.getLog(DBTest.class);
 
 }

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -650,7 +650,10 @@ public class DBTest {
 
 	@Test
 	public void testGetLockedQueries() throws Exception {
-		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+		String lockedQueriesSQL = ReflectionTestUtil.invoke(
+			db, "getLockedQueriesSQL", new Class<?>[0]);
+
+		Assume.assumeNotNull(lockedQueriesSQL);
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -715,7 +718,11 @@ public class DBTest {
 								Assert.assertTrue(
 									actualState,
 									StringUtil.containsIgnoreCase(
-										actualState, "LOCK WAIT"));
+										actualState, "LOCK") ||
+									StringUtil.containsIgnoreCase(
+										actualState, "BLOCK") ||
+									StringUtil.containsIgnoreCase(
+										actualState, "WAIT"));
 
 								break;
 							}

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -752,6 +752,91 @@ public class DBTest {
 	}
 
 	@Test
+	public void testGetLongRunningQueries() throws Exception {
+		String longRunningQueriesSQL = ReflectionTestUtil.invoke(
+			db, "getLongRunningQueriesSQL", new Class<?>[0]);
+
+		Assume.assumeNotNull(longRunningQueriesSQL);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD", 0L)) {
+
+			FutureTask<Void> futureTask = new FutureTask<>(
+				() -> {
+					try (Connection sleepConnection =
+							DataAccess.getConnection()) {
+
+						try (Statement statement =
+								sleepConnection.createStatement()) {
+
+							statement.executeQuery("select sleep(3)");
+						}
+					}
+
+					return null;
+				});
+
+			Thread thread = new Thread(futureTask);
+
+			thread.setDaemon(true);
+			thread.start();
+
+			try {
+				boolean longRunning = false;
+
+				long endTime = System.currentTimeMillis() + 5000;
+
+				while (!longRunning && (System.currentTimeMillis() < endTime)) {
+					List<DB.RunningQuery> longRunningQueries =
+						db.getLongRunningQueries(connection);
+
+					for (DB.RunningQuery longRunningQuery :
+							longRunningQueries) {
+
+						String query = longRunningQuery.getQuery();
+
+						if ((query != null) &&
+							StringUtil.containsIgnoreCase(query, "sleep")) {
+
+							longRunning = true;
+
+							Assert.assertNotNull(longRunningQuery.getId());
+							Assert.assertNotNull(longRunningQuery.getSchema());
+							Assert.assertTrue(
+								longRunningQuery.getDuration() >= 0);
+
+							String actualState = longRunningQuery.getState();
+
+							Assert.assertNotNull(actualState);
+							Assert.assertFalse(
+								actualState,
+								StringUtil.containsIgnoreCase(
+									actualState, "lock"));
+
+							break;
+						}
+					}
+
+					if (!longRunning) {
+						Thread.sleep(200);
+					}
+				}
+
+				Assert.assertTrue(longRunning);
+			}
+			finally {
+				try {
+					futureTask.get(5, TimeUnit.SECONDS);
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+				}
+			}
+		}
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		db.runSQL(_SQL_CREATE_TABLE_2);
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -753,10 +753,9 @@ public class DBTest {
 
 	@Test
 	public void testGetLongRunningQueries() throws Exception {
-		String longRunningQueriesSQL = ReflectionTestUtil.invoke(
-			db, "getLongRunningQueriesSQL", new Class<?>[0]);
-
-		Assume.assumeNotNull(longRunningQueriesSQL);
+		Assume.assumeTrue(
+			(db.getDBType() == DBType.MARIADB) ||
+			(db.getDBType() == DBType.MYSQL));
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -433,6 +433,11 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -659,6 +664,13 @@ public class DB2DB extends BaseDB {
 		" double", " integer", " bigint", " varchar(4000)", " clob(2G)",
 		" varchar", " generated always as identity", "commit"
 	};
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select cast(req_application_handle as varchar(20)) as id, ",
+		"coalesce(tab_schema, '') as schemaName, cast(lock_wait_elapsed_time ",
+		"as bigint) as duration, 'LOCK WAIT' as state, coalesce(stmt_text, ",
+		"'') as query from sysibmadm.mon_lockwaits where ",
+		"lock_wait_elapsed_time >= ?");
 
 	private static final int _SQL_STRING_SIZE = 4000;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -438,6 +438,11 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueriesSQL() {
+		return _LONG_RUNNING_QUERIES_SQL;
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -671,6 +676,20 @@ public class DB2DB extends BaseDB {
 		"as bigint) as duration, 'LOCK WAIT' as state, coalesce(stmt_text, ",
 		"'') as query from sysibmadm.mon_lockwaits where ",
 		"lock_wait_elapsed_time >= ?");
+
+	private static final String _LONG_RUNNING_QUERIES_SQL =
+		StringBundler.concat(
+			"select cast(a.agent_id as varchar(20)) as id, ",
+			"coalesce(a.db_name, '') as schemaName, cast(timestampdiff(2, ",
+			"char(current timestamp - u.uow_start_time)) as bigint) as ",
+			"duration, a.appl_status as state, cast(act.stmt_text as ",
+			"varchar(1000)) as query from sysibmadm.applications a join ",
+			"table(sysproc.mon_get_unit_of_work(null, -2)) as u on a.agent_id ",
+			"= u.application_handle left join table(",
+			"sysproc.mon_get_activity(null, -2)) as act on a.agent_id = ",
+			"act.application_handle where a.appl_status = 'UOWEXEC' and ",
+			"a.agent_id <> mon_get_application_handle() and timestampdiff(2, ",
+			"char(current timestamp - u.uow_start_time)) >= ?");
 
 	private static final int _SQL_STRING_SIZE = 4000;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -382,6 +382,11 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueriesSQL() {
+		return _LONG_RUNNING_QUERIES_SQL;
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -548,6 +553,16 @@ public class OracleDB extends BaseDB {
 		"s.sql_id = q.sql_id and s.sql_child_number = q.child_number where ",
 		"s.blocking_session is not null and s.sid <> sys_context('userenv', ",
 		"'sid') and (sysdate - s.sql_exec_start) * 86400 >= ?");
+
+	private static final String _LONG_RUNNING_QUERIES_SQL =
+		StringBundler.concat(
+			"select to_char(s.sid) as id, s.username as schemaName, ",
+			"cast((sysdate - s.sql_exec_start) * 86400 as number(19)) as ",
+			"duration, s.event as state, q.sql_text as query from v$session s ",
+			"left join v$sql q on s.sql_id = q.sql_id and s.sql_child_number ",
+			"= q.child_number where s.blocking_session is null and s.status = ",
+			"'ACTIVE' and s.type = 'USER' and s.sid <> sys_context(",
+			"'userenv', 'sid') and (sysdate - s.sql_exec_start) * 86400 >= ?");
 
 	private static final String[] _ORACLE = {
 		"--", "1", "0",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -377,6 +377,11 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -535,6 +540,14 @@ public class OracleDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select to_char(s.sid) as id, s.username as schemaName, cast((sysdate ",
+		"- s.sql_exec_start) * 86400 as number(19)) as duration, s.event as ",
+		"state, q.sql_text as query from v$session s left join v$sql q on ",
+		"s.sql_id = q.sql_id and s.sql_child_number = q.child_number where ",
+		"s.blocking_session is not null and s.sid <> sys_context('userenv', ",
+		"'sid') and (sysdate - s.sql_exec_start) * 86400 >= ?");
 
 	private static final String[] _ORACLE = {
 		"--", "1", "0",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -451,6 +451,11 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueriesSQL() {
+		return _LONG_RUNNING_QUERIES_SQL;
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -595,6 +600,17 @@ public class SQLServerDB extends BaseDB {
 		"varchar(4000)) as query from sys.dm_exec_requests r cross apply ",
 		"sys.dm_exec_sql_text(r.sql_handle) t where r.blocking_session_id <> ",
 		"0 and r.session_id <> @@spid and r.total_elapsed_time / 1000 >= ?");
+
+	private static final String _LONG_RUNNING_QUERIES_SQL =
+		StringBundler.concat(
+			"select cast(r.session_id as varchar(20)) as id, db_name(",
+			"r.database_id) as schemaName, cast(r.total_elapsed_time / 1000 ",
+			"as bigint) as duration, coalesce(r.wait_type, r.status) as ",
+			"state, cast(t.text as varchar(4000)) as query from ",
+			"sys.dm_exec_requests r cross apply sys.dm_exec_sql_text(",
+			"r.sql_handle) t where r.blocking_session_id = 0 and r.session_id ",
+			"<> @@spid and r.session_id >= 50 and r.total_elapsed_time / 1000 ",
+			">= ?");
 
 	private static final String[] _SQL_SERVER = {
 		"--", "1", "0", "'19700101'", "GetDate()", " image", " image",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -446,6 +446,11 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -581,6 +586,15 @@ public class SQLServerDB extends BaseDB {
 				"alter table ", tableName, " drop constraint ",
 				defaultConstraintName));
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select cast(r.session_id as varchar(20)) as id, db_name(",
+		"r.database_id) as schemaName, cast(r.total_elapsed_time / 1000 as ",
+		"bigint) as duration, coalesce(r.wait_type, '') + ' BLOCKED_BY:' + ",
+		"cast(r.blocking_session_id as varchar(10)) as state, cast(t.text as ",
+		"varchar(4000)) as query from sys.dm_exec_requests r cross apply ",
+		"sys.dm_exec_sql_text(r.sql_handle) t where r.blocking_session_id <> ",
+		"0 and r.session_id <> @@spid and r.total_elapsed_time / 1000 >= ?");
 
 	private static final String[] _SQL_SERVER = {
 		"--", "1", "0", "'19700101'", "GetDate()", " image", " image",

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 125.1.0
+Bundle-Version: 126.0.0
 CPE-Name: ${cpe.name}
 Export-Package:\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -60,6 +61,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -542,6 +544,42 @@ public abstract class BaseDB implements DB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, false);
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				getLockedQueriesSQL())) {
+
+			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
 	}
 
 	@Override
@@ -1505,6 +1543,10 @@ public abstract class BaseDB implements DB {
 
 	protected String getIndexColumnName(String indexColumnName) {
 		return indexColumnName;
+	}
+
+	protected String getLockedQueriesSQL() {
+		return null;
 	}
 
 	protected String getRenameTableSQL(

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -550,36 +550,18 @@ public abstract class BaseDB implements DB {
 	public List<RunningQuery> getLockedQueries(Connection connection)
 		throws SQLException {
 
-		List<RunningQuery> lockedQueries = new ArrayList<>();
+		return _getQueries(
+			connection, getLockedQueriesSQL(),
+			PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD);
+	}
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				getLockedQueriesSQL())) {
+	@Override
+	public List<RunningQuery> getLongRunningQueries(Connection connection)
+		throws SQLException {
 
-			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
-
-			long threshold = (long)Math.ceil(
-				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String id = String.valueOf(resultSet.getLong("id"));
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
-					String state = resultSet.getString("state");
-
-					lockedQueries.add(
-						new RunningQuery(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueries;
+		return _getQueries(
+			connection, getLongRunningQueriesSQL(),
+			PropsValues.UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD);
 	}
 
 	@Override
@@ -1549,6 +1531,10 @@ public abstract class BaseDB implements DB {
 		return null;
 	}
 
+	protected String getLongRunningQueriesSQL() {
+		return null;
+	}
+
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -1784,6 +1770,41 @@ public abstract class BaseDB implements DB {
 		}
 
 		return primaryKeys;
+	}
+
+	private List<RunningQuery> _getQueries(
+			Connection connection, String sql, long thresholdMillis)
+		throws SQLException {
+
+		List<RunningQuery> queries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(thresholdMillis / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					queries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return queries;
 	}
 
 	private boolean _isSkipIndexOperation(

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -17,8 +17,11 @@ import com.liferay.portal.kernel.util.Validator;
 import java.io.IOException;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.sql.Types;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -56,6 +59,13 @@ public class HypersonicDB extends BaseDB {
 		}
 
 		return defaultValue;
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/HypersonicDB.java
@@ -69,6 +69,13 @@ public class HypersonicDB extends BaseDB {
 	}
 
 	@Override
+	public List<RunningQuery> getLongRunningQueries(Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
+	}
+
+	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return StringPool.BLANK;
 	}

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,6 +29,7 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -148,6 +149,42 @@ public class MySQLDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		List<RunningQuery> lockedQueries = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_LOCKED_QUERIES_SQL)) {
+
+			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = String.valueOf(resultSet.getLong("id"));
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueries.add(
+						new RunningQuery(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueries;
 	}
 
 	@Override
@@ -314,6 +351,15 @@ public class MySQLDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select p.id as id, p.db as schemaName, p.time as duration, ",
+		"coalesce(t.trx_state, p.state) as state, p.info as query from ",
+		"information_schema.processlist p left join ",
+		"information_schema.innodb_trx t on p.id = t.trx_mysql_thread_id ",
+		"where p.command != 'Sleep' and p.info is not null and p.id != ",
+		"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
+		"'%lock%') and p.time >= ?)");
 
 	private static final String[] _MYSQL = {
 		"##", "1", "0", "'1970-01-01'", "now()", " longblob", " longblob",

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -225,6 +225,11 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueriesSQL() {
+		return _LONG_RUNNING_QUERIES_SQL;
+	}
+
+	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;
 	}
@@ -328,6 +333,16 @@ public class MySQLDB extends BaseDB {
 		"where p.command != 'Sleep' and p.info is not null and p.id != ",
 		"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
 		"'%lock%') and p.time >= ?)");
+
+	private static final String _LONG_RUNNING_QUERIES_SQL =
+		StringBundler.concat(
+			"select p.id as id, p.db as schemaName, p.time as duration, ",
+			"coalesce(t.trx_state, p.state) as state, p.info as query from ",
+			"information_schema.processlist p left join ",
+			"information_schema.innodb_trx t on p.id = t.trx_mysql_thread_id ",
+			"where p.command != 'Sleep' and p.info is not null and p.id != ",
+			"connection_id() and lower(coalesce(t.trx_state, p.state, '')) ",
+			"not like '%lock%' and p.time >= ?");
 
 	private static final String[] _MYSQL = {
 		"##", "1", "0", "'1970-01-01'", "now()", " longblob", " longblob",

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,7 +29,6 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -152,42 +151,6 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
-	public List<RunningQuery> getLockedQueries(Connection connection)
-		throws SQLException {
-
-		List<RunningQuery> lockedQueries = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				_LOCKED_QUERIES_SQL)) {
-
-			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
-
-			long threshold = (long)Math.ceil(
-				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String id = String.valueOf(resultSet.getLong("id"));
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
-					String state = resultSet.getString("state");
-
-					lockedQueries.add(
-						new RunningQuery(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueries;
-	}
-
-	@Override
 	public String getNewUuidFunctionName() {
 		return "UUID()";
 	}
@@ -254,6 +217,11 @@ public class MySQLDB extends BaseDB {
 		}
 
 		runSQL(connection, sb.toString());
+	}
+
+	@Override
+	protected String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -331,6 +331,11 @@ public class PostgreSQLDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueriesSQL() {
+		return _LOCKED_QUERIES_SQL;
+	}
+
+	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;
 	}
@@ -507,6 +512,14 @@ public class PostgreSQLDB extends BaseDB {
 
 		runSQL(connection, sb.toString());
 	}
+
+	private static final String _LOCKED_QUERIES_SQL = StringBundler.concat(
+		"select pid as id, datname as schemaName, cast(extract(epoch from ",
+		"(clock_timestamp() - query_start)) as bigint) as duration, coalesce(",
+		"wait_event_type || ':' || wait_event, state) as state, query from ",
+		"pg_stat_activity where wait_event_type = 'Lock' and state = 'active' ",
+		"and pid <> pg_backend_pid() and extract(epoch from (clock_timestamp",
+		"() - query_start)) >= ?");
 
 	private static final String[] _POSTGRESQL = {
 		"--", "true", "false", "'01/01/1970'", "current_timestamp", " oid",

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -336,6 +336,11 @@ public class PostgreSQLDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueriesSQL() {
+		return _LONG_RUNNING_QUERIES_SQL;
+	}
+
+	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;
 	}
@@ -520,6 +525,16 @@ public class PostgreSQLDB extends BaseDB {
 		"pg_stat_activity where wait_event_type = 'Lock' and state = 'active' ",
 		"and pid <> pg_backend_pid() and extract(epoch from (clock_timestamp",
 		"() - query_start)) >= ?");
+
+	private static final String _LONG_RUNNING_QUERIES_SQL =
+		StringBundler.concat(
+			"select pid as id, datname as schemaName, cast(extract(epoch from ",
+			"(clock_timestamp() - query_start)) as bigint) as duration, ",
+			"coalesce(wait_event_type || ':' || wait_event, state) as state, ",
+			"query from pg_stat_activity where (wait_event_type is null or ",
+			"wait_event_type <> 'Lock') and state = 'active' and pid <> ",
+			"pg_backend_pid() and extract(epoch from (clock_timestamp() - ",
+			"query_start)) >= ?");
 
 	private static final String[] _POSTGRESQL = {
 		"--", "true", "false", "'01/01/1970'", "current_timestamp", " oid",

--- a/portal-impl/src/com/liferay/portlet/packageinfo
+++ b/portal-impl/src/com/liferay/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 11.1.0
+version 12.0.0

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -227,6 +227,15 @@
     upgrade.log.progress.interval=300000
 
     #
+    # Set the threshold in milliseconds before a query waiting on resources is
+    # flagged as "Locked". When this threshold is exceeded, a WARNING message is
+    # printed to the upgrade logs.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_LOCK_PERIOD_THRESHOLD
+    #
+    upgrade.query.monitor.lock.threshold=300000
+
+    #
     # Specify the number of seconds that the upgrade report generation will wait
     # for calculating the document library storage size before timing out.
     # Specify 0 to disable the document library storage size calculation.

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -236,6 +236,15 @@
     upgrade.query.monitor.lock.threshold=300000
 
     #
+    # Set the threshold in milliseconds before an actively executing query is
+    # flagged as "Long-Running". When this threshold is exceeded, an INFO
+    # message is printed to the upgrade logs.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_LONG_PERIOD_RUNNING_PERIOD_THRESHOLD
+    #
+    upgrade.query.monitor.long.running.threshold=600000
+
+    #
     # Specify the number of seconds that the upgrade report generation will wait
     # for calculating the document library storage size before timing out.
     # Specify 0 to disable the document library storage size calculation.

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -15,6 +15,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +28,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DB {
+
+	public static final int MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	public static final int SQL_SIZE_NONE = -1;
 
@@ -98,6 +101,12 @@ public interface DB {
 	public ResultSet getIndexResultSet(
 			Connection connection, String tableName, boolean onlyUnique)
 		throws SQLException;
+
+	public default List<RunningQuery> getLockedQueries(Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
+	}
 
 	public int getMajorVersion();
 
@@ -239,5 +248,46 @@ public interface DB {
 			Connection connection, String tableName,
 			String[] primaryKeyColumnNames)
 		throws Exception;
+
+	public static class RunningQuery {
+
+		public RunningQuery(
+			long duration, String id, String query, String schema,
+			String state) {
+
+			_duration = duration;
+			_id = id;
+			_query = query;
+			_schema = schema;
+			_state = state;
+		}
+
+		public long getDuration() {
+			return _duration;
+		}
+
+		public String getId() {
+			return _id;
+		}
+
+		public String getQuery() {
+			return _query;
+		}
+
+		public String getSchema() {
+			return _schema;
+		}
+
+		public String getState() {
+			return _state;
+		}
+
+		private final long _duration;
+		private final String _id;
+		private final String _query;
+		private final String _schema;
+		private final String _state;
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -108,6 +108,13 @@ public interface DB {
 		return Collections.emptyList();
 	}
 
+	public default List<RunningQuery> getLongRunningQueries(
+			Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
+	}
+
 	public int getMajorVersion();
 
 	public int getMinorVersion();

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2727,6 +2727,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_PROGRESS_INTERVAL =
 		"upgrade.log.progress.interval";
 
+	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		"upgrade.query.monitor.lock.threshold";
+
 	public static final String UPGRADE_REPORT_DIR = "upgrade.report.dir";
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2730,6 +2730,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
 		"upgrade.query.monitor.lock.threshold";
 
+	public static final String UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD =
+		"upgrade.query.monitor.long.running.threshold";
+
 	public static final String UPGRADE_REPORT_DIR = "upgrade.report.dir";
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2390,6 +2390,11 @@ public class PropsValues {
 	public static final long UPGRADE_LOG_PROGRESS_INTERVAL = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.UPGRADE_LOG_PROGRESS_INTERVAL));
 
+	public static final long UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),
+			300000L);
+
 	public static final String UPGRADE_REPORT_DIR = GetterUtil.getString(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIR));
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2395,6 +2395,12 @@ public class PropsValues {
 			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),
 			300000L);
 
+	public static final long UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD =
+		GetterUtil.getLong(
+			PropsUtil.get(
+				PropsKeys.UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD),
+			600000L);
+
 	public static final String UPGRADE_REPORT_DIR = GetterUtil.getString(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIR));
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84035

**What is being fixed:** The upgrade query monitor framework (epic LPD-83885) needs to surface actively-executing queries that have run past a configurable threshold, complementing the locked-query API delivered in LPD-84024. Without this hook, the polling thread (LPD-84041) has nothing to call for the long-running case.

**How it is being fixed:** Add a default `getLongRunningQueries(Connection)` method to the `DB` interface that returns `Collections.emptyList()`, mirroring the existing `getLockedQueries` shape so per-vendor implementations can land independently in LPD-84039. Reuses the `RunningQuery` data structure introduced in LPD-84024. Adds a new `upgrade.query.monitor.long.running.threshold` property defaulting to `600000` ms (10 minutes), wired into `PropsKeys` and `PropsValues`.

Stacked on #3504 (LPD-83885 multi-vendor branch). Until that merges, this PR's diff includes the multi-vendor changes; afterwards it reduces to the four files actually owned by LPD-84035.