### PR TITLE
LPD-87736 Support legacy database dumps from outside the liferay-qa-portal-legacy-ee repository

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11042,11 +11042,15 @@ org.apache.catalina.ha.session.level=INFO]]>
 					</then>
 				</if>
 
+				<get-testcase-property property.name="legacy.database.file" />
 				<get-testcase-property property.name="portal.version" />
 
 				<if>
 					<and>
-						<isset property="portal.version" />
+						<or>
+							<isset property="legacy.database.file" />
+							<isset property="portal.version" />
+						</or>
 						<not>
 							<equals arg1="${keep.osgi.state}" arg2="true" />
 						</not>
@@ -15649,6 +15653,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 			</not>
 			<then>
 				<get-testcase-property property.name="data.archive.type" />
+				<get-testcase-property property.name="legacy.database.file" />
 				<get-testcase-property property.name="portal.version" />
 			</then>
 		</if>
@@ -15656,20 +15661,161 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 		<delete dir="${liferay.home}/data" />
 
 		<if>
-			<contains string="${data.archive.type}" substring="partition-large" />
+			<isset property="legacy.database.file" />
 			<then>
-				<mirrors-get
-					dest="${liferay.home}"
-					src="http://files.liferay.com/mirrors/data-archive-portal-partition-large.zip"
-				/>
+				<local name="legacy.database.temp.dir" />
 
-				<unzip
-					dest="${liferay.home}"
-					src="${liferay.home}/data-archive-portal-partition-large.zip"
-				/>
+				<tempfile destdir="${liferay.home}" prefix="legacy-database-" property="legacy.database.temp.dir" />
 
-				<delete file="${liferay.home}/data-archive-portal-partition-large.zip" />
+				<mkdir dir="${legacy.database.temp.dir}" />
+
+				<trycatch>
+					<try>
+						<if>
+							<matches casesensitive="false" pattern=".*\.tar\.gz$" string="${legacy.database.file}" />
+							<then>
+								<untar
+									compression="gzip"
+									dest="${legacy.database.temp.dir}"
+									src="${legacy.database.file}"
+								/>
+							</then>
+							<elseif>
+								<matches casesensitive="false" pattern=".*\.gz$" string="${legacy.database.file}" />
+								<then>
+									<gunzip
+										dest="${legacy.database.temp.dir}"
+										src="${legacy.database.file}"
+									/>
+								</then>
+							</elseif>
+							<elseif>
+								<matches casesensitive="false" pattern=".*\.zip$" string="${legacy.database.file}" />
+								<then>
+									<unzip
+										dest="${legacy.database.temp.dir}"
+										src="${legacy.database.file}"
+									/>
+								</then>
+							</elseif>
+							<else>
+								<copy
+									file="${legacy.database.file}"
+									todir="${legacy.database.temp.dir}"
+								/>
+							</else>
+						</if>
+
+						<if>
+							<not>
+								<equals arg1="${database.type}" arg2="db2" />
+							</not>
+							<then>
+								<local name="legacy.database.dump.extension" />
+
+								<if>
+									<equals arg1="${database.type}" arg2="oracle" />
+									<then>
+										<property name="legacy.database.dump.extension" value="dmp" />
+									</then>
+									<elseif>
+										<equals arg1="${database.type}" arg2="sqlserver" />
+										<then>
+											<property name="legacy.database.dump.extension" value="bak" />
+										</then>
+									</elseif>
+									<else>
+										<property name="legacy.database.dump.extension" value="sql" />
+									</else>
+								</if>
+
+								<local name="legacy.database.dump.count" />
+
+								<resourcecount property="legacy.database.dump.count">
+									<fileset
+										dir="${legacy.database.temp.dir}"
+										includes="*"
+									>
+										<type type="file" />
+									</fileset>
+								</resourcecount>
+
+								<local name="legacy.database.dump.ext.count" />
+
+								<resourcecount property="legacy.database.dump.ext.count">
+									<fileset
+										dir="${legacy.database.temp.dir}"
+										includes="*.${legacy.database.dump.extension}"
+									>
+										<type type="file" />
+									</fileset>
+								</resourcecount>
+
+								<local name="legacy.database.dump.includes" />
+
+								<if>
+									<equals arg1="${legacy.database.dump.count}" arg2="1" />
+									<then>
+										<property name="legacy.database.dump.includes" value="*" />
+									</then>
+									<elseif>
+										<equals arg1="${legacy.database.dump.ext.count}" arg2="1" />
+										<then>
+											<property name="legacy.database.dump.includes" value="*.${legacy.database.dump.extension}" />
+										</then>
+									</elseif>
+									<else>
+										<fail message="Unable to identify the database dump file in ${legacy.database.file}." />
+									</else>
+								</if>
+
+								<local name="legacy.database.dump.file" />
+
+								<pathconvert property="legacy.database.dump.file">
+									<fileset
+										dir="${legacy.database.temp.dir}"
+										includes="${legacy.database.dump.includes}"
+									>
+										<type type="file" />
+									</fileset>
+								</pathconvert>
+
+								<move
+									file="${legacy.database.dump.file}"
+									tofile="${liferay.home}/${database.type}.${legacy.database.dump.extension}"
+								/>
+							</then>
+						</if>
+
+						<move
+							todir="${liferay.home}"
+						>
+							<fileset
+								dir="${legacy.database.temp.dir}"
+							/>
+						</move>
+					</try>
+					<finally>
+						<delete dir="${legacy.database.temp.dir}" />
+					</finally>
+				</trycatch>
 			</then>
