### PR TITLE
LPD-86835 Guard against null SQL in DBResourceUtil

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -214,6 +214,10 @@ public class DBResourceUtil {
 	public static Set<String> parseCreateTableSQL(String createTableSQL) {
 		Set<String> tableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
+		if (createTableSQL == null) {
+			return tableNames;
+		}
+
 		Matcher matcher = _createTablePattern.matcher(createTableSQL);
 
 		while (matcher.find()) {
@@ -298,6 +302,10 @@ public class DBResourceUtil {
 		String sql) {
 
 		Map<String, List<String>> columnDefinitionsMap = new TreeMap<>();
+
+		if (sql == null) {
+			return columnDefinitionsMap;
+		}
 
 		String tableName = null;
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/db/DBResourceUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/db/DBResourceUtilTest.java
@@ -119,6 +119,14 @@ public class DBResourceUtilTest {
 		}
 	}
 
+	@Test
+	public void testParseCreateTableSQLWhenSQLIsNull() {
+		Assert.assertTrue(
+			DBResourceUtil.parseCreateTableSQL(
+				null
+			).isEmpty());
+	}
+
 	private InputStream _getSQLFileInputStream(String lineSeparator) {
 		String sqlFile = StringBundler.concat(
 			"create index IX_TEST1 on Table1 (field1);", lineSeparator,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86835

**What is being fixed:** `parseCreateTableSQL` and `_parseColumnDefinitionsMap` in `DBResourceUtil` pass the result of `resultSet.getString(1)` directly to `Pattern.matcher()`. On Oracle, a blank `VARCHAR2` column returns `NULL` from `getString`, which causes `Pattern.matcher()` to throw a `NullPointerException`.

**How it is being fixed:** Guard clauses are added at the top of both methods — `parseCreateTableSQL` returns `Collections.emptySet()` immediately when the SQL argument is null, and `_parseColumnDefinitionsMap` returns `Collections.emptyMap()`. A unit test covering the null input path is added to `DBResourceUtilTest`.