### PR TITLE
LPD-89553 Grant Oracle test user SELECT on sys.v_$session and sys.v_$sql

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -10143,7 +10143,9 @@ update db cfg for lportal${databases.size} using logsecond 254;</echo>
 							>
 								<replacetoken>grant connect,resource to &amp;1;</replacetoken>
 								<replacevalue>grant connect,resource to &amp;1;
-	grant unlimited tablespace to &amp;1;</replacevalue>
+	grant unlimited tablespace to &amp;1;
+	grant select on sys.v_$session to &amp;1;
+	grant select on sys.v_$sql to &amp;1;</replacevalue>
 							</replace>
 
 							<if>
@@ -10153,7 +10155,9 @@ update db cfg for lportal${databases.size} using logsecond 254;</echo>
 										file="create.sql"
 									>
 										<replacetoken>grant connect,resource to &amp;1;
-	grant unlimited tablespace to &amp;1;</replacetoken>
+	grant unlimited tablespace to &amp;1;
+	grant select on sys.v_$session to &amp;1;
+	grant select on sys.v_$sql to &amp;1;</replacetoken>
 										<replacevalue>grant all privileges to &amp;1;</replacevalue>
 									</replace>
 									<replace
@@ -10388,7 +10392,9 @@ update db cfg for lportal${databases.size} using logsecond 254;</echo>
 							>
 								<replacetoken>grant connect,resource to &amp;1;</replacetoken>
 								<replacevalue>grant connect,resource to &amp;1;
-grant unlimited tablespace to &amp;1;</replacevalue>
+grant unlimited tablespace to &amp;1;
+grant select on sys.v_$session to &amp;1;
+grant select on sys.v_$sql to &amp;1;</replacevalue>
 							</replace>
 
 							<if>
@@ -10398,7 +10404,9 @@ grant unlimited tablespace to &amp;1;</replacevalue>
 										file="create.sql"
 									>
 										<replacetoken>grant connect,resource to &amp;1;
-grant unlimited tablespace to &amp;1;</replacetoken>
+grant unlimited tablespace to &amp;1;
+grant select on sys.v_$session to &amp;1;
+grant select on sys.v_$sql to &amp;1;</replacetoken>
 										<replacevalue>grant all privileges to &amp;1;</replacevalue>
 									</replace>
 									<replace


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89553

**What is being fixed:** `OracleDBTest.testGetLockedQueryInfos` fails on Oracle CI with `ORA-00942: table or view does not exist` because the test user lacks SELECT access on `sys.v_$session` and `sys.v_$sql`, which are the underlying Oracle views that back the `v$session` and `v$sql` synonyms used by `OracleDB.getLockedQueryInfos`.

**How it is being fixed:** The Oracle test user setup script in `build-test.xml` is updated to explicitly grant `select on sys.v_$session` and `select on sys.v_$sql` to the test user immediately after the existing `grant unlimited tablespace` grant. This applies to both the standard schema creation path and the DXP schema path so the grants are consistently present regardless of which setup branch is taken.