### PR TITLE
LPD-84035 LPD-84039 Add getLongRunningQueryInfos to DB interface and implementations

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -721,6 +721,169 @@ public class DBTest {
 	}
 
 	@Test
+	public void testGetLongRunningQueryInfos() throws Exception {
+		Assume.assumeTrue(db.getDBType() != DBType.HYPERSONIC);
+
+		String slowQuery = _getSlowQuerySQL();
+
+		FutureTask<Void> futureTask = null;
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD", 0L);
+			Connection pollingConnection = DataAccess.getConnection()) {
+
+			futureTask = new FutureTask<>(
+				() -> {
+					try (Connection backgroundConnection =
+							DataAccess.getConnection()) {
+
+						db.runSQL(backgroundConnection, slowQuery);
+					}
+
+					return null;
+				});
+
+			Thread thread = new Thread(futureTask);
+
+			thread.setDaemon(true);
+
+			thread.start();
+
+			long endTime = System.currentTimeMillis() + 30000;
+
+			while (System.currentTimeMillis() < endTime) {
+				for (DB.QueryInfo queryInfo :
+						db.getLongRunningQueryInfos(pollingConnection)) {
+
+					String query = queryInfo.getQuery();
+
+					if (query.contains(_getSlowQueryFragment())) {
+						Assert.assertNotNull(queryInfo.getId());
+						Assert.assertNotNull(queryInfo.getSchema());
+						Assert.assertNotNull(queryInfo.getState());
+
+						for (DB.QueryInfo lockedQueryInfo :
+								db.getLockedQueryInfos(pollingConnection)) {
+
+							Assert.assertFalse(
+								lockedQueryInfo.getQuery(
+								).contains(
+									_getSlowQueryFragment()
+								));
+						}
+
+						return;
+					}
+				}
+
+				Thread.sleep(200);
+			}
+
+			Assert.fail();
+		}
+		finally {
+			if (futureTask != null) {
+				try {
+					futureTask.get(30, TimeUnit.SECONDS);
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+				}
+			}
+		}
+	}
+
+	@Test
+	public void testGetLongRunningQueryInfosExcludesLockedQueries()
+		throws Exception {
+
+		Assume.assumeTrue(db.getDBType() != DBType.HYPERSONIC);
+
+		db.runSQL(
+			"insert into " + TABLE_NAME_1 +
+				" (id, notNilColumn) values (2, '2')");
+
+		FutureTask<Void> futureTask = null;
+
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L);
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD", 0L);
+			Connection lockingConnection = DataAccess.getConnection()) {
+
+			lockingConnection.setAutoCommit(false);
+
+			db.runSQL(
+				lockingConnection,
+				"update " + TABLE_NAME_1 +
+					" set nilColumn = 'locked' where id = 2");
+
+			futureTask = new FutureTask<>(
+				() -> {
+					db.runSQL(
+						connection,
+						"update " + TABLE_NAME_1 +
+							" set nilColumn = 'waiting' where id = 2");
+
+					return null;
+				});
+
+			Thread thread = new Thread(futureTask);
+
+			thread.setDaemon(true);
+
+			thread.start();
+
+			long endTime = System.currentTimeMillis() + 30000;
+
+			boolean foundInLocked = false;
+
+			while (System.currentTimeMillis() < endTime) {
+				for (DB.QueryInfo lockedQueryInfo :
+						db.getLockedQueryInfos(lockingConnection)) {
+
+					String query = lockedQueryInfo.getQuery();
+
+					if (query.contains("waiting")) {
+						foundInLocked = true;
+
+						break;
+					}
+				}
+
+				if (foundInLocked) {
+					break;
+				}
+
+				Thread.sleep(200);
+			}
+
+			Assert.assertTrue(foundInLocked);
+
+			for (DB.QueryInfo queryInfo :
+					db.getLongRunningQueryInfos(lockingConnection)) {
+
+				String query = queryInfo.getQuery();
+
+				Assert.assertFalse(query.contains("waiting"));
+			}
+		}
+		finally {
+			if (futureTask != null) {
+				try {
+					futureTask.get(30, TimeUnit.SECONDS);
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+				}
+			}
+		}
+	}
+
+	@Test
 	public void testGetPrimaryKeyColumnNames() throws Exception {
 		db.runSQL(_SQL_CREATE_TABLE_2);
 
@@ -1063,6 +1226,52 @@ public class DBTest {
 				Connection.class, String.class, String.class, boolean.class
 			},
 			connection, tableName, columnNames[0], false);
