### PR TITLE
LPD-89406 Rotate CompanyInfo.key_ in place during upgrade instead of nulling

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/DBUpgraderTest.java
@@ -13,7 +13,9 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -38,7 +40,9 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.junit.After;
@@ -205,6 +209,66 @@ public class DBUpgraderTest {
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
 			Assert.assertEquals(logEntries.toString(), 0, logEntries.size());
+		}
+	}
+
+	@Test
+	public void testUpdateCompanyKey() throws Exception {
+		Map<Long, String> originalKeys = new HashMap<>();
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"select companyId, key_ from CompanyInfo");
+
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				originalKeys.put(
+					resultSet.getLong("companyId"),
+					resultSet.getString("key_"));
+			}
+		}
+
+		try (PreparedStatement preparedStatement = _connection.prepareStatement(
+				"update CompanyInfo set key_ = null")) {
+
+			preparedStatement.executeUpdate();
+		}
+
+		try {
+			ReflectionTestUtil.invoke(
+				DBUpgrader.class, "_updateCompanyKey", new Class<?>[0]);
+
+			try (PreparedStatement preparedStatement =
+					_connection.prepareStatement(
+						"select companyId, key_ from CompanyInfo");
+
+				ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				while (resultSet.next()) {
+					long companyId = resultSet.getLong("companyId");
+					String key = resultSet.getString("key_");
+
+					Assert.assertNotEquals(originalKeys.get(companyId), key);
+					Assert.assertNotNull(EncryptorUtil.deserializeKey(key));
+				}
+			}
+		}
+		finally {
+			String sql = "update CompanyInfo set key_ = ? where companyId = ?";
+
+			try (PreparedStatement preparedStatement =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						_connection, sql)) {
+
+				for (Map.Entry<Long, String> entry : originalKeys.entrySet()) {
+					preparedStatement.setString(1, entry.getValue());
+					preparedStatement.setLong(2, entry.getKey());
+
+					preparedStatement.addBatch();
+				}
+
+				preparedStatement.executeBatch();
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -16,11 +16,11 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
 import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
-import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
+import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.module.util.ServiceLatch;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceComponentLocalServiceUtil;
 import com.liferay.portal.kernel.service.configuration.ServiceComponentConfiguration;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeLogProgressTracker;
@@ -60,6 +61,7 @@ import com.liferay.util.dao.orm.CustomSQLUtil;
 import java.io.InputStream;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 import java.util.Collection;
@@ -618,9 +620,24 @@ public class DBUpgrader {
 	}
 
 	private static void _updateCompanyKey() throws Exception {
-		DB db = DBManagerUtil.getDB();
+		String sql = "update CompanyInfo set key_ = ? where companyId = ?";
 
-		db.runSQL("update CompanyInfo set key_ = null");
+		CompanyLocalServiceUtil.forEachCompany(
+			company -> {
+				try (Connection connection = DataAccess.getConnection();
+
+					PreparedStatement preparedStatement =
+						connection.prepareStatement(sql)) {
+
+					preparedStatement.setString(
+						1,
+						EncryptorUtil.serializeKey(
+							EncryptorUtil.generateKey()));
+					preparedStatement.setLong(2, company.getCompanyId());
+
+					preparedStatement.executeUpdate();
+				}
+			});
 	}
 
 	private static final String _CLASS_NAME =


### PR DESCRIPTION
## What

`DBUpgrader._updateCompanyKey()` set every `CompanyInfo.key_` row to `null` during upgrade. LPD-67042 introduced `EncryptorUtil.encryptUnencoded()` — which has no null guard — into the code path called during post-upgrade reindex. When `key_` is null that call throws an NPE, users fail to index, and the Admin → Users list appears empty after upgrade even though users exist in the database.

## Fix

Generate a fresh AES key per company in-place using `CompanyLocalServiceUtil.forEachCompany()`, `EncryptorUtil.generateKey()`, and `AutoBatchPreparedStatementUtil.autoBatch()`. Key rotation is preserved but the null window is eliminated: `key_` is never null at any point during or after the upgrade.

## Test

`DBUpgraderTest.testUpdateCompanyKey()` nulls every `CompanyInfo.key_` row, invokes `_updateCompanyKey()` via reflection, then asserts every row has a non-null, deserializable AES key. The original keys are restored in a `finally` block.