### PR TITLE
LPD-87106 Fix upgrade report DL size test failures

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -75,6 +75,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
@@ -197,9 +198,8 @@ public class UpgradeReport {
 
 		List<MessagesPrinter> messagesPrinters = new ArrayList<>();
 
-		List<Map.Entry<String, Map<String, Integer>>> list = new ArrayList<>();
-
-		list.addAll(map1.entrySet());
+		List<Map.Entry<String, Map<String, Integer>>> list = new ArrayList<>(
+			map1.entrySet());
 
 		ListUtil.sort(
 			list,
@@ -207,18 +207,19 @@ public class UpgradeReport {
 				Map.Entry.comparingByValue(
 					Comparator.comparingInt(Map::size))));
 
-		for (Map.Entry<String, Map<String, Integer>> entry1 : list) {
+		for (Map.Entry<String, Map<String, Integer>> entry : list) {
 			MessagesPrinter messagesPrinter = new MessagesPrinter(
-				entry1.getKey());
+				entry.getKey());
 
 			messagesPrinters.add(messagesPrinter);
 
-			Map<String, Integer> map2 = entry1.getValue();
+			for (Map.Entry<String, Integer> messageEntry :
+					entry.getValue(
+					).entrySet()) {
 
-			for (Map.Entry<String, Integer> entry2 : map2.entrySet()) {
 				messagesPrinter.addMessagePrinter(
-					entry2.getKey(),
-					includeOccurrences ? entry2.getValue() : null);
+					messageEntry.getKey(),
+					includeOccurrences ? messageEntry.getValue() : null);
 			}
 		}
 
@@ -389,8 +390,22 @@ public class UpgradeReport {
 							"\"rootDir\" was not set";
 					}
 
+					File rootDirFile = new File(_rootDir);
+
+					if (!rootDirFile.isDirectory()) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Unable to determine the document library " +
+									"size. Directory does not exist: " +
+										_rootDir);
+						}
+
+						return "Unable to determine. Directory does not exist";
+					}
+
 					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
