### PR TITLE
LPD-84025 Implement DB Locked Query Detection for the other DBs

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -651,9 +651,7 @@ public class DBTest {
 	public void testGetLockedQueryInfos() throws Exception {
 		DBType dbType = db.getDBType();
 
-		Assume.assumeTrue(
-			(dbType == DBType.DB2) || (dbType == DBType.MARIADB) ||
-			(dbType == DBType.MYSQL) || (dbType == DBType.SQLSERVER));
+		Assume.assumeTrue(dbType != DBType.HYPERSONIC);
 
 		db.runSQL(
 			"insert into " + TABLE_NAME_1 +
@@ -701,23 +699,22 @@ public class DBTest {
 						Assert.assertNotNull(lockedQueryInfo.getId());
 						Assert.assertNotNull(lockedQueryInfo.getSchema());
 
-						String upperCaseState = StringUtil.toUpperCase(
-							lockedQueryInfo.getState());
+						String state = lockedQueryInfo.getState();
 
 						if (dbType == DBType.DB2) {
 							Assert.assertTrue(
-								upperCaseState.equals("LOCKWAIT") ||
-								upperCaseState.equals("UOWEXEC"));
+								StringUtil.equalsIgnoreCase(state, "LOCKWAIT"));
 						}
 						else if ((dbType == DBType.MARIADB) ||
 								 (dbType == DBType.MYSQL)) {
 
 							Assert.assertTrue(
-								upperCaseState.contains("LOCK WAIT"));
+								StringUtil.containsIgnoreCase(
+									state, "LOCK WAIT"));
 						}
 						else if (dbType == DBType.SQLSERVER) {
 							Assert.assertTrue(
-								upperCaseState.startsWith("LCK_"));
+								StringUtil.startsWith(state, "LCK_"));
 						}
 
 						return;

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -649,7 +649,11 @@ public class DBTest {
 
 	@Test
 	public void testGetLockedQueryInfos() throws Exception {
-		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+		DBType dbType = db.getDBType();
+
+		Assume.assumeTrue(
+			(dbType == DBType.DB2) || (dbType == DBType.MARIADB) ||
+			(dbType == DBType.MYSQL) || (dbType == DBType.SQLSERVER));
 
 		db.runSQL(
 			"insert into " + TABLE_NAME_1 +
@@ -696,9 +700,25 @@ public class DBTest {
 					if ((query != null) && query.contains("waiting")) {
 						Assert.assertNotNull(lockedQueryInfo.getId());
 						Assert.assertNotNull(lockedQueryInfo.getSchema());
-						Assert.assertTrue(
-							StringUtil.containsIgnoreCase(
-								lockedQueryInfo.getState(), "LOCK WAIT"));
+
+						String upperCaseState = StringUtil.toUpperCase(
+							lockedQueryInfo.getState());
+
+						if (dbType == DBType.DB2) {
+							Assert.assertTrue(
+								upperCaseState.equals("LOCKWAIT") ||
+								upperCaseState.equals("UOWEXEC"));
+						}
+						else if ((dbType == DBType.MARIADB) ||
+								 (dbType == DBType.MYSQL)) {
+
+							Assert.assertTrue(
+								upperCaseState.contains("LOCK WAIT"));
+						}
+						else if (dbType == DBType.SQLSERVER) {
+							Assert.assertTrue(
+								upperCaseState.startsWith("LCK_"));
+						}
 
 						return;
 					}

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -37,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author Alexander Chow
@@ -223,53 +221,6 @@ public class DB2DB extends BaseDB {
 		}
 
 		return StringPool.BLANK;
-	}
-
-	@Override
-	public List<QueryInfo> getLockedQueryInfos(Connection connection)
-		throws SQLException {
-
-		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
-
-		String sql = StringBundler.concat(
-			"select timestampdiff(2, char(current timestamp - ",
-			"unit_of_work.uow_start_time)) as duration, ",
-			"sysibmadm.applications.agent_id as id, cast(activity.stmt_text ",
-			"as varchar(1000)) as query, sysibmadm.applications.db_name as ",
-			"schema_, sysibmadm.applications.appl_status as state from ",
-			"sysibmadm.applications join table(sysproc.mon_get_unit_of_work(",
-			"null, -2)) as unit_of_work on sysibmadm.applications.agent_id = ",
-			"unit_of_work.application_handle left join table(",
-			"sysproc.mon_get_activity(null, -2)) as activity on ",
-			"sysibmadm.applications.agent_id = activity.application_handle ",
-			"where sysibmadm.applications.agent_id != ",
-			"mon_get_application_handle() and ",
-			"sysibmadm.applications.appl_status in ('LOCKWAIT', 'UOWEXEC') ",
-			"and timestampdiff(2, char(current timestamp - ",
-			"unit_of_work.uow_start_time)) >= ?");
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(
-				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-					String id = resultSet.getString("id");
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					lockedQueryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueryInfos;
 	}
 
 	@Override
@@ -479,6 +430,26 @@ public class DB2DB extends BaseDB {
 		return StringBundler.concat(
 			"create table ", newTableName, " as (select * from ", tableName,
 			") with no data");
+	}
+
+	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select timestampdiff(2, char(current timestamp - ",
+			"unit_of_work.uow_start_time)) * 1000 as duration, ",
+			"sysibmadm.applications.agent_id as id, cast(activity.stmt_text ",
+			"as varchar(4000)) as query, sysibmadm.applications.db_name as ",
+			"schema_, sysibmadm.applications.appl_status as state from ",
+			"sysibmadm.applications join table(sysproc.mon_get_unit_of_work(",
+			"null, -2)) as unit_of_work on sysibmadm.applications.agent_id = ",
+			"unit_of_work.application_handle left join table(",
+			"sysproc.mon_get_activity(null, -2)) as activity on ",
+			"sysibmadm.applications.agent_id = activity.application_handle ",
+			"where sysibmadm.applications.agent_id != ",
+			"mon_get_application_handle() and ",
+			"sysibmadm.applications.appl_status = 'LOCKWAIT' and ",
+			"timestampdiff(2, char(current timestamp - ",
+			"unit_of_work.uow_start_time)) * 1000 >= ?");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -36,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Alexander Chow
@@ -221,6 +223,53 @@ public class DB2DB extends BaseDB {
 		}
 
 		return StringPool.BLANK;
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		String sql = StringBundler.concat(
+			"select timestampdiff(2, char(current timestamp - ",
+			"unit_of_work.uow_start_time)) as duration, ",
+			"sysibmadm.applications.agent_id as id, cast(activity.stmt_text ",
+			"as varchar(1000)) as query, sysibmadm.applications.db_name as ",
+			"schema_, sysibmadm.applications.appl_status as state from ",
+			"sysibmadm.applications join table(sysproc.mon_get_unit_of_work(",
+			"null, -2)) as unit_of_work on sysibmadm.applications.agent_id = ",
+			"unit_of_work.application_handle left join table(",
+			"sysproc.mon_get_activity(null, -2)) as activity on ",
+			"sysibmadm.applications.agent_id = activity.application_handle ",
+			"where sysibmadm.applications.agent_id != ",
+			"mon_get_application_handle() and ",
+			"sysibmadm.applications.appl_status in ('LOCKWAIT', 'UOWEXEC') ",
+			"and timestampdiff(2, char(current timestamp - ",
+			"unit_of_work.uow_start_time)) >= ?");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(
+				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+					String id = resultSet.getString("id");
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -36,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -195,46 +193,6 @@ public class OracleDB extends BaseDB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, true);
-	}
-
-	@Override
-	public List<QueryInfo> getLockedQueryInfos(Connection connection)
-		throws SQLException {
-
-		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
-
-		String sql = StringBundler.concat(
-			"select v$session.last_call_et as duration, v$session.sid as id, ",
-			"cast(v$sql.sql_fulltext as varchar2(1000)) as query, ",
-			"v$session.schemaname as schema_, v$session.event as state from ",
-			"v$session left join v$sql on v$session.sql_id = v$sql.sql_id ",
-			"where v$session.audsid != sys_context('USERENV', 'SESSIONID') ",
-			"and v$session.last_call_et >= ? and v$session.status = 'ACTIVE' ",
-			"and v$session.type = 'USER' and (v$session.event like 'enq:%' or ",
-			"v$session.event like '%library cache%')");
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(
-				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-					String id = resultSet.getString("id");
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					lockedQueryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueryInfos;
 	}
 
 	@Override
@@ -416,6 +374,20 @@ public class OracleDB extends BaseDB {
 		}
 
 		runSQL(connection, sb.toString());
+	}
+
+	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select v$session.last_call_et * 1000 as duration, v$session.sid ",
+			"as id, dbms_lob.substr(v$sql.sql_fulltext, 4000, 1) as query, ",
+			"v$session.schemaname as schema_, v$session.event as state from ",
+			"v$session left join v$sql on v$session.sql_id = v$sql.sql_id and ",
+			"v$session.sql_child_number = v$sql.child_number where ",
+			"v$session.audsid != sys_context('USERENV', 'SESSIONID') and ",
+			"v$session.last_call_et * 1000 >= ? and v$session.status = ",
+			"'ACTIVE' and v$session.type = 'USER' and (v$session.event like ",
+			"'enq:%' or v$session.event like '%library cache%')");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -193,6 +195,46 @@ public class OracleDB extends BaseDB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, true);
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		String sql = StringBundler.concat(
+			"select v$session.last_call_et as duration, v$session.sid as id, ",
+			"cast(v$sql.sql_fulltext as varchar2(1000)) as query, ",
+			"v$session.schemaname as schema_, v$session.event as state from ",
+			"v$session left join v$sql on v$session.sql_id = v$sql.sql_id ",
+			"where v$session.audsid != sys_context('USERENV', 'SESSIONID') ",
+			"and v$session.last_call_et >= ? and v$session.status = 'ACTIVE' ",
+			"and v$session.type = 'USER' and (v$session.event like 'enq:%' or ",
+			"v$session.event like '%library cache%')");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(
+				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+					String id = resultSet.getString("id");
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -31,7 +30,6 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -165,48 +163,6 @@ public class SQLServerDB extends BaseDB {
 		}
 
 		return indexes;
-	}
-
-	@Override
-	public List<QueryInfo> getLockedQueryInfos(Connection connection)
-		throws SQLException {
-
-		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
-
-		String sql = StringBundler.concat(
-			"select sys.dm_exec_requests.total_elapsed_time / 1000 as ",
-			"duration, sys.dm_exec_requests.session_id as id, sql_text.text ",
-			"as query, db_name(sys.dm_exec_requests.database_id) as schema_, ",
-			"sys.dm_exec_requests.wait_type as state from ",
-			"sys.dm_exec_requests cross apply sys.dm_exec_sql_text(",
-			"sys.dm_exec_requests.sql_handle) as sql_text where ",
-			"sys.dm_exec_requests.session_id != @@spid and ",
-			"sys.dm_exec_requests.session_id >= 50 and ",
-			"sys.dm_exec_requests.total_elapsed_time / 1000 >= ? and ",
-			"sys.dm_exec_requests.wait_type like 'LCK\\_%' escape '\\'");
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(
-				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-					String id = resultSet.getString("id");
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					lockedQueryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueryInfos;
 	}
 
 	@Override
@@ -487,6 +443,21 @@ public class SQLServerDB extends BaseDB {
 		return StringBundler.concat(
 			"select * into ", newTableName, " from ", tableName,
 			" where 1 = 0");
+	}
+
+	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select sys.dm_exec_requests.total_elapsed_time as duration, ",
+			"sys.dm_exec_requests.session_id as id, substring(sql_text.text, ",
+			"1, 4000) as query, db_name(sys.dm_exec_requests.database_id) as ",
+			"schema_, sys.dm_exec_requests.wait_type as state from ",
+			"sys.dm_exec_requests cross apply sys.dm_exec_sql_text(",
+			"sys.dm_exec_requests.sql_handle) as sql_text where ",
+			"sys.dm_exec_requests.session_id != @@spid and ",
+			"sys.dm_exec_requests.session_id >= 50 and ",
+			"sys.dm_exec_requests.total_elapsed_time >= ? and ",
+			"sys.dm_exec_requests.wait_type like 'LCK\\_%' escape '\\'");
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -30,6 +31,7 @@ import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -163,6 +165,48 @@ public class SQLServerDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		String sql = StringBundler.concat(
+			"select sys.dm_exec_requests.total_elapsed_time / 1000 as ",
+			"duration, sys.dm_exec_requests.session_id as id, sql_text.text ",
+			"as query, db_name(sys.dm_exec_requests.database_id) as schema_, ",
+			"sys.dm_exec_requests.wait_type as state from ",
+			"sys.dm_exec_requests cross apply sys.dm_exec_sql_text(",
+			"sys.dm_exec_requests.sql_handle) as sql_text where ",
+			"sys.dm_exec_requests.session_id != @@spid and ",
+			"sys.dm_exec_requests.session_id >= 50 and ",
+			"sys.dm_exec_requests.total_elapsed_time / 1000 >= ? and ",
+			"sys.dm_exec_requests.wait_type like 'LCK\\_%' escape '\\'");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(
+				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+					String id = resultSet.getString("id");
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -542,6 +543,41 @@ public abstract class BaseDB implements DB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, false);
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		String sql = getLockedQueryInfosSQL();
+
+		if (sql == null) {
+			return Collections.emptyList();
+		}
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(
+				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					long duration = resultSet.getLong("duration");
+					String id = resultSet.getString("id");
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override
@@ -1505,6 +1541,10 @@ public abstract class BaseDB implements DB {
 
 	protected String getIndexColumnName(String indexColumnName) {
 		return indexColumnName;
+	}
+
+	protected String getLockedQueryInfosSQL() {
+		return null;
 	}
 
 	protected String getRenameTableSQL(

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,7 +29,6 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -152,54 +151,6 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
-	public List<QueryInfo> getLockedQueryInfos(Connection connection)
-		throws SQLException {
-
-		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
-
-		String sql = StringBundler.concat(
-			"select information_schema.processlist.time as duration, ",
-			"information_schema.processlist.id as id, ",
-			"information_schema.processlist.info as query, ",
-			"information_schema.processlist.db as schema_, ",
-			"coalesce(information_schema.innodb_trx.trx_state, ",
-			"information_schema.processlist.state) as state from ",
-			"information_schema.processlist left join ",
-			"information_schema.innodb_trx on ",
-			"information_schema.processlist.id = ",
-			"information_schema.innodb_trx.trx_mysql_thread_id where ",
-			"information_schema.processlist.command != 'Sleep' and ",
-			"information_schema.processlist.id != connection_id() and ",
-			"information_schema.processlist.info is not null and ",
-			"information_schema.processlist.time >= ? and (",
-			"information_schema.innodb_trx.trx_state = 'LOCK WAIT' or ",
-			"information_schema.processlist.state like '%lock%')");
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(
-				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-					String id = resultSet.getString("id");
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					lockedQueryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueryInfos;
-	}
-
-	@Override
 	public String getNewUuidFunctionName() {
 		return "UUID()";
 	}
@@ -266,6 +217,27 @@ public class MySQLDB extends BaseDB {
 		}
 
 		runSQL(connection, sb.toString());
+	}
+
+	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select information_schema.processlist.time * 1000 as duration, ",
+			"information_schema.processlist.id as id, ",
+			"substring(information_schema.processlist.info, 1, 4000) as ",
+			"query, information_schema.processlist.db as schema_, ",
+			"coalesce(information_schema.innodb_trx.trx_state, ",
+			"information_schema.processlist.state) as state from ",
+			"information_schema.processlist left join ",
+			"information_schema.innodb_trx on ",
+			"information_schema.processlist.id = ",
+			"information_schema.innodb_trx.trx_mysql_thread_id where ",
+			"information_schema.processlist.command != 'Sleep' and ",
+			"information_schema.processlist.id != connection_id() and ",
+			"information_schema.processlist.info is not null and ",
+			"information_schema.processlist.time * 1000 >= ? and (",
+			"information_schema.innodb_trx.trx_state = 'LOCK WAIT' or ",
+			"lower(information_schema.processlist.state) like '%lock%')");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -12,7 +12,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -28,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -129,50 +127,6 @@ public class PostgreSQLDB extends BaseDB {
 		}
 
 		return indexes;
-	}
-
-	@Override
-	public List<QueryInfo> getLockedQueryInfos(Connection connection)
-		throws SQLException {
-
-		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
-
-		String sql = StringBundler.concat(
-			"select extract(epoch from (now() - ",
-			"pg_catalog.pg_stat_activity.query_start)) as duration, ",
-			"pg_catalog.pg_stat_activity.pid as id, ",
-			"pg_catalog.pg_stat_activity.query as query, ",
-			"pg_catalog.pg_stat_activity.datname as schema_, ",
-			"pg_catalog.pg_stat_activity.wait_event_type as state from ",
-			"pg_catalog.pg_stat_activity where ",
-			"pg_catalog.pg_stat_activity.pid != pg_backend_pid() and ",
-			"extract(epoch from (now() - ",
-			"pg_catalog.pg_stat_activity.query_start)) >= ? and ",
-			"pg_catalog.pg_stat_activity.state != 'idle' and ",
-			"pg_catalog.pg_stat_activity.wait_event_type = 'Lock'");
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(
-				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-					String id = resultSet.getString("id");
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					lockedQueryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueryInfos;
 	}
 
 	@Override
@@ -374,6 +328,22 @@ public class PostgreSQLDB extends BaseDB {
 	@Override
 	protected String getIndexColumnName(String indexColumnName) {
 		return StringUtil.replaceFirst(indexColumnName, "left\"(", "left(");
+	}
+
+	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select extract(epoch from (now() - ",
+			"pg_catalog.pg_stat_activity.query_start)) * 1000 as duration, ",
+			"pg_catalog.pg_stat_activity.pid as id, ",
+			"substring(pg_catalog.pg_stat_activity.query, 1, 4000) as query, ",
+			"pg_catalog.pg_stat_activity.datname as schema_, ",
+			"pg_catalog.pg_stat_activity.wait_event_type as state from ",
+			"pg_catalog.pg_stat_activity where ",
+			"pg_catalog.pg_stat_activity.pid != pg_backend_pid() and ",
+			"extract(epoch from (now() - ",
+			"pg_catalog.pg_stat_activity.query_start)) * 1000 >= ? and ",
+			"pg_catalog.pg_stat_activity.wait_event_type = 'Lock'");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -12,6 +12,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -127,6 +129,50 @@ public class PostgreSQLDB extends BaseDB {
 		}
 
 		return indexes;
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		String sql = StringBundler.concat(
+			"select extract(epoch from (now() - ",
+			"pg_catalog.pg_stat_activity.query_start)) as duration, ",
+			"pg_catalog.pg_stat_activity.pid as id, ",
+			"pg_catalog.pg_stat_activity.query as query, ",
+			"pg_catalog.pg_stat_activity.datname as schema_, ",
+			"pg_catalog.pg_stat_activity.wait_event_type as state from ",
+			"pg_catalog.pg_stat_activity where ",
+			"pg_catalog.pg_stat_activity.pid != pg_backend_pid() and ",
+			"extract(epoch from (now() - ",
+			"pg_catalog.pg_stat_activity.query_start)) >= ? and ",
+			"pg_catalog.pg_stat_activity.state != 'idle' and ",
+			"pg_catalog.pg_stat_activity.wait_event_type = 'Lock'");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(
+				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					long duration = TimeUnit.SECONDS.toMillis(
+						resultSet.getLong("duration"));
+					String id = resultSet.getString("id");
+					String query = resultSet.getString("query");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84025

**What is being fixed:** The MySQL implementation of locked query detection landed earlier, but the `DB.getLockedQueryInfos` API still returned an empty list for DB2, Oracle, PostgreSQL, and SQL Server. The upcoming polling thread (LPD-84027) needs every vendor to surface lock waits.

**How it is being fixed:** The common JDBC plumbing (prepare the statement, set the threshold, read the standard `duration / id / query / schema_ / state` columns, build `QueryInfo` objects) is consolidated in `BaseDB.getLockedQueryInfos`. Each vendor only overrides `getLockedQueryInfosSQL()` to return its system-view query. PostgreSQL uses `pg_catalog.pg_stat_activity` filtered by `wait_event_type = 'Lock'`. DB2 joins `sysibmadm.applications` with `sysproc.mon_get_unit_of_work` and `sysproc.mon_get_activity` and filters by `appl_status = 'LOCKWAIT'` to match the waiter-only semantics of every other vendor. Oracle left joins `v$session` with `v$sql` and matches events `enq:%` or `%library cache%` within active user sessions. SQL Server cross applies `sys.dm_exec_sql_text` against `sys.dm_exec_requests` and filters by `wait_type like 'LCK\_%'`. MariaDB inherits the MySQL implementation through `MariaDBDB extends MySQLDB`. All vendor SQL emits `duration` in milliseconds. The integration test `DBTest.testGetLockedQueryInfos` runs on DB2, MariaDB, MySQL, and SQL Server with per-vendor assertions on the returned state string; Oracle and PostgreSQL stay excluded by the existing class-level assume.