### PR TITLE
LPD-84251 Hard refresh after the post-upgrade login

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
@@ -13,6 +13,8 @@ definition {
 			specificURL = "http://localhost:8080",
 			userEmailAddress = "test@liferay.com");
 
+		TestUtils.hardRefresh();
+
 		ApplicationsMenu.gotoPortlet(
 			category = "Configuration",
 			panel = "Control Panel",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/searchportlet/SearchContinuousUpgrade.testcase
@@ -54,8 +54,6 @@ definition {
 
 		Upgrade.restoreOriginalBundleAndUpgrade();
 
-		TestUtils.hardRefresh();
-
 		SearchPage.searchEmbedded(searchTerm = "WC Title");
 
 		Portlet.gotoPortletOptions(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalContinuousUpgrade.testcase
@@ -39,8 +39,6 @@ definition {
 
 		Upgrade.restoreOriginalBundleAndUpgrade();
 
-		TestUtils.hardRefresh();
-
 		ContentPages.viewFragmentImage(
 			fragmentName = "image",
 			id = "image-square",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84251

## What is being fixed

After auto-upgrade from a 2026.q1.x-lts bundle to master, several Poshi tests fail at the first SPA-rendered UI element they try to interact with — the Apps Menu side-nav (Configuration → Search), the GlobalMenu toggle button, or the Search Administration index actions table — because the first post-upgrade page load is slower than Poshi's wait window. The failures show up across at least four testcases (PortalContinuousUpgrade, SearchContinuousUpgrade, PortalDatabaseValidationUpgrade, plus the partitioned variants in PortalContinuousUpgrade) and have a 100% failure rate in CI on recent builds with bundle `2026.q1.6-lts`.

## How it is being fixed

Add a single `TestUtils.hardRefresh()` inside `Upgrade.restoreOriginalBundleAndUpgrade()`, between `User.firstLoginUI` and `ApplicationsMenu.gotoPortlet`, so the slow first-mount happens against a warm server with caches populated on the second request. This is the same workaround pattern already established under LPD-84251 by commit 30d5bd62 in `SearchAdministration.startReindex`. The two `TestUtils.hardRefresh()` calls previously placed right after `restoreOriginalBundleAndUpgrade()` in `PortalContinuousUpgrade.testcase` and `SearchContinuousUpgrade.testcase` are now redundant — the macro itself does the refresh — and are removed in a follow-up commit. The other four call sites of `restoreOriginalBundleAndUpgrade()` were audited and correctly left as-is: their following `firstLoginUI`/`firstLoginPG` to a virtual host is a separate login that the macro's internal refresh doesn't cover.

## Why are there no tests?

These commits *are* the test-framework changes. They modify Poshi macros and testcases to stabilize the existing upgrade test suite. Validation is the existing test suite running in CI: the four affected upgrade testcases should go from consistently failing (100% red on recent builds) to consistently passing once this lands.