### PR TITLE
LPD-88096 Improve UpgradeReport date and time formatting

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -753,10 +753,16 @@ public class UpgradeReport {
 		File reportFile = new File(reportsDir, reportFileName);
 
 		if (reportFile.exists()) {
+			SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
+				"yyyyMMdd_HHmmss", LocaleUtil.US);
+
+			simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+			String timestamp = simpleDateFormat.format(
+				new Date(reportFile.lastModified()));
+
 			reportFile.renameTo(
-				new File(
-					reportsDir,
-					reportFileName + "." + reportFile.lastModified()));
+				new File(reportsDir, reportFileName + "." + timestamp));
 
 			reportFile = new File(reportsDir, reportFileName);
 		}

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -112,8 +112,7 @@ public class UpgradeReport {
 		}
 
 		_executionDateString = _getExecutionDateString();
-		_executionTimeString =
-			(DBUpgrader.getUpgradeTime() / Time.SECOND) + " seconds";
+		_executionTimeString = _getExecutionTimeString();
 		_rootDir = _getRootDir();
 
 		Map<String, Object> reportData = _getReportData(upgradeRecorder);
@@ -150,6 +149,47 @@ public class UpgradeReport {
 		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
 		return simpleDateFormat.format(new Date());
+	}
+
+	private String _getExecutionTimeString() {
+		long upgradeTime = DBUpgrader.getUpgradeTime();
+
+		List<String> parts = new ArrayList<>();
+
+		long hours = upgradeTime / Time.HOUR;
+
+		if (hours > 0) {
+			parts.add(
+				hours + " hour" + ((hours == 1) ? StringPool.BLANK : "s"));
+		}
+
+		long minutes = (upgradeTime % Time.HOUR) / Time.MINUTE;
+
+		if (minutes > 0) {
+			parts.add(
+				minutes + " minute" +
+					((minutes == 1) ? StringPool.BLANK : "s"));
+		}
+
+		long totalSeconds = upgradeTime / Time.SECOND;
+
+		if (parts.isEmpty()) {
+			return totalSeconds + " second" +
+				((totalSeconds == 1) ? StringPool.BLANK : "s");
+		}
+
+		long seconds = (upgradeTime % Time.MINUTE) / Time.SECOND;
+
+		if (seconds > 0) {
+			parts.add(
+				seconds + " second" +
+					((seconds == 1) ? StringPool.BLANK : "s"));
+		}
+
+		return StringBundler.concat(
+			totalSeconds, " seconds (",
+			StringUtil.merge(parts, StringPool.SPACE),
+			StringPool.CLOSE_PARENTHESIS);
 	}
 
 	private List<MessagesPrinter> _getMessagesPrinters(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -61,10 +61,10 @@ import java.sql.SQLException;
 import java.text.SimpleDateFormat;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
@@ -145,13 +145,11 @@ public class UpgradeReport {
 
 	private String _getExecutionDateString() {
 		SimpleDateFormat simpleDateFormat = new SimpleDateFormat(
-			"EEE, MMM dd, yyyy hh:mm:ss z");
+			"EEE, MMM dd, yyyy HH:mm:ss z", LocaleUtil.US);
 
 		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-		Calendar calendar = Calendar.getInstance();
-
-		return simpleDateFormat.format(calendar.getTime());
+		return simpleDateFormat.format(new Date());
 	}
 
 	private List<MessagesPrinter> _getMessagesPrinters(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88096

**What is being fixed:** The upgrade report header used a 12-hour clock pattern, so any UTC time at or after noon was silently shown shifted by 12 hours; the execution time was printed as bare seconds (hard to read for long upgrades); and previously rotated reports were renamed using raw epoch milliseconds, producing filenames like `upgrade_report.txt.1745934512000` that were neither human-readable nor sortable.

**How it is being fixed:** The execution date now uses the 24-hour pattern `HH` and pins the locale to `LocaleUtil.US` so `EEE`/`MMM` render in English. The execution time keeps the raw seconds value but appends a parenthesized hours/minutes/seconds breakdown, omitting any unit that is zero (for example `10800 seconds (3 hours)`, `91815 seconds (25 hours 30 minutes 15 seconds)`). The rotated report filename now uses a `yyyyMMdd_HHmmss` UTC timestamp instead of raw `lastModified()` milliseconds.