### PR TITLE
LPD-88624 Capture SQL Server deadlock graphs and harden CI setup

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16130,7 +16130,15 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<![CDATA[
 									#!/bin/bash
 
-									${database.sqlserver.executable} -P ${database.sqlserver.password} -Q "RESTORE DATABASE ${database.sqlserver.schema} FROM DISK='/tmp/${database.type}.bak'" -S localhost -U ${database.sqlserver.username}
+									set -e
+
+									${database.sqlserver.executable} -b -P "${database.sqlserver.password}" -Q "restore database ${database.sqlserver.schema} from disk='/tmp/${database.type}.bak'" -S localhost -U ${database.sqlserver.username}
+
+									${database.sqlserver.executable} -b -P "${database.sqlserver.password}" -Q "alter database ${database.sqlserver.schema} set allow_snapshot_isolation on;" -S localhost -U ${database.sqlserver.username}
+
+									${database.sqlserver.executable} -b -P "${database.sqlserver.password}" -Q "alter database ${database.sqlserver.schema} set read_committed_snapshot on with rollback immediate;" -S localhost -U ${database.sqlserver.username}
+
+									${database.sqlserver.executable} -b -P "${database.sqlserver.password}" -Q "dbcc traceon (1222, -1);" -S localhost -U ${database.sqlserver.username}
 								]]>
 							</echo>
 
@@ -16329,15 +16337,9 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 							<get-database-property property.name="database.schema" />
 							<get-database-property property.name="database.username" />
 
-							<exec executable="${database.sqlserver.executable}" failonerror="true">
-								<arg value="-P" />
-								<arg value="${database.password}" />
-								<arg value="-Q" />
-								<arg value="RESTORE DATABASE ${database.schema} FROM DISK='${liferay.home}/${database.type}.bak'" />
-								<arg value="-S" />
-								<arg value="${database.host}" />
-								<arg value="-U" />
-								<arg value="${database.username}" />
+							<exec executable="/bin/bash" failonerror="true">
+								<arg value="-c" />
+								<arg value="${database.sqlserver.executable} -b -P &quot;${database.password}&quot; -Q &quot;restore database ${database.schema} from disk='${liferay.home}/${database.type}.bak' with replace; alter database ${database.schema} set allow_snapshot_isolation on; alter database ${database.schema} set read_committed_snapshot on with rollback immediate; dbcc traceon (1222, -1);&quot; -S ${database.host} -U ${database.username}" />
 							</exec>
 						</then>
 					</elseif>

--- a/build-test.xml
+++ b/build-test.xml
@@ -10168,7 +10168,11 @@ alter database lportal set allow_snapshot_isolation on;
 
 go
 
-alter database lportal set read_committed_snapshot on;
+alter database lportal set read_committed_snapshot on with rollback immediate;
+
+go
+
+dbcc traceon (1222, -1);
 
 go]]></replacevalue>
 								</replacefilter>
@@ -10186,7 +10190,7 @@ alter database lportal${databases.size} set allow_snapshot_isolation on;
 
 go
 
-alter database lportal${databases.size} set read_committed_snapshot on;
+alter database lportal${databases.size} set read_committed_snapshot on with rollback immediate;
 
 go</echo>
 								</then>
@@ -10410,7 +10414,11 @@ alter database lportal set allow_snapshot_isolation on;
 
 go
 
-alter database lportal set read_committed_snapshot on;
+alter database lportal set read_committed_snapshot on with rollback immediate;
+
+go
+
+dbcc traceon (1222, -1);
 
 go]]></replacevalue>
 								</replacefilter>
@@ -10428,7 +10436,7 @@ alter database lportal${databases.size} set allow_snapshot_isolation on;
 
 go
 
-alter database lportal${databases.size} set read_committed_snapshot on;
+alter database lportal${databases.size} set read_committed_snapshot on with rollback immediate;
 
 go</echo>
 								</then>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88624

## What is being fixed

Daily runs of the `ci:test:upgrade` suite on SQL Server 2019 fail
every night with deadlocks during portal boot. Hibernate auto-flush
of pending inserts is chosen as the SQL Server deadlock victim, but
the current CI setup gives us no way to attribute the cause:

- SQL Server's deadlock graph is not being captured anywhere in CI
  artifacts, so we only see the `BatchUpdateException` thrown by the
  JDBC driver — not the two transactions, their statements, the lock
  modes, or the contended resources.
- The legacy `.bak` RESTORE paths don't explicitly enforce
  `read_committed_snapshot`, so the restored database's isolation
  configuration depends on whatever was baked into the archive.

## How it is being fixed

Two changes to `build-test.xml`.

### 1. Capture deadlock graphs in `create.sql`

Append `dbcc traceon (1222, -1);` to the SQL Server `create.sql` block
in both `build-sql-file` and `build-sql-file-playwright`. About trace
flag 1222:

- It is a diagnostic-output flag — when the deadlock monitor picks a
  victim, SQL Server serializes the full deadlock graph as XML into
  `/var/opt/mssql/log/errorlog`.
- The XML graph contains both transactions, their executing
  statements, their lock modes, and the contended resource pages —
  enough to attribute the cause directly.
- The `-1` argument enables it server-wide.
- There is no runtime overhead when no deadlock occurs; the flag only
  changes what is written when the deadlock monitor already fires.
  Safe to leave on permanently in CI.
- The errorlog is already collected as a CI artifact, so the next
  failing nightly will land us a complete graph automatically.

The same blocks also pick up `with rollback immediate` on the existing
`read_committed_snapshot on` flip, so the alter is defensive against
any held connections.

### 2. Harden the `.bak` RESTORE paths

In `rebuild-legacy-database`, the SQL Server branch is updated so the
restored database always ends up with the same isolation settings and
diagnostic flags as a freshly-built one, regardless of how the `.bak`
was produced. After the RESTORE the path now also runs:

- `alter database … set allow_snapshot_isolation on;`
- `alter database … set read_committed_snapshot on with rollback immediate;`
- `dbcc traceon (1222, -1);`

Additional hardenings apply to both variants:

- **Docker shell-script** — adds `set -e` (fail fast), the `-b` flag on
  every `sqlcmd` invocation (so SQL errors return a non-zero exit
  code), and shell-quotes the password (`"${database.sqlserver.password}"`)
  so it survives shell-metacharacter expansion.
- **Non-docker `<exec>`** — rewritten to invoke through `bash -c` so
  that `database.sqlserver.executable` can carry multi-token values
  (e.g. `/opt/mssql-tools18/bin/sqlcmd -C`) without ant treating the
  whole string as a single executable path. The four SQL statements
  run as a single `sqlcmd` batch via combined `-Q`.