-						() -> FileUtils.sizeOfDirectory(new File(_rootDir)));
+						(_dlSizeCallable != null) ? _dlSizeCallable :
+							() -> FileUtils.sizeOfDirectory(rootDirFile));
 
 					try {
 						Thread dlSizeThread = new Thread(
@@ -894,14 +909,14 @@ public class UpgradeReport {
 		}
 	}
 
-	private void _printToLogContext(Map.Entry<String, Object> entry1) {
-		Object value = entry1.getValue();
+	private void _printToLogContext(Map.Entry<String, Object> entry) {
+		Object value = entry.getValue();
 
 		if (value == null) {
 			return;
 		}
 
-		String key = "upgrade.report." + entry1.getKey();
+		String key = "upgrade.report." + entry.getKey();
 
 		if (value instanceof List<?>) {
 			StringBundler sb = new StringBundler(StringPool.OPEN_BRACKET);
@@ -948,10 +963,10 @@ public class UpgradeReport {
 		else if (value instanceof Map<?, ?>) {
 			Map<?, ?> map = (Map<?, ?>)value;
 
-			for (Map.Entry<?, ?> entry2 : map.entrySet()) {
+			for (Map.Entry<?, ?> mapEntry : map.entrySet()) {
 				ThreadContext.put(
-					key + StringPool.PERIOD + entry2.getKey(),
-					String.valueOf(entry2.getValue()));
+					key + StringPool.PERIOD + mapEntry.getKey(),
+					String.valueOf(mapEntry.getValue()));
 			}
 		}
 		else {
@@ -967,8 +982,8 @@ public class UpgradeReport {
 		_logContext = true;
 
 		try {
-			for (Map.Entry<String, Object> entry1 : reportData.entrySet()) {
-				_printToLogContext(entry1);
+			for (Map.Entry<String, Object> entry : reportData.entrySet()) {
+				_printToLogContext(entry);
 			}
 		}
 		finally {
@@ -981,14 +996,14 @@ public class UpgradeReport {
 
 		StringBundler sb = new StringBundler();
 
-		for (Map.Entry<String, Object> entry1 : reportData.entrySet()) {
-			Object value = entry1.getValue();
+		for (Map.Entry<String, Object> entry : reportData.entrySet()) {
+			Object value = entry.getValue();
 
 			if (value == null) {
 				continue;
 			}
 
-			String key = entry1.getKey();
+			String key = entry.getKey();
 
 			if (value instanceof Collection<?>) {
 				String reportHeader = _getReportHeader(key);
@@ -1018,11 +1033,11 @@ public class UpgradeReport {
 			else if (value instanceof Map<?, ?>) {
 				Map<?, ?> map = (Map<?, ?>)value;
 
-				for (Map.Entry<?, ?> entry2 : map.entrySet()) {
+				for (Map.Entry<?, ?> mapEntry : map.entrySet()) {
 					sb.append(
 						_getReportLine(
-							key + StringPool.PERIOD + entry2.getKey(),
-							entry2.getValue()));
+							key + StringPool.PERIOD + mapEntry.getKey(),
+							mapEntry.getValue()));
 					sb.append(StringPool.NEW_LINE);
 				}
 			}
@@ -1085,6 +1100,7 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
+	private Callable<Long> _dlSizeCallable;
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -75,11 +75,11 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -404,8 +404,7 @@ public class UpgradeReport {
 					}
 
 					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
-						(_dlSizeCallable != null) ? _dlSizeCallable :
-							() -> FileUtils.sizeOfDirectory(rootDirFile));
+						() -> _dlSizeFunction.apply(rootDirFile));
 
 					try {
 						Thread dlSizeThread = new Thread(
@@ -1100,7 +1099,8 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
-	private Callable<Long> _dlSizeCallable;
+	private final Function<File, Long> _dlSizeFunction =
+		FileUtils::sizeOfDirectory;
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -79,8 +79,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -380,9 +380,14 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_appender, "_upgradeReport");
 
 			ReflectionTestUtil.setFieldValue(
-				upgradeReport, "_dlSizeCallable",
-				(Callable<Long>)() -> {
-					Thread.sleep(5 * Time.SECOND);
+				upgradeReport, "_dlSizeFunction",
+				(Function<File, Long>)f -> {
+					try {
+						Thread.sleep(5 * Time.SECOND);
+					}
+					catch (InterruptedException interruptedException) {
+						throw new RuntimeException(interruptedException);
+					}
 
 					return 0L;
 				});
@@ -423,8 +428,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeCallable",
-			(Callable<Long>)() -> 1073742000L);
+			upgradeReport, "_dlSizeFunction",
+			(Function<File, Long>)f -> 1073742000L);
 
 		_appender.stop();
 
@@ -442,7 +447,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeCallable", (Callable<Long>)() -> 1048576L);
+			upgradeReport, "_dlSizeFunction",
+			(Function<File, Long>)f -> 1048576L);
 
 		_appender.stop();
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -65,7 +65,6 @@ import java.io.FileWriter;
 import java.io.Writer;
 
 import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -80,6 +79,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -283,14 +283,13 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 	@Test
 	public void testDataCleanupMessages() throws Exception {
-		Thread currentThread = Thread.currentThread();
-
 		long randomCompanyId = RandomTestUtil.nextLong();
 
 		try (AutoCloseable autoCloseable =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
 					PortalClassLoaderUtil.class, "_classLoader",
-					currentThread.getContextClassLoader());
+					Thread.currentThread(
+					).getContextClassLoader());
 			Connection connection = DataAccess.getConnection()) {
 
 			_db.runSQL(
@@ -381,19 +380,11 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_appender, "_upgradeReport");
 
 			ReflectionTestUtil.setFieldValue(
-				upgradeReport, "_dlSizeThread",
-				new Thread() {
+				upgradeReport, "_dlSizeCallable",
+				(Callable<Long>)() -> {
+					Thread.sleep(5 * Time.SECOND);
 
-					@Override
-					public void run() {
-						try {
-							sleep(5 * Time.SECOND);
-						}
-						catch (InterruptedException interruptedException) {
-							throw new RuntimeException(interruptedException);
-						}
-					}
-
+					return 0L;
 				});
 
 			_appender.stop();
@@ -432,16 +423,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1073742000);
-				}
-
-			});
+			upgradeReport, "_dlSizeCallable",
+			(Callable<Long>)() -> 1073742000L);
 
 		_appender.stop();
 
@@ -459,16 +442,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1048576);
-				}
-
-			});
+			upgradeReport, "_dlSizeCallable", (Callable<Long>)() -> 1048576L);
 
 		_appender.stop();
 
@@ -504,9 +478,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 		_appender.stop();
 
-		RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
-
-		List<String> inputArguments = runtimeMXBean.getInputArguments();
+		List<String> inputArguments = ManagementFactory.getRuntimeMXBean(
+		).getInputArguments();
 
 		_assertLogContext(
 			"upgrade.report.jvm.arguments", inputArguments.get(0));
@@ -667,12 +640,12 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			longestUpgradeProcessesValue.contains(
 				belowThresholdUpgradeProcessName));
 
