### PR TITLE
LPD-89559 Increase lock detection timeouts in DBTest from 5 to 30 seconds

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -685,7 +685,7 @@ public class DBTest {
 
 			thread.start();
 
-			long endTime = System.currentTimeMillis() + 5000;
+			long endTime = System.currentTimeMillis() + 30000;
 
 			while (System.currentTimeMillis() < endTime) {
 				for (DB.QueryInfo lockedQueryInfo :
@@ -711,7 +711,7 @@ public class DBTest {
 		finally {
 			if (futureTask != null) {
 				try {
-					futureTask.get(5, TimeUnit.SECONDS);
+					futureTask.get(30, TimeUnit.SECONDS);
 				}
 				catch (Exception exception) {
 					_log.error(exception);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89559

## What is being fixed

`DBTest.testGetLockedQueryInfos` intermittently fails on CI because the 5-second poll budget is too tight on heavily-loaded workers. OS scheduling and JIT latency under noisy-neighbour CPU contention can push the daemon thread's first DB round-trip past the window, causing a spurious `Assert.fail()`.

## How it is being fixed

Both the poll-loop deadline and the `FutureTask.get` timeout are bumped from 5 seconds to 30 seconds. The loop returns immediately on success, so passing runs are unaffected — only legitimate failures pay the longer wait.