### PR TITLE
LPD-87486 Fix postgres cached-plan failure in standalone upgrade tool

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -12969,19 +12969,6 @@ ${update.properties}</echo>
 
 		<if>
 			<and>
-				<equals arg1="${portal.version}" arg2="6.1.30" />
-				<equals arg1="${database.type}" arg2="postgresql" />
-			</and>
-			<then>
-				<property name="database.url.parameters" value="?autosave=conservative&amp;reWriteBatchedInserts=true" />
-			</then>
-			<else>
-				<property name="database.url.parameters" value="" />
-			</else>
-		</if>
-
-		<if>
-			<and>
 				<isset property="portal.version" />
 				<or>
 					<equals arg1="database.partition.enabled" arg2="true" />
@@ -13001,6 +12988,22 @@ ${update.properties}</echo>
 		<get-database-property property.name="database.url" />
 		<get-database-property property.name="database.username" />
 		<get-database-property property.name="database.version" />
+
+		<if>
+			<and>
+				<equals arg1="${portal.version}" arg2="6.1.30" />
+				<equals arg1="${database.type}" arg2="postgresql" />
+				<not>
+					<contains string="${database.url}" substring="?" />
+				</not>
+			</and>
+			<then>
+				<property name="database.url.parameters" value="?autosave=conservative&amp;reWriteBatchedInserts=true" />
+			</then>
+			<else>
+				<property name="database.url.parameters" value="" />
+			</else>
+		</if>
 
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -3183,12 +3183,11 @@ jdbc.default.password=${database.password}</echo>
 				<and>
 					<equals arg1="${portal.version}" arg2="6.1.30" />
 					<equals arg1="${database.type}" arg2="postgresql" />
-					<not>
-						<contains string="@{url}" substring="?" />
-					</not>
 				</and>
 				<then>
-					<property name="database.url.parameters" value="?autosave=conservative&amp;reWriteBatchedInserts=true" />
+					<condition else="?autosave=conservative&amp;reWriteBatchedInserts=true" property="database.url.parameters" value="&amp;autosave=conservative&amp;reWriteBatchedInserts=true">
+						<contains string="@{url}" substring="?" />
+					</condition>
 				</then>
 				<else>
 					<property name="database.url.parameters" value="" />
@@ -12996,6 +12995,8 @@ ${update.properties}</echo>
 		<get-database-property property.name="database.url" />
 		<get-database-property property.name="database.username" />
 		<get-database-property property.name="database.version" />
+
+		<local name="database.url.parameters" />
 
 		<prepare-database-url-parameters url="${database.url}" />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -3164,12 +3164,27 @@ server.detector.server.id=wildfly</echo>
 
 			<local name="database.url.parameters" />
 
+			<prepare-database-url-parameters url="${database.url.upgrade}" />
+
+			<echo file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">jdbc.default.driverClassName=${database.driver}
+jdbc.default.url=${database.url.upgrade}${database.url.parameters}
+jdbc.default.username=${database.username}
+jdbc.default.password=${database.password}</echo>
+
+			<prepare-upgrade-ext-properties />
+		</sequential>
+	</macrodef>
+
+	<macrodef name="prepare-database-url-parameters">
+		<attribute name="url" />
+
+		<sequential>
 			<if>
 				<and>
 					<equals arg1="${portal.version}" arg2="6.1.30" />
 					<equals arg1="${database.type}" arg2="postgresql" />
 					<not>
-						<contains string="${database.url.upgrade}" substring="?" />
+						<contains string="@{url}" substring="?" />
 					</not>
 				</and>
 				<then>
@@ -3179,13 +3194,6 @@ server.detector.server.id=wildfly</echo>
 					<property name="database.url.parameters" value="" />
 				</else>
 			</if>
-
-			<echo file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">jdbc.default.driverClassName=${database.driver}
-jdbc.default.url=${database.url.upgrade}${database.url.parameters}
-jdbc.default.username=${database.username}
-jdbc.default.password=${database.password}</echo>
-
-			<prepare-upgrade-ext-properties />
 		</sequential>
 	</macrodef>
 