+			<elseif>
+				<contains string="${data.archive.type}" substring="partition-large" />
+				<then>
+					<mirrors-get
+						dest="${liferay.home}"
+						src="http://files.liferay.com/mirrors/data-archive-portal-partition-large.zip"
+					/>
+
+					<unzip
+						dest="${liferay.home}"
+						src="${liferay.home}/data-archive-portal-partition-large.zip"
+					/>
+
+					<delete file="${liferay.home}/data-archive-portal-partition-large.zip" />
+				</then>
+			</elseif>
 			<else>
 				<unzip
 					dest="${liferay.home}"
@@ -17088,12 +17234,16 @@ sendBlacklist=[]
 			</then>
 		</if>
 
+		<get-testcase-property property.name="legacy.database.file" />
 		<get-testcase-property property.name="portal.version" />
 		<get-testcase-property property.name="rebuild.staging.database" />
 		<get-testcase-property property.name="skip.upgrade-legacy-database" />
 
 		<if>
-			<isset property="portal.version" />
+			<or>
+				<isset property="legacy.database.file" />
+				<isset property="portal.version" />
+			</or>
 			<then>
 				<antcall target="rebuild-legacy-database" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -15663,6 +15663,18 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 		<if>
 			<isset property="legacy.database.file" />
 			<then>
+				<for param="legacy.database.leftover.dir">
+					<path>
+						<dirset
+							dir="${liferay.home}"
+							includes="legacy-database-*"
+						/>
+					</path>
+					<sequential>
+						<delete dir="@{legacy.database.leftover.dir}" />
+					</sequential>
+				</for>
+
 				<local name="legacy.database.temp.dir" />
 
 				<tempfile destdir="${liferay.home}" prefix="legacy-database-" property="legacy.database.temp.dir" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -211,7 +211,7 @@ passwords.encryption.algorithm=NONE</echo>
 			<basename file="@{src}" property="archive.basename" />
 
 			<if>
-				<matches pattern=".*\.7z$" string="${archive.basename}" />
+				<matches casesensitive="false" pattern=".*\.7z$" string="${archive.basename}" />
 				<then>
 					<if>
 						<os family="mac" />
@@ -232,7 +232,7 @@ passwords.encryption.algorithm=NONE</echo>
 					</if>
 				</then>
 				<elseif>
-					<matches pattern=".*\.tar\.gz$" string="${archive.basename}" />
+					<matches casesensitive="false" pattern=".*\.tar\.gz$" string="${archive.basename}" />
 					<then>
 						<execute>
 							<![CDATA[
@@ -244,7 +244,7 @@ passwords.encryption.algorithm=NONE</echo>
 					</then>
 				</elseif>
 				<elseif>
-					<matches pattern=".*\.zip$" string="${archive.basename}" />
+					<matches casesensitive="false" pattern=".*\.zip$" string="${archive.basename}" />
 					<then>
 						<execute>
 							<![CDATA[
@@ -15672,10 +15672,9 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 				<trycatch>
 					<try>
 						<if>
-							<matches casesensitive="false" pattern=".*\.tar\.gz$" string="${legacy.database.file}" />
+							<matches casesensitive="false" pattern=".*\.(7z|tar\.gz|zip)$" string="${legacy.database.file}" />
 							<then>
-								<untar
-									compression="gzip"
+								<decompress
 									dest="${legacy.database.temp.dir}"
 									src="${legacy.database.file}"
 								/>
@@ -15684,15 +15683,6 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<matches casesensitive="false" pattern=".*\.gz$" string="${legacy.database.file}" />
 								<then>
 									<gunzip
-										dest="${legacy.database.temp.dir}"
-										src="${legacy.database.file}"
-									/>
-								</then>
-							</elseif>
-							<elseif>
-								<matches casesensitive="false" pattern=".*\.zip$" string="${legacy.database.file}" />
-								<then>
-									<unzip
 										dest="${legacy.database.temp.dir}"
 										src="${legacy.database.file}"
 									/>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87736

**What is being fixed:** The `rebuild-legacy-database` target in `build-test.xml` could only import a database dump from a fixed location under `${portal.legacy.dir}/${portal.version}/data-archive/${data.archive.type}-${database.type}.zip`.

**How it is being fixed:** A new `legacy.database.file` testcase property lets the target import a dump from any path on disk. Accepted input shapes are `.gz`, `.zip` / `.tar.gz` / `.7z`, or a raw dump file, across all five supported database types: mariadb/mysql/postgresql (`.sql`), oracle (`.dmp`), sqlserver (`.bak`), and db2 (directory of restore files). The input is extracted to a `<tempfile>` directory under `${liferay.home}`, wrapped in `<trycatch><finally>` so the temp dir is always cleaned up. For non-db2 types, a two-pass detection picks the canonical dump file: if the temp dir has exactly one file at the root, that file is renamed (covers gunzip with arbitrary inner names); otherwise the single `*.<ext>` match is renamed. Sibling content such as a `data/` folder is then moved into `${liferay.home}` so downstream cleanup logic still works.