### PR TITLE
LPD-84025 Implement DB Locked Query Detection for the other DBs

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -649,7 +649,7 @@ public class DBTest {
 
 	@Test
 	public void testGetLockedQueryInfos() throws Exception {
-		Assume.assumeTrue(db.getDBType() == DBType.MYSQL);
+		Assume.assumeTrue(db.getDBType() != DBType.HYPERSONIC);
 
 		db.runSQL(
 			"insert into " + TABLE_NAME_1 +
@@ -693,12 +693,11 @@ public class DBTest {
 
 					String query = lockedQueryInfo.getQuery();
 
-					if ((query != null) && query.contains("waiting")) {
+					if (query.contains("waiting")) {
 						Assert.assertNotNull(lockedQueryInfo.getId());
 						Assert.assertNotNull(lockedQueryInfo.getSchema());
-						Assert.assertTrue(
-							StringUtil.containsIgnoreCase(
-								lockedQueryInfo.getState(), "LOCK WAIT"));
+
+						assertLockedQueryState(lockedQueryInfo.getState());
 
 						return;
 					}
@@ -1009,6 +1008,29 @@ public class DBTest {
 
 	protected void addIndex(String[] columnNames) {
 		addIndex(TABLE_NAME_1, columnNames, false);
+	}
+
+	protected void assertLockedQueryState(String state) {
+		DBType dbType = db.getDBType();
+
+		if (dbType == DBType.DB2) {
+			Assert.assertTrue(StringUtil.equalsIgnoreCase(state, "LOCKWAIT"));
+		}
+		else if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+			Assert.assertTrue(
+				StringUtil.containsIgnoreCase(state, "LOCK WAIT"));
+		}
+		else if (dbType == DBType.ORACLE) {
+			Assert.assertTrue(
+				StringUtil.startsWith(state, "enq:") ||
+				StringUtil.containsIgnoreCase(state, "library cache"));
+		}
+		else if (dbType == DBType.POSTGRESQL) {
+			Assert.assertTrue(StringUtil.equalsIgnoreCase(state, "Lock"));
+		}
+		else if (dbType == DBType.SQLSERVER) {
+			Assert.assertTrue(StringUtil.startsWith(state, "LCK_"));
+		}
 	}
 
 	protected static final String INDEX_NAME = "IX_TEMP";

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -433,6 +433,23 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select timestampdiff(2, char(current timestamp - ",
+			"activity.local_start_time)) * 1000 as duration, ",
+			"sysibmadm.applications.agent_id as id, cast(activity.stmt_text ",
+			"as varchar(4000)) as query, sysibmadm.applications.db_name as ",
+			"schema_, sysibmadm.applications.appl_status as state from ",
+			"sysibmadm.applications left join table(",
+			"sysproc.mon_get_activity(null, -2)) as activity on ",
+			"sysibmadm.applications.agent_id = activity.application_handle ",
+			"where timestampdiff(2, char(current timestamp - ",
+			"activity.local_start_time)) * 1000 >= ? and ",
+			"sysibmadm.applications.agent_id != mon_get_application_handle() ",
+			"and sysibmadm.applications.appl_status = 'LOCKWAIT'");
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -377,6 +377,20 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select v$session.last_call_et * 1000 as duration, v$session.sid ",
+			"as id, dbms_lob.substr(v$sql.sql_fulltext, 4000, 1) as query, ",
+			"v$session.schemaname as schema_, v$session.event as state from ",
+			"v$session left join v$sql on v$session.sql_id = v$sql.sql_id and ",
+			"v$session.sql_child_number = v$sql.child_number where ",
+			"v$session.audsid != sys_context('USERENV', 'SESSIONID') and ",
+			"v$session.last_call_et * 1000 >= ? and v$session.status = ",
+			"'ACTIVE' and v$session.type = 'USER' and (v$session.event like ",
+			"'enq:%' or v$session.event like '%library cache%')");
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -446,6 +446,23 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select sys.dm_exec_requests.total_elapsed_time as duration, ",
+			"sys.dm_exec_requests.session_id as id, substring(",
+			"input_buffer.event_info, 1, 4000) as query, db_name(",
+			"sys.dm_exec_requests.database_id) as schema_, ",
+			"sys.dm_exec_requests.wait_type as state from ",
+			"sys.dm_exec_requests cross apply sys.dm_exec_input_buffer(",
+			"sys.dm_exec_requests.session_id, ",
+			"sys.dm_exec_requests.request_id) as input_buffer where ",
+			"sys.dm_exec_requests.session_id != @@spid and ",
+			"sys.dm_exec_requests.session_id >= 50 and ",
+			"sys.dm_exec_requests.total_elapsed_time >= ? and ",
+			"sys.dm_exec_requests.wait_type like 'LCK\\_%' escape '\\'");
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -46,6 +46,7 @@ import java.io.InputStream;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -542,6 +543,46 @@ public abstract class BaseDB implements DB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, false);
+	}
+
+	@Override
+	public List<QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		String sql = getLockedQueryInfosSQL();
+
+		if (sql == null) {
+			return Collections.emptyList();
+		}
+
+		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(
+				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String query = resultSet.getString("query");
+
+					if (query == null) {
+						continue;
+					}
+
+					long duration = resultSet.getLong("duration");
+					String id = resultSet.getString("id");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					lockedQueryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return lockedQueryInfos;
 	}
 
 	@Override
@@ -1505,6 +1546,10 @@ public abstract class BaseDB implements DB {
 
 	protected String getIndexColumnName(String indexColumnName) {
 		return indexColumnName;
+	}
+
+	protected String getLockedQueryInfosSQL() {
+		return null;
 	}
 
 	protected String getRenameTableSQL(

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -29,7 +29,6 @@ import java.sql.Types;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 
 /**
@@ -152,54 +151,6 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
-	public List<QueryInfo> getLockedQueryInfos(Connection connection)
-		throws SQLException {
-
-		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
-
-		String sql = StringBundler.concat(
-			"select information_schema.processlist.time as duration, ",
-			"information_schema.processlist.id as id, ",
-			"information_schema.processlist.info as query, ",
-			"information_schema.processlist.db as schema_, ",
-			"coalesce(information_schema.innodb_trx.trx_state, ",
-			"information_schema.processlist.state) as state from ",
-			"information_schema.processlist left join ",
-			"information_schema.innodb_trx on ",
-			"information_schema.processlist.id = ",
-			"information_schema.innodb_trx.trx_mysql_thread_id where ",
-			"information_schema.processlist.command != 'Sleep' and ",
-			"information_schema.processlist.id != connection_id() and ",
-			"information_schema.processlist.info is not null and ",
-			"information_schema.processlist.time >= ? and (",
-			"information_schema.innodb_trx.trx_state = 'LOCK WAIT' or ",
-			"information_schema.processlist.state like '%lock%')");
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(
-				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD / 1000);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					long duration = TimeUnit.SECONDS.toMillis(
-						resultSet.getLong("duration"));
-					String id = resultSet.getString("id");
-					String query = resultSet.getString("query");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					lockedQueryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueryInfos;
-	}
-
-	@Override
 	public String getNewUuidFunctionName() {
 		return "UUID()";
 	}
@@ -266,6 +217,27 @@ public class MySQLDB extends BaseDB {
 		}
 
 		runSQL(connection, sb.toString());
+	}
+
+	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select information_schema.processlist.time * 1000 as duration, ",
+			"information_schema.processlist.id as id, ",
+			"substring(information_schema.processlist.info, 1, 4000) as ",
+			"query, information_schema.processlist.db as schema_, ",
+			"coalesce(information_schema.innodb_trx.trx_state, ",
+			"information_schema.processlist.state) as state from ",
+			"information_schema.processlist left join ",
+			"information_schema.innodb_trx on ",
+			"information_schema.processlist.id = ",
+			"information_schema.innodb_trx.trx_mysql_thread_id where ",
+			"information_schema.processlist.command != 'Sleep' and ",
+			"information_schema.processlist.id != connection_id() and ",
+			"information_schema.processlist.info is not null and ",
+			"information_schema.processlist.time * 1000 >= ? and (",
+			"information_schema.innodb_trx.trx_state = 'LOCK WAIT' or ",
+			"lower(information_schema.processlist.state) like '%lock%')");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -331,6 +331,22 @@ public class PostgreSQLDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLockedQueryInfosSQL() {
+		return StringBundler.concat(
+			"select extract(epoch from (clock_timestamp() - ",
+			"pg_catalog.pg_stat_activity.query_start)) * 1000 as duration, ",
+			"pg_catalog.pg_stat_activity.pid as id, ",
+			"substring(pg_catalog.pg_stat_activity.query, 1, 4000) as query, ",
+			"pg_catalog.pg_stat_activity.datname as schema_, ",
+			"pg_catalog.pg_stat_activity.wait_event_type as state from ",
+			"pg_catalog.pg_stat_activity where ",
+			"pg_catalog.pg_stat_activity.pid != pg_backend_pid() and ",
+			"extract(epoch from (clock_timestamp() - ",
+			"pg_catalog.pg_stat_activity.query_start)) * 1000 >= ? and ",
+			"pg_catalog.pg_stat_activity.wait_event_type = 'Lock'");
+	}
+
+	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84025

**What is being fixed:** The MySQL implementation of locked query detection landed earlier, but the `DB.getLockedQueryInfos` API still returned an empty list for DB2, Oracle, PostgreSQL, and SQL Server. The upcoming polling thread (LPD-84027) needs every vendor to surface lock waits.

**How it is being fixed:** The common JDBC plumbing (prepare the statement, set the threshold, read the standard `duration / id / query / schema_ / state` columns, build `QueryInfo` objects) is consolidated in `BaseDB.getLockedQueryInfos`. Each vendor only overrides `getLockedQueryInfosSQL()` to return its system-view query. `BaseDB` skips rows with a null `query` so a `QueryInfo` always has all five fields populated. PostgreSQL uses `pg_catalog.pg_stat_activity` filtered by `wait_event_type = 'Lock'` and computes elapsed time with `clock_timestamp()` (not `now()`, which is transaction-scoped in PostgreSQL and would underreport multi-statement waits). DB2 left joins `sysibmadm.applications` with `sysproc.mon_get_activity` and filters by `appl_status = 'LOCKWAIT'`, computing duration from `activity.local_start_time` so the threshold reflects current-statement elapsed time, not whole-transaction elapsed time. Oracle left joins `v$session` with `v$sql` (on `sql_id` and `sql_child_number` to avoid duplicate child-cursor rows) and matches events `enq:%` or `%library cache%` within active user sessions. SQL Server cross applies `sys.dm_exec_input_buffer` against `sys.dm_exec_requests` and filters by `wait_type like 'LCK\_%'`; `dm_exec_input_buffer` is used instead of `dm_exec_sql_text` because SQL Server's automatic parameterization rewrites string literals in the cached plan (e.g., `WHERE x = 'foo'` becomes `WHERE x = @1` in `dm_exec_sql_text`), whereas `dm_exec_input_buffer` returns the actual client-sent batch with literals intact. MariaDB inherits the MySQL implementation through `MariaDBDB extends MySQLDB`. All vendor SQL emits `duration` in milliseconds and caps the captured query text at 4000 characters for a uniform contract.

**Tests:** The integration test `DBTest.testGetLockedQueryInfos` creates row-level lock contention between two transactions and verifies `getLockedQueryInfos` returns the waiter with the expected per-vendor `state` string. The assertion lives in a single `DBTest.assertLockedQueryState` hook holding all DB2 / MariaDB / MySQL / Oracle / PostgreSQL / SQL Server branches in one if-chain, so subclass tests do not need to override it. The test was run live against PostgreSQL 16, Oracle 23c, DB2 11.5.7, and SQL Server 2022 — all four passed end-to-end through the Liferay portal stack. MySQL 8.4 vendor SQL was verified directly against the running container; MariaDB rides on `MariaDBDB extends MySQLDB`.

**Operational note for Oracle:** Reading `v$session` and `v$sql` requires the `SELECT_CATALOG_ROLE` role or explicit `GRANT SELECT ON sys.v_$session, sys.v_$sql TO <liferay_user>` (must be granted by `SYS AS SYSDBA`). Without these grants, `getLockedQueryInfos` will fail with `ORA-00942: table or view does not exist`.

**Commits:**

1. `LPD-84025 Consolidate locked query detection logic in BaseDB` — adds the consolidated `BaseDB.getLockedQueryInfos(Connection)` plus the abstract `getLockedQueryInfosSQL()` hook, and refactors `MySQLDB` onto the new pattern.
2. `LPD-84025 Implement DB Locked Query Detection for the other DBs` — adds the `getLockedQueryInfosSQL()` override in `PostgreSQLDB`, `DB2DB`, `OracleDB`, and `SQLServerDB`.
3. `LPD-84025 Add tests for DB Locked Query Detection` — adds `DBTest.testGetLockedQueryInfos` and the `assertLockedQueryState` hook covering all five vendor `state` shapes.

The previous PR (#3534) carried the equivalent tree across an interim history and was closed in favor of this resend.