### PR TITLE
LPD-84024 / LPD-84025 Add Locked Query Monitoring API + MySQL impl

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.dao.db.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -14,12 +15,16 @@ import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ObjectValuePair;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -32,6 +37,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -641,6 +648,82 @@ public class DBTest {
 	}
 
 	@Test
+	public void testGetLockedQueryInfos() throws Exception {
+		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+
+		db.runSQL(
+			"insert into " + TABLE_NAME_1 +
+				" (id, notNilColumn) values (1, '1')");
+
+		FutureTask<Void> futureTask = null;
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L);
+			Connection lockingConnection = DataAccess.getConnection()) {
+
+			lockingConnection.setAutoCommit(false);
+
+			db.runSQL(
+				lockingConnection,
+				"update " + TABLE_NAME_1 +
+					" set nilColumn = 'locked' where id = 1");
+
+			futureTask = new FutureTask<>(
+				() -> {
+					db.runSQL(
+						connection,
+						"update " + TABLE_NAME_1 +
+							" set nilColumn = 'waiting' where id = 1");
+
+					return null;
+				});
+
+			Thread thread = new Thread(futureTask);
+
+			thread.setDaemon(true);
+
+			thread.start();
+
+			long endTime = System.currentTimeMillis() + 5000;
+
+			while (System.currentTimeMillis() < endTime) {
+				for (DB.QueryInfo lockedQueryInfo :
+						db.getLockedQueryInfos(lockingConnection)) {
+
+					String query = lockedQueryInfo.getQuery();
+
+					if ((query != null) && query.contains("waiting")) {
+						Assert.assertNotNull(lockedQueryInfo.getId());
+						Assert.assertNotNull(lockedQueryInfo.getSchema());
+						Assert.assertTrue(
+							StringUtil.containsIgnoreCase(
+								lockedQueryInfo.getState(), "LOCK WAIT"));
+
+						return;
+					}
+				}
+
+				Thread.sleep(200);
+			}
+
+			Assert.fail(
+				"No locked query containing \"waiting\" was detected within " +
+					"5 seconds");
+		}
+		finally {
+			if (futureTask != null) {
+				try {
+					futureTask.get(5, TimeUnit.SECONDS);
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+				}
+			}
+		}
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		db.runSQL(_SQL_CREATE_TABLE_2);
 
@@ -673,9 +756,6 @@ public class DBTest {
 			connection, new ObjectValuePair<>(TABLE_NAME_1, _TABLE_NAME_3),
 			new ObjectValuePair<>(_TABLE_NAME_2, TABLE_NAME_1),
 			new ObjectValuePair<>(_TABLE_NAME_3, _TABLE_NAME_2));
-
-		Assert.assertTrue(dbInspector.hasTable(TABLE_NAME_1));
-		Assert.assertTrue(dbInspector.hasTable(_TABLE_NAME_2));
 
 		Assert.assertTrue(dbInspector.hasColumn(TABLE_NAME_1, "id1"));
 		Assert.assertTrue(dbInspector.hasColumn(_TABLE_NAME_2, "id"));
@@ -996,5 +1076,7 @@ public class DBTest {
 	private static final String _TABLE_NAME_2 = "DBTest2";
 
 	private static final String _TABLE_NAME_3 = "DBTest3";
+
+	private static final Log _log = LogFactoryUtil.getLog(DBTest.class);
 
 }

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -707,9 +707,7 @@ public class DBTest {
 				Thread.sleep(200);
 			}
 
