### PR TITLE
LPD-87737 Support custom.<db>.sql.statement for all databases

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16140,22 +16140,6 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 						docker exec ${database.host} /bin/bash /tmp/import-database.sh
 					]]>
 				</execute>
-
-				<get-testcase-property property.name="custom.mysql.sql.statement" />
-
-				<if>
-					<and>
-						<equals arg1="${database.type}" arg2="mysql" />
-						<isset property="custom.mysql.sql.statement" />
-					</and>
-					<then>
-						<sql classpath="${app.server.shielded-container-lib.portal.dir}/${jdbc.mysql.driver}" driver="${database.mysql.driver}" onerror="continue" output="output.txt" password="${database.mysql.password}" print="true" url="${database.mysql.url}" userid="${database.mysql.username}">
-							<![CDATA[
-								${custom.mysql.sql.statement}
-							]]>
-						</sql>
-					</then>
-				</if>
 			</then>
 			<else>
 				<if>
@@ -16258,22 +16242,6 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 									<exec executable="mysql_upgrade" />
 								</then>
 							</if>
-
-							<get-testcase-property property.name="custom.mysql.sql.statement" />
-
-							<if>
-								<and>
-									<equals arg1="${database.type}" arg2="mysql" />
-									<isset property="custom.mysql.sql.statement" />
-								</and>
-								<then>
-									<sql classpath="${app.server.shielded-container-lib.portal.dir}/${jdbc.mysql.driver}" driver="${database.mysql.driver}" onerror="continue" output="output.txt" password="${database.mysql.password}" print="true" url="${database.mysql.url}" userid="${database.mysql.username}">
-										<![CDATA[
-											${custom.mysql.sql.statement}
-										]]>
-									</sql>
-								</then>
-							</if>
 						</then>
 					</elseif>
 					<elseif>
@@ -16347,6 +16315,35 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					</elseif>
 				</if>
 			</else>
+		</if>
+
+		<get-testcase-property property.name="custom.${database.type}.sql.statement" />
+
+		<local name="custom.sql.statement" />
+
+		<propertycopy from="custom.${database.type}.sql.statement" name="custom.sql.statement" silent="true" />
+
+		<if>
+			<isset property="custom.sql.statement" />
+			<then>
+				<local name="custom.sql.driver" />
+				<local name="custom.sql.driver.jar" />
+				<local name="custom.sql.password" />
+				<local name="custom.sql.url" />
+				<local name="custom.sql.username" />
+
+				<propertycopy from="jdbc.${database.type}.driver" name="custom.sql.driver.jar" silent="true" />
+				<propertycopy from="database.${database.type}.driver" name="custom.sql.driver" silent="true" />
+				<propertycopy from="database.${database.type}.password" name="custom.sql.password" silent="true" />
+				<propertycopy from="database.${database.type}.url" name="custom.sql.url" silent="true" />
+				<propertycopy from="database.${database.type}.username" name="custom.sql.username" silent="true" />
+
+				<sql classpath="${app.server.shielded-container-lib.portal.dir}/${custom.sql.driver.jar}" driver="${custom.sql.driver}" onerror="continue" output="output.txt" password="${custom.sql.password}" print="true" url="${custom.sql.url}" userid="${custom.sql.username}">
+					<![CDATA[
+						${custom.sql.statement}
+					]]>
+				</sql>
+			</then>
 		</if>
 
 		<delete file="sql/create-bare/create-bare-mysql-utf8mb3.sql" quiet="true" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -16313,6 +16313,26 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 							</exec>
 						</then>
 					</elseif>
+					<elseif>
+						<equals arg1="${database.type}" arg2="sqlserver" />
+						<then>
+							<get-database-property property.name="database.host" />
+							<get-database-property property.name="database.password" />
+							<get-database-property property.name="database.schema" />
+							<get-database-property property.name="database.username" />
+
+							<exec executable="${database.sqlserver.executable}" failonerror="true">
+								<arg value="-P" />
+								<arg value="${database.password}" />
+								<arg value="-Q" />
+								<arg value="RESTORE DATABASE ${database.schema} FROM DISK='${liferay.home}/${database.type}.bak'" />
+								<arg value="-S" />
+								<arg value="${database.host}" />
+								<arg value="-U" />
+								<arg value="${database.username}" />
+							</exec>
+						</then>
+					</elseif>
 				</if>
 			</else>
 		</if>

--- a/build-test.xml
+++ b/build-test.xml
@@ -16358,11 +16358,24 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 				<propertycopy from="database.${database.type}.url" name="custom.sql.url" silent="true" />
 				<propertycopy from="database.${database.type}.username" name="custom.sql.username" silent="true" />
 
-				<sql classpath="${app.server.shielded-container-lib.portal.dir}/${custom.sql.driver.jar}" driver="${custom.sql.driver}" onerror="continue" output="output.txt" password="${custom.sql.password}" print="true" url="${custom.sql.url}" userid="${custom.sql.username}">
-					<![CDATA[
-						${custom.sql.statement}
-					]]>
-				</sql>
+				<delete failonerror="false" file="output.txt" />
+
+				<for delimiter="${line.separator}" list="${custom.sql.statement}" param="sql.statement">
+					<sequential>
+						<if>
+							<not>
+								<equals arg1="@{sql.statement}" arg2="" trim="true" />
+							</not>
+							<then>
+								<sql append="true" classpath="${app.server.shielded-container-lib.portal.dir}/${custom.sql.driver.jar}" driver="${custom.sql.driver}" onerror="continue" output="output.txt" password="${custom.sql.password}" print="true" url="${custom.sql.url}" userid="${custom.sql.username}">
+									<![CDATA[
+										@{sql.statement}
+									]]>
+								</sql>
+							</then>
+						</if>
+					</sequential>
+				</for>
 			</then>
 		</if>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87737

## What is being fixed

The `rebuild-legacy-database` ant target only invoked
`custom.mysql.sql.statement` after restoring the database. Custom SQL
statements for the other supported databases (PostgreSQL, DB2, Oracle,
SQL Server) were never executed, so tests needing pre-upgrade SQL
adjustments only worked against MySQL.

## How it is being fixed

The first commit replaces the MySQL-only blocks with a unified
`custom.${database.type}.sql.statement` invocation that runs after
either the docker or non-docker restore branch finishes. The dynamic
property name is dereferenced through `<propertycopy>` since Ant does
not resolve nested `${}` references.

The second commit adds a `sqlserver` elseif to the non-docker restore
branch — previously absent — so the unified custom SQL block has a
place to run after a SQL Server restore. The third commit splits the
custom SQL on `${line.separator}` and runs the statements one at a
time, so a multi-statement value executes correctly and any failure
isolates to the offending statement.