### PR TITLE
LPD-86832 Fix ProductMenu.gotoPortlet failing on sites with no pages

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -85,6 +85,13 @@ definition {
 	macro gotoPortlet(site = null, portlet = null, category = null) {
 		if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});
+
+			if (isSet(site)) {
+				var siteNameURL = StringUtil.replace(${site}, " ", "-");
+				var siteNameURL = StringUtil.lowerCase(${siteNameURL});
+
+				Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+			}
 		}
 
 		ProductMenuHelper.openProductMenu();

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/applicationsmenu/ApplicationsMenu.path
@@ -57,7 +57,7 @@
 </tr>
 <tr>
 	<td>VIEW_ALL_LINK</td>
-	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//button[@role='menuitem' and contains(.,'View All')]</td>
+	<td>//ul[@role='menu' and contains(@class, 'sites-list')]//*[@role='menuitem' and contains(.,'View All')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86832

**What is being fixed:** ProductMenu.gotoPortlet fails with a productMenuBody not present error when the target site has no pages. After ApplicationsMenu.gotoSite navigates to the site, the product menu is not available in the expected context, so ProductMenuHelper.openProductMenu cannot find its elements.

**How it is being fixed:** When a site parameter is provided and the product menu toggle is not already present, the macro now navigates directly to the site's control panel URL (group/<site-name-url>/~/control_panel/manage) after opening the site, ensuring the product menu context is active before openProductMenu is called. The ApplicationsMenu VIEW_ALL_LINK path selector is also broadened from button[@role='menuitem'] to *[@role='menuitem'] so it matches non-button implementations of that role.