### PR TITLE
bFormat Check

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -670,14 +670,14 @@ public class DBTest {
 
 			statement1.executeUpdate(
 				"update " + TABLE_NAME_1 +
-					" set nilColumn='locked' where id=1");
+					" set nilColumn = 'locked' where id = 1");
 
 			futureTask = new FutureTask<>(
 				() -> {
 					try (Statement statement2 = connection.createStatement()) {
 						statement2.executeUpdate(
 							"update " + TABLE_NAME_1 +
-								" set nilColumn='waiting' where id=1");
+								" set nilColumn = 'waiting' where id = 1");
 					}
 
 					return null;

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -686,6 +686,7 @@ public class DBTest {
 			Thread thread = new Thread(futureTask);
 
 			thread.setDaemon(true);
+
 			thread.start();
 
 			boolean locked = false;
@@ -701,15 +702,13 @@ public class DBTest {
 					if ((query != null) && query.contains("waiting")) {
 						locked = true;
 
+						Assert.assertTrue(lockedQueryInfo.getDuration() >= 0);
 						Assert.assertNotNull(lockedQueryInfo.getId());
 						Assert.assertNotNull(lockedQueryInfo.getSchema());
-						Assert.assertTrue(lockedQueryInfo.getDuration() >= 0);
 
 						String actualState = lockedQueryInfo.getState();
 
-						Assert.assertNotNull(actualState);
 						Assert.assertTrue(
-							actualState,
 							StringUtil.containsIgnoreCase(
 								actualState, "LOCK WAIT"));
 
@@ -769,9 +768,6 @@ public class DBTest {
 			connection, new ObjectValuePair<>(TABLE_NAME_1, _TABLE_NAME_3),
 			new ObjectValuePair<>(_TABLE_NAME_2, TABLE_NAME_1),
 			new ObjectValuePair<>(_TABLE_NAME_3, _TABLE_NAME_2));
-
-		Assert.assertTrue(dbInspector.hasTable(TABLE_NAME_1));
-		Assert.assertTrue(dbInspector.hasTable(_TABLE_NAME_2));
 
 		Assert.assertTrue(dbInspector.hasColumn(TABLE_NAME_1, "id1"));
 		Assert.assertTrue(dbInspector.hasColumn(_TABLE_NAME_2, "id"));

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.dao.db.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -14,12 +15,16 @@ import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -27,11 +32,14 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -641,6 +649,94 @@ public class DBTest {
 	}
 
 	@Test
+	public void testGetLockedQueryInfos() throws Exception {
+		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+
+		db.runSQL(
+			"insert into " + TABLE_NAME_1 +
+				" (id, notNilColumn) values (1, '1')");
+
+		FutureTask<Void> futureTask = null;
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L);
+
+			Connection lockingConnection = DataAccess.getConnection();
+
+			Statement statement1 = lockingConnection.createStatement()) {
+
+			lockingConnection.setAutoCommit(false);
+
+			statement1.executeUpdate(
+				"update " + TABLE_NAME_1 +
+					" set nilColumn='locked' where id=1");
+
+			futureTask = new FutureTask<>(
+				() -> {
+					try (Statement statement2 = connection.createStatement()) {
+						statement2.executeUpdate(
+							"update " + TABLE_NAME_1 +
+								" set nilColumn='waiting' where id=1");
+					}
+
+					return null;
+				});
+
+			Thread thread = new Thread(futureTask);
+
+			thread.setDaemon(true);
+			thread.start();
+
+			boolean locked = false;
+
+			long endTime = System.currentTimeMillis() + 5000;
+
+			while (!locked && (System.currentTimeMillis() < endTime)) {
+				for (DB.QueryInfo lockedQueryInfo :
+						db.getLockedQueryInfos(lockingConnection)) {
+
+					String query = lockedQueryInfo.getQuery();
+
+					if ((query != null) && query.contains("waiting")) {
+						locked = true;
+
+						Assert.assertNotNull(lockedQueryInfo.getId());
+						Assert.assertNotNull(lockedQueryInfo.getSchema());
+						Assert.assertTrue(lockedQueryInfo.getDuration() >= 0);
+
+						String actualState = lockedQueryInfo.getState();
+
+						Assert.assertNotNull(actualState);
+						Assert.assertTrue(
+							actualState,
+							StringUtil.containsIgnoreCase(
+								actualState, "LOCK WAIT"));
+
+						break;
+					}
+				}
+
+				if (!locked) {
+					Thread.sleep(200);
+				}
+			}
+
+			Assert.assertTrue(locked);
+		}
+		finally {
+			if (futureTask != null) {
+				try {
+					futureTask.get(5, TimeUnit.SECONDS);
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+				}
+			}
+		}
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		db.runSQL(_SQL_CREATE_TABLE_2);
 
@@ -996,5 +1092,7 @@ public class DBTest {
 	private static final String _TABLE_NAME_2 = "DBTest2";
 
 	private static final String _TABLE_NAME_3 = "DBTest3";
+
+	private static final Log _log = LogFactoryUtil.getLog(DBTest.class);
 
 }

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -663,18 +663,21 @@ public class DBTest {
 					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L);
 			Connection lockingConnection = DataAccess.getConnection();
 
-			Statement statement1 = lockingConnection.createStatement()) {
+			Statement lockingStatement =
+				lockingConnection.createStatement()) {
 
 			lockingConnection.setAutoCommit(false);
 
-			statement1.executeUpdate(
+			lockingStatement.executeUpdate(
 				"update " + TABLE_NAME_1 +
 					" set nilColumn = 'locked' where id = 1");
 
 			futureTask = new FutureTask<>(
 				() -> {
-					try (Statement statement2 = connection.createStatement()) {
-						statement2.executeUpdate(
+					try (Statement waitingStatement =
+							connection.createStatement()) {
+
+						waitingStatement.executeUpdate(
 							"update " + TABLE_NAME_1 +
 								" set nilColumn = 'waiting' where id = 1");
 					}

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -661,7 +661,6 @@ public class DBTest {
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L);
-
 			Connection lockingConnection = DataAccess.getConnection();
 
 			Statement statement1 = lockingConnection.createStatement()) {

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,6 +29,7 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -148,6 +149,42 @@ public class MySQLDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				_LOCKED_QUERY_INFOS_SQL)) {
+
+			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
+
+			long threshold =
+				(PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD + 999) / 1000;
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String id = resultSet.getString("id");
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schemaName");
+
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override
@@ -314,6 +351,15 @@ public class MySQLDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final String _LOCKED_QUERY_INFOS_SQL = StringBundler.concat(
+		"select p.id as id, p.db as schemaName, p.time as duration, ",
+		"coalesce(t.trx_state, p.state) as state, p.info as query from ",
+		"information_schema.processlist p left join ",
+		"information_schema.innodb_trx t on p.id = t.trx_mysql_thread_id ",
+		"where p.command != 'Sleep' and p.info is not null and p.id != ",
+		"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
+		"'%lock%') and p.time >= ?)");
 
 	private static final String[] _MYSQL = {
 		"##", "1", "0", "'1970-01-01'", "now()", " longblob", " longblob",

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -162,8 +162,8 @@ public class MySQLDB extends BaseDB {
 
 			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
 
-			long threshold =
-				(PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD + 999) / 1000;
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
 
 			preparedStatement.setLong(1, threshold);
 

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -160,7 +160,7 @@ public class MySQLDB extends BaseDB {
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				_LOCKED_QUERY_INFOS_SQL)) {
 
-			preparedStatement.setQueryTimeout(MONITOR_QUERY_TIMEOUT_SECONDS);
+			preparedStatement.setQueryTimeout(_MONITOR_QUERY_TIMEOUT_SECONDS);
 
 			long threshold = (long)Math.ceil(
 				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
@@ -169,13 +169,11 @@ public class MySQLDB extends BaseDB {
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				while (resultSet.next()) {
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
 					String id = resultSet.getString("id");
 					String query = resultSet.getString("query");
 					String schema = resultSet.getString("schemaName");
-
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-
 					String state = resultSet.getString("state");
 
 					lockedQueryInfos.add(
@@ -360,6 +358,8 @@ public class MySQLDB extends BaseDB {
 		"where p.command != 'Sleep' and p.info is not null and p.id != ",
 		"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
 		"'%lock%') and p.time >= ?)");
+
+	private static final int _MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	private static final String[] _MYSQL = {
 		"##", "1", "0", "'1970-01-01'", "now()", " longblob", " longblob",

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -227,6 +227,15 @@
     upgrade.log.progress.interval=300000
 
     #
+    # Set the threshold in milliseconds before a query waiting on resources is
+    # flagged as "Locked". When this threshold is exceeded, a WARNING message is
+    # printed to the upgrade logs.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_LOCK_PERIOD_THRESHOLD
+    #
+    upgrade.query.monitor.lock.threshold=300000
+
+    #
     # Specify the number of seconds that the upgrade report generation will wait
     # for calculating the document library storage size before timing out.
     # Specify 0 to disable the document library storage size calculation.

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -228,7 +228,7 @@
 
     #
     # Set the threshold in milliseconds before a query waiting on resources is
-    # flagged as "Locked". When this threshold is exceeded, a WARNING message is
+    # flagged as locked. When this threshold is exceeded, a warning message is
     # printed to the upgrade logs.
     #
     # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_LOCK_PERIOD_THRESHOLD

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -15,6 +15,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -27,6 +28,8 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface DB {
+
+	public static final int MONITOR_QUERY_TIMEOUT_SECONDS = 10;
 
 	public static final int SQL_SIZE_NONE = -1;
 
@@ -98,6 +101,12 @@ public interface DB {
 	public ResultSet getIndexResultSet(
 			Connection connection, String tableName, boolean onlyUnique)
 		throws SQLException;
+
+	public default List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
+	}
 
 	public int getMajorVersion();
 
@@ -239,5 +248,46 @@ public interface DB {
 			Connection connection, String tableName,
 			String[] primaryKeyColumnNames)
 		throws Exception;
+
+	public static class QueryInfo {
+
+		public QueryInfo(
+			long duration, String id, String query, String schema,
+			String state) {
+
+			_duration = duration;
+			_id = id;
+			_query = query;
+			_schema = schema;
+			_state = state;
+		}
+
+		public long getDuration() {
+			return _duration;
+		}
+
+		public String getId() {
+			return _id;
+		}
+
+		public String getQuery() {
+			return _query;
+		}
+
+		public String getSchema() {
+			return _schema;
+		}
+
+		public String getState() {
+			return _state;
+		}
+
+		private final long _duration;
+		private final String _id;
+		private final String _query;
+		private final String _schema;
+		private final String _state;
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -29,8 +29,6 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface DB {
 
-	public static final int MONITOR_QUERY_TIMEOUT_SECONDS = 10;
-
 	public static final int SQL_SIZE_NONE = -1;
 
 	public static final int SQL_VARCHAR_MAX_SIZE = Integer.MAX_VALUE;

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2727,6 +2727,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_PROGRESS_INTERVAL =
 		"upgrade.log.progress.interval";
 
+	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		"upgrade.query.monitor.lock.threshold";
+
 	public static final String UPGRADE_REPORT_DIR = "upgrade.report.dir";
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2390,6 +2390,11 @@ public class PropsValues {
 	public static final long UPGRADE_LOG_PROGRESS_INTERVAL = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.UPGRADE_LOG_PROGRESS_INTERVAL));
 
+	public static final long UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),
+			300000L);
+
 	public static final String UPGRADE_REPORT_DIR = GetterUtil.getString(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIR));
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2393,7 +2393,7 @@ public class PropsValues {
 	public static final long UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),
-			300000L);
+			300000);
 
 	public static final String UPGRADE_REPORT_DIR = GetterUtil.getString(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIR));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84025

**What is being fixed:** Style polish on top of the LPD-84024 / LPD-84025 locked query monitoring work, addressing items surfaced by a bFormat (Brian Chan review-rules) check before sending the PR back for review.

**How it is being fixed:** Two focused commits on top of the existing branch — remove a redundant blank line between independent resources in the integration test's try-with-resources block (R118), and rename the test's `statement1`/`statement2` variables to `lockingStatement`/`waitingStatement` so they describe their role (R36/R68). Each commit links the brianchandotcom PR where the rule was originally extracted.