+	}
+
+	private String _getSlowQueryFragment() {
+		DBType dbType = db.getDBType();
+
+		if (dbType == DBType.DB2) {
+			return "with t(n)";
+		}
+		else if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+			return "sleep";
+		}
+		else if (dbType == DBType.ORACLE) {
+			return "connect by";
+		}
+		else if (dbType == DBType.POSTGRESQL) {
+			return "pg_sleep";
+		}
+		else if (dbType == DBType.SQLSERVER) {
+			return "waitfor";
+		}
+
+		throw new UnsupportedOperationException(String.valueOf(dbType));
+	}
+
+	private String _getSlowQuerySQL() {
+		DBType dbType = db.getDBType();
+
+		if (dbType == DBType.DB2) {
+			return "with t(n) as (values 1 union all select n+1 from t where " +
+				"n < 50000000) select max(n) from t";
+		}
+		else if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+			return "select sleep(2)";
+		}
+		else if (dbType == DBType.ORACLE) {
+			return "select count(*) from (select level from dual connect by " +
+				"level <= 100000000)";
+		}
+		else if (dbType == DBType.POSTGRESQL) {
+			return "select pg_sleep(2)";
+		}
+		else if (dbType == DBType.SQLSERVER) {
+			return "waitfor delay '00:00:02'";
+		}
+
+		throw new UnsupportedOperationException(String.valueOf(dbType));
 	}
 
 	private void _validateIndex(String[] columnNames) throws Exception {

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -450,6 +450,24 @@ public class DB2DB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueryInfosSQL() {
+		return StringBundler.concat(
+			"select timestampdiff(2, char(current timestamp - ",
+			"activity.local_start_time)) * 1000 as duration, ",
+			"sysibmadm.applications.agent_id as id, cast(activity.stmt_text ",
+			"as varchar(4000)) as query, sysibmadm.applications.db_name as ",
+			"schema_, sysibmadm.applications.appl_status as state from ",
+			"sysibmadm.applications left join table(",
+			"sysproc.mon_get_activity(null, -2)) as activity on ",
+			"sysibmadm.applications.agent_id = activity.application_handle ",
+			"where timestampdiff(2, char(current timestamp - ",
+			"activity.local_start_time)) * 1000 >= ? and ",
+			"sysibmadm.applications.agent_id != mon_get_application_handle() ",
+			"and (sysibmadm.applications.appl_status is null or ",
+			"sysibmadm.applications.appl_status != 'LOCKWAIT')");
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -391,6 +391,21 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueryInfosSQL() {
+		return StringBundler.concat(
+			"select v$session.last_call_et * 1000 as duration, v$session.sid ",
+			"as id, dbms_lob.substr(v$sql.sql_fulltext, 4000, 1) as query, ",
+			"v$session.schemaname as schema_, v$session.event as state from ",
+			"v$session left join v$sql on v$session.sql_id = v$sql.sql_id and ",
+			"v$session.sql_child_number = v$sql.child_number where ",
+			"v$session.audsid != sys_context('USERENV', 'SESSIONID') and ",
+			"v$session.last_call_et * 1000 >= ? and v$session.status = ",
+			"'ACTIVE' and v$session.type = 'USER' and (v$session.event is ",
+			"null or (v$session.event not like 'enq:%' and v$session.event ",
+			"not like '%library cache%'))");
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/SQLServerDB.java
@@ -463,6 +463,24 @@ public class SQLServerDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueryInfosSQL() {
+		return StringBundler.concat(
+			"select sys.dm_exec_requests.total_elapsed_time as duration, ",
+			"sys.dm_exec_requests.session_id as id, substring(",
+			"input_buffer.event_info, 1, 4000) as query, db_name(",
+			"sys.dm_exec_requests.database_id) as schema_, ",
+			"sys.dm_exec_requests.wait_type as state from ",
+			"sys.dm_exec_requests cross apply sys.dm_exec_input_buffer(",
+			"sys.dm_exec_requests.session_id, ",
+			"sys.dm_exec_requests.request_id) as input_buffer where ",
+			"sys.dm_exec_requests.session_id != @@spid and ",
+			"sys.dm_exec_requests.session_id >= 50 and ",
+			"sys.dm_exec_requests.total_elapsed_time >= ? and (",
+			"sys.dm_exec_requests.wait_type is null or ",
+			"sys.dm_exec_requests.wait_type not like 'LCK\\_%' escape '\\')");
+	}
+
+	@Override
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -549,40 +549,18 @@ public abstract class BaseDB implements DB {
 	public List<QueryInfo> getLockedQueryInfos(Connection connection)
 		throws SQLException {
 
-		String sql = getLockedQueryInfosSQL();
+		return _getQueryInfos(
+			connection, getLockedQueryInfosSQL(),
+			PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD);
+	}
 
-		if (sql == null) {
-			return Collections.emptyList();
-		}
+	@Override
+	public List<QueryInfo> getLongRunningQueryInfos(Connection connection)
+		throws SQLException {
 
-		List<QueryInfo> lockedQueryInfos = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(
-				1, PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String query = resultSet.getString("query");
-
-					if (query == null) {
-						continue;
-					}
-
-					long duration = resultSet.getLong("duration");
-					String id = resultSet.getString("id");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					lockedQueryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return lockedQueryInfos;
+		return _getQueryInfos(
+			connection, getLongRunningQueryInfosSQL(),
+			PropsValues.UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD);
 	}
 
 	@Override
@@ -1552,6 +1530,10 @@ public abstract class BaseDB implements DB {
 		return null;
 	}
 
+	protected String getLongRunningQueryInfosSQL() {
+		return null;
+	}
+
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -1787,6 +1769,43 @@ public abstract class BaseDB implements DB {
 		}
 
 		return primaryKeys;
+	}
+
+	private List<QueryInfo> _getQueryInfos(
+			Connection connection, String sql, long threshold)
+		throws SQLException {
+
+		if (sql == null) {
+			return Collections.emptyList();
+		}
+
+		List<QueryInfo> queryInfos = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String query = resultSet.getString("query");
+
+					if (query == null) {
+						continue;
+					}
+
+					long duration = resultSet.getLong("duration");
+					String id = resultSet.getString("id");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					queryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return queryInfos;
 	}
 
 	private boolean _isSkipIndexOperation(

--- a/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/MySQLDB.java
@@ -241,6 +241,29 @@ public class MySQLDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueryInfosSQL() {
+		return StringBundler.concat(
+			"select information_schema.processlist.time * 1000 as duration, ",
+			"information_schema.processlist.id as id, ",
+			"substring(information_schema.processlist.info, 1, 4000) as ",
+			"query, information_schema.processlist.db as schema_, ",
+			"coalesce(information_schema.innodb_trx.trx_state, ",
+			"information_schema.processlist.state) as state from ",
+			"information_schema.processlist left join ",
+			"information_schema.innodb_trx on ",
+			"information_schema.processlist.id = ",
+			"information_schema.innodb_trx.trx_mysql_thread_id where ",
+			"information_schema.processlist.command != 'Sleep' and ",
+			"information_schema.processlist.id != connection_id() and ",
+			"information_schema.processlist.info is not null and ",
+			"information_schema.processlist.time * 1000 >= ? and (",
+			"information_schema.innodb_trx.trx_state is null or ",
+			"information_schema.innodb_trx.trx_state != 'LOCK WAIT') and (",
+			"information_schema.processlist.state is null or ",
+			"lower(information_schema.processlist.state) not like '%lock%')");
+	}
+
+	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;
 	}

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -347,6 +347,24 @@ public class PostgreSQLDB extends BaseDB {
 	}
 
 	@Override
+	protected String getLongRunningQueryInfosSQL() {
+		return StringBundler.concat(
+			"select extract(epoch from (clock_timestamp() - ",
+			"pg_catalog.pg_stat_activity.query_start)) * 1000 as duration, ",
+			"pg_catalog.pg_stat_activity.pid as id, ",
+			"substring(pg_catalog.pg_stat_activity.query, 1, 4000) as query, ",
+			"pg_catalog.pg_stat_activity.datname as schema_, ",
+			"pg_catalog.pg_stat_activity.wait_event_type as state from ",
+			"pg_catalog.pg_stat_activity where ",
+			"pg_catalog.pg_stat_activity.pid != pg_backend_pid() and ",
+			"pg_catalog.pg_stat_activity.state = 'active' and extract(epoch ",
+			"from (clock_timestamp() - ",
+			"pg_catalog.pg_stat_activity.query_start)) * 1000 >= ? and (",
+			"pg_catalog.pg_stat_activity.wait_event_type is null or ",
+			"pg_catalog.pg_stat_activity.wait_event_type != 'Lock')");
+	}
+
+	@Override
 	protected int[] getSQLTypes() {
 		return _SQL_TYPES;
 	}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -235,6 +235,14 @@
     upgrade.query.monitor.lock.threshold=300000
 
     #
+    # Set the threshold in milliseconds before an active query is flagged as
+    # long-running.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_LONG_PERIOD_RUNNING_PERIOD_THRESHOLD
+    #
+    upgrade.query.monitor.long.running.threshold=600000
+
+    #
     # Specify the number of seconds that the upgrade report generation will wait
     # for calculating the document library storage size before timing out.
     # Specify 0 to disable the document library storage size calculation.

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -106,6 +106,13 @@ public interface DB {
 		return Collections.emptyList();
 	}
 
+	public default List<QueryInfo> getLongRunningQueryInfos(
+			Connection connection)
+		throws SQLException {
+
+		return Collections.emptyList();
+	}
+
 	public int getMajorVersion();
 
 	public int getMinorVersion();

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 22.1.0
+version 22.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2735,6 +2735,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
 		"upgrade.query.monitor.lock.threshold";
 
+	public static final String UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD =
+		"upgrade.query.monitor.long.running.threshold";
+
 	public static final String UPGRADE_REPORT_DIR = "upgrade.report.dir";
 
 	public static final String UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2401,6 +2401,12 @@ public class PropsValues {
 			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),
 			300000);
 
+	public static final long UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD =
+		GetterUtil.getLong(
+			PropsUtil.get(
+				PropsKeys.UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD),
+			600000);
+
 	public static final String UPGRADE_REPORT_DIR = GetterUtil.getString(
 		PropsUtil.get(PropsKeys.UPGRADE_REPORT_DIR));
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84035
https://liferay.atlassian.net/browse/LPD-84039

**What is being fixed:** The upgrade process had no way to detect queries that were running for an unusually long time without being blocked by a lock. The existing `getLockedQueryInfos` API only surfaced lock-contended queries, leaving silent long-running queries invisible during upgrade monitoring.

**How it is being fixed:** A new `getLongRunningQueryInfos(Connection, long threshold)` method is added to the `DB` interface with a default no-op implementation. `BaseDB` implements the method by delegating to a shared private `_getQueryInfos` helper, which also absorbs the duplicate logic previously inlined in `getLockedQueryInfos`. A new `getLongRunningQueryInfosSQL()` protected hook (returning `null` by default) is overridden in DB2DB, MySQLDB, OracleDB, PostgreSQLDB, and SQLServerDB with database-specific queries that filter out sleeping, lock-waiting, and self connections and return duration, ID, query text, schema, and state columns. A new portal property `upgrade.query.monitor.long.running.threshold` (default 600000 ms) controls the threshold, mirroring the existing lock-threshold property. Integration tests covering all five databases are added to `DBTest`.