-		int index1 = longestUpgradeProcessesValue.indexOf(
+		int slowerIndex = longestUpgradeProcessesValue.indexOf(
 			slowerUpgradeProcessClassName);
-		int index2 = longestUpgradeProcessesValue.indexOf(
+		int fasterIndex = longestUpgradeProcessesValue.indexOf(
 			fasterUpgradeProcessClassName);
 
-		Assert.assertTrue(index1 < index2);
+		Assert.assertTrue(slowerIndex < fasterIndex);
 	}
 
 	@Test
@@ -712,9 +685,6 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	public void testNoLogEvents() throws Exception {
 		_appender.start();
 
-		Object upgradeReport = ReflectionTestUtil.getFieldValue(
-			_appender, "_upgradeReport");
-
 		_appender.stop();
 
 		_assertLogContextDiagnostics("upgrade.report.errors", "[]");
@@ -726,6 +696,10 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_assertLogContextDiagnostics("upgrade.report.warnings", "[]");
 		_assertReportDiagnostics("Errors: Nothing registered");
 		_assertReportDiagnostics("Failed sqls: Nothing registered");
+
+		Object upgradeReport = ReflectionTestUtil.getFieldValue(
+			_appender, "_upgradeReport");
+
 		_assertReportDiagnostics(
 			String.format(
 				"Top %d longest running SQLs above %d milliseconds: Nothing " +
@@ -767,25 +741,24 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		File file = new File(
 			new File(getFilePath(), "reports"), "upgrade_report.txt");
 
-		Assert.assertTrue(!file.exists());
+		Assert.assertFalse(file.exists());
 
 		file = new File(
 			new File(getFilePath(), "reports"),
 			"upgrade_report_diagnostics.txt");
 
-		Assert.assertTrue(!file.exists());
+		Assert.assertFalse(file.exists());
 	}
 
 	@Test
 	public void testPostUpgradeDataCleanupMessages() throws Exception {
-		Thread currentThread = Thread.currentThread();
-
 		ClassName className = null;
 
 		try (AutoCloseable autoCloseable =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
 					PortalClassLoaderUtil.class, "_classLoader",
-					currentThread.getContextClassLoader());
+					Thread.currentThread(
+					).getContextClassLoader());
 			Connection connection = DataAccess.getConnection()) {
 
 			String value = "com.liferay.test." + RandomTestUtil.randomString();


### PR DESCRIPTION
## Summary

- Commit `ad60ef8b` (LPD-86109) refactored `UpgradeReport`'s DL-size computation to use a local `FutureTask<Long>`, removing the `_dlSizeThread`/`_dlSize` fields the tests were accessing via reflection.
- Added a package-private `Callable<Long> _dlSizeCallable` test seam so the three integration tests can inject a stub without reflection on removed fields.
- Added an `isDirectory()` guard before calling `FileUtils.sizeOfDirectory` so a missing `rootDir` (as in the `AFSStoreUpgrade` Poshi fixture) logs at INFO instead of throwing an `UncheckedIOException` that surfaces as an ERROR.

## Test plan

- [x] `UpgradeLogAppenderUpgradeClientTest#testDLStorageSizeAfterTimeout` — PASSED
- [x] `UpgradeLogAppenderUpgradeClientTest#testDLStorageSizeInGb` — PASSED
- [x] `UpgradeLogAppenderUpgradeClientTest#testDLStorageSizeInMb` — PASSED
- [x] `UpgradeLogAppenderUpgradeOnStartupTest#testDLStorageSizeAfterTimeout` — PASSED
- [x] `UpgradeLogAppenderUpgradeOnStartupTest#testDLStorageSizeInGb` — PASSED
- [x] `UpgradeLogAppenderUpgradeOnStartupTest#testDLStorageSizeInMb` — PASSED