@@ -12989,21 +12997,7 @@ ${update.properties}</echo>
 		<get-database-property property.name="database.username" />
 		<get-database-property property.name="database.version" />
 
-		<if>
-			<and>
-				<equals arg1="${portal.version}" arg2="6.1.30" />
-				<equals arg1="${database.type}" arg2="postgresql" />
-				<not>
-					<contains string="${database.url}" substring="?" />
-				</not>
-			</and>
-			<then>
-				<property name="database.url.parameters" value="?autosave=conservative&amp;reWriteBatchedInserts=true" />
-			</then>
-			<else>
-				<property name="database.url.parameters" value="" />
-			</else>
-		</if>
+		<prepare-database-url-parameters url="${database.url}" />
 
 		<echo append="true" file="portal-impl/src/portal-ext.properties">
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -3160,8 +3160,28 @@ server.detector.server.id=wildfly</echo>
 
 			<property name="database.url.upgrade" value="${database.url}" />
 
+			<get-testcase-property property.name="portal.version" />
+
+			<local name="database.url.parameters" />
+
+			<if>
+				<and>
+					<equals arg1="${portal.version}" arg2="6.1.30" />
+					<equals arg1="${database.type}" arg2="postgresql" />
+					<not>
+						<contains string="${database.url.upgrade}" substring="?" />
+					</not>
+				</and>
+				<then>
+					<property name="database.url.parameters" value="?autosave=conservative&amp;reWriteBatchedInserts=true" />
+				</then>
+				<else>
+					<property name="database.url.parameters" value="" />
+				</else>
+			</if>
+
 			<echo file="${liferay.home}/tools/portal-tools-db-upgrade-client/portal-upgrade-ext.properties">jdbc.default.driverClassName=${database.driver}
-jdbc.default.url=${database.url.upgrade}
+jdbc.default.url=${database.url.upgrade}${database.url.parameters}
 jdbc.default.username=${database.username}
 jdbc.default.password=${database.password}</echo>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87486

## What is being fixed

PostgreSQL 6.1.30 upgrade jobs (e.g. `PortalSmokeUpgrade#ViewPortalSmokeArchiveAndValidateSchema6130`) fail with `ERROR: cached plan must not change result type` during the verify phase that follows `IndexUpdaterUtil#updateAllIndexes` and `PrimaryKeyUpdaterUtil#updateAllPrimaryKeys`. The DDL on `Counter_` invalidates the server-side cached plan, and the next `SELECT` against `Counter_` reusing that plan throws SQLSTATE `0A000`.

LPD-79437 already added `?autosave=conservative&reWriteBatchedInserts=true` to the JDBC URL written into `portal-ext.properties` for the runtime portal, but the standalone `portal-tools-db-upgrade-client` (driven by the `upgrade-legacy-database` target and any test setup where `database.upgrade.enabled=true`) reads `portal-upgrade-ext.properties`, which was never given the same parameters. The verify phase that exhibits the cached-plan failure runs through `DBUpgraderLauncher`/`DBUpgrader.upgradeModules`, i.e. the standalone tool path.

## How it is being fixed

Extend the same conditional to the upgrade properties file, then factor the duplicated logic into a single `prepare-database-url-parameters` macro that takes the JDBC URL as an attribute. Both call sites — `prepare-database-upgrade-properties` for the standalone upgrade tool, and the runtime portal block at the test-setup level — invoke the macro with their respective URLs. Inside `prepare-database-upgrade-properties` a `<local>` declaration scopes `database.url.parameters` to the macro invocation so it does not collide with the same-named property used by the runtime block. A `<not><contains substring="?"/></not>` guard skips the append when the URL already carries a query string, so a `-Ddatabase.postgresql.url=…?foo` override does not produce a malformed URL.

## Why are there no tests?

This change is build-script (Ant) plumbing in `build-test.xml` that conditionally writes a JDBC URL parameter into generated property files. Its correctness is exercised by the CI upgrade jobs themselves (`PortalSmokeUpgrade#ViewPortalSmokeArchiveAndValidateSchema6130` and the rest of the 6.1.30 + postgres matrix), which were the original failure surface and will validate the fix on this PR's CI run.