-			Assert.fail(
-				"No locked query containing \"waiting\" was detected within " +
-					"5 seconds");
+			Assert.fail();
 		}
 		finally {
 			if (futureTask != null) {

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,6 +29,7 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -148,6 +149,47 @@ public class MySQLDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		String sql = StringBundler.concat(
+			"select p.id as id, p.db as schema_, p.time as duration, ",
+			"coalesce(t.trx_state, p.state) as state, p.info as query from ",
+			"information_schema.processlist p left join ",
+			"information_schema.innodb_trx t on p.id = t.trx_mysql_thread_id ",
+			"where p.command != 'Sleep' and p.info is not null and p.id != ",
+			"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
+			"'%lock%') and p.time >= ?)");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			long threshold = (long)Math.ceil(
+				PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000.0);
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+					String id = resultSet.getString("id");
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -158,13 +158,22 @@ public class MySQLDB extends BaseDB {
 		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
 
 		String sql = StringBundler.concat(
-			"select p.id as id, p.db as schema_, p.time as duration, ",
-			"coalesce(t.trx_state, p.state) as state, p.info as query from ",
-			"information_schema.processlist p left join ",
-			"information_schema.innodb_trx t on p.id = t.trx_mysql_thread_id ",
-			"where p.command != 'Sleep' and p.info is not null and p.id != ",
-			"connection_id() and ((t.trx_state = 'LOCK WAIT' or p.state like ",
-			"'%lock%') and p.time >= ?)");
+			"select information_schema.processlist.id as id, ",
+			"information_schema.processlist.db as schema_, ",
+			"information_schema.processlist.time as duration, coalesce(",
+			"information_schema.innodb_trx.trx_state, ",
+			"information_schema.processlist.state) as state, ",
+			"information_schema.processlist.info as query from ",
+			"information_schema.processlist left join ",
+			"information_schema.innodb_trx on ",
+			"information_schema.processlist.id = ",
+			"information_schema.innodb_trx.trx_mysql_thread_id where ",
+			"information_schema.processlist.command != 'Sleep' and ",
+			"information_schema.processlist.info is not null and ",
+			"information_schema.processlist.id != connection_id() and ((",
+			"information_schema.innodb_trx.trx_state = 'LOCK WAIT' or ",
+			"information_schema.processlist.state like '%lock%') and ",
+			"information_schema.processlist.time >= ?)");
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				sql)) {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -227,6 +227,14 @@
     upgrade.log.progress.interval=300000
 
     #
+    # Set the threshold in milliseconds before a query waiting on resources is
+    # flagged as locked.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_LOCK_PERIOD_THRESHOLD
+    #
+    upgrade.query.monitor.lock.threshold=300000
+
+    #
     # Specify the number of seconds that the upgrade report generation will wait
     # for calculating the document library storage size before timing out.
     # Specify 0 to disable the document library storage size calculation.

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -15,6 +15,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -98,6 +99,12 @@ public interface DB {
 	public ResultSet getIndexResultSet(
 			Connection connection, String tableName, boolean onlyUnique)
 		throws SQLException;
+
+	public default List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
+	}
 
 	public int getMajorVersion();
 
@@ -239,5 +246,46 @@ public interface DB {
 			Connection connection, String tableName,
 			String[] primaryKeyColumnNames)
 		throws Exception;
+
+	public static class QueryInfo {
+
+		public QueryInfo(
+			long duration, String id, String query, String schema,
+			String state) {
+
+			_duration = duration;
+			_id = id;
+			_query = query;
+			_schema = schema;
+			_state = state;
+		}
+
+		public long getDuration() {
+			return _duration;
+		}
+
+		public String getId() {
+			return _id;
+		}
+
+		public String getQuery() {
+			return _query;
+		}
+
+		public String getSchema() {
+			return _schema;
+		}
+
+		public String getState() {
+			return _state;
+		}
+
+		private final long _duration;
+		private final String _id;
+		private final String _query;
+		private final String _schema;
+		private final String _state;
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 22.0.0
+version 22.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2727,6 +2727,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_PROGRESS_INTERVAL =
 		"upgrade.log.progress.interval";
 
+	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		"upgrade.query.monitor.lock.threshold";
+
 	public static final String UPGRADE_REPORT_DIR = "upgrade.report.dir";
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2390,6 +2390,11 @@ public class PropsValues {
 	public static final long UPGRADE_LOG_PROGRESS_INTERVAL = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.UPGRADE_LOG_PROGRESS_INTERVAL));
 
+	public static final long UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
+		GetterUtil.getLong(
+			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),
+			300000);
+
 	public static final String UPGRADE_REPORT_DIR = GetterUtil.getString(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIR));
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 97.1.0
+version 97.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84024
https://liferay.atlassian.net/browse/LPD-84025

previous pr:
https://github.com/brianchandotcom/liferay-portal/pull/173883


> Is there any other QueryInfo that is not locked?

The class is shared with the long-running query detection coming in subtask LPD-84035 of epic LPD-83885. The epic defines two monitoring paths over the same record shape (schema, duration, query text, session ID) — locked queries and long-running queries.

> That you need to know the duration of?

The duration filter is in the SQL itself (`time >= ?` against the configured threshold), so callers only receive queries already past it. duration is exposed on the record for diagnostics — the upgrade logger needs the actual elapsed time so the WARN/INFO message can report "waiting on a lock for X ms" / "running for X ms". Same shape serves both paths.

https://liferay.atlassian.net/browse/LPD-83885
https://liferay.atlassian.net/browse/LPD-84035