### PR TITLE
LPD-83541 Search for user before viewing in database partitioning upgrade macro

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/ValidateDatabasePartitioningUpgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/ValidateDatabasePartitioningUpgrade.macro
@@ -11,6 +11,8 @@ definition {
 
 		User.openUsersAdmin(baseURL = "http://www.able.com:8080");
 
+		User.searchCP(searchTerm = "test1");
+
 		User.viewCP(
 			userEmailAddress = "test1@www.able.com",
 			userFirstName = "Test1",
@@ -56,6 +58,8 @@ definition {
 			userEmailAddress = "test@www.baker.com");
 
 		User.openUsersAdmin(baseURL = "http://www.baker.com:8080");
+
+		User.searchCP(searchTerm = "test2");
 
 		User.viewCP(
 			userEmailAddress = "test2@www.baker.com",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-83541

**What is being fixed:** The `ValidateDatabasePartitioningUpgrade` Poshi macro called `User.viewCP` directly after opening Users Admin, without first performing a search. When the user list is not filtered, `viewCP` fails to locate the expected user because the CP view may display paginated results or require a search step before the row is visible.

**How it is being fixed:** A `User.searchCP` call is added before each `User.viewCP` invocation — once for the `able.com` virtual instance (searching for `test1`) and once for the `baker.com` virtual instance (searching for `test2`). This ensures the correct user record is visible in the list before the view assertion runs.