### PR TITLE
LPD-87734 Speed up utf8mb3 charset detection with grep

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15618,17 +15618,19 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 				<equals arg1="${database.type}" arg2="mysql" />
 			</or>
 			<then>
-				<loadresource property="found.utf8mb3.line">
-					<concat>
-						<file file="${liferay.home}/${database.type}.sql" />
-						<filterchain>
-							<linecontainsregexp casesensitive="false">
-								<regexp pattern="DEFAULT CHARSET\s*=\s*utf8(mb3)?(?![mb4])" />
-							</linecontainsregexp>
-							<headfilter lines="1" />
-						</filterchain>
-					</concat>
-				</loadresource>
+				<local name="grep.utf8mb3.exit" />
+
+				<exec executable="grep" failonerror="false" resultproperty="grep.utf8mb3.exit">
+					<arg value="-iE" />
+					<arg value="-m" />
+					<arg value="1" />
+					<arg value="DEFAULT CHARSET\s*=\s*utf8(mb3)?([^mb4]|$)" />
+					<arg value="${liferay.home}/${database.type}.sql" />
+				</exec>
+
+				<condition property="found.utf8mb3.line">
+					<equals arg1="${grep.utf8mb3.exit}" arg2="0" />
+				</condition>
 
 				<if>
 					<isset property="found.utf8mb3.line" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87734

**What is being fixed:** The `rebuild-legacy-database` target in `build-test.xml` detects whether a `utf8mb3` charset declaration exists in the imported MySQL/MariaDB SQL dump, and uses that to choose between `create-bare-mysql.sql` and `create-bare-mysql-utf8mb3.sql`. The previous implementation used Ant's `<loadresource>` + `<concat>` + `<filterchain>` with a per-line regex, which scans the entire file inside the JVM. On multi-GB dumps — especially the worst case where no `utf8mb3` declaration exists and the whole file must be read — this becomes a measurable bottleneck.

**How it is being fixed:** The Ant filterchain is replaced with a single `<exec executable="grep" -iE -m 1>` invocation. Native grep performs the same scan in C and exits early on the first match, which is roughly 10–30× faster per byte. The Java negative-lookahead `(?![mb4])` is rewritten as POSIX ERE `([^mb4]|$)`, which is functionally equivalent for an "any-match" question. Behavior is preserved: a grep exit code of 0 sets `found.utf8mb3.line`, and the existing downstream `<isset>` check continues to gate the `create-bare-mysql-utf8mb3.sql` variant.