### PR TITLE
LPD-84027 Add UpgradeQueryMonitor to log locked queries during upgrades

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -49,6 +49,7 @@ import com.liferay.portal.transaction.TransactionsUtil;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 import com.liferay.portal.upgrade.data.cleanup.DataCleanupPreupgradeProcessSuite;
 import com.liferay.portal.upgrade.log.UpgradeLogContext;
+import com.liferay.portal.upgrade.monitor.UpgradeQueryMonitor;
 import com.liferay.portal.util.InitUtil;
 import com.liferay.portal.util.PortalClassPathUtil;
 import com.liferay.portal.verify.PreupgradeVerifyProcessSuite;
@@ -249,9 +250,13 @@ public class DBUpgrader {
 		serviceLatch.openOn(
 			() -> {
 			});
+
+		UpgradeQueryMonitor.start();
 	}
 
 	public static void stopUpgradeLogAppender() {
+		UpgradeQueryMonitor.stop();
+
 		UpgradeLogProgressTracker.stop();
 
 		if ((_appender != null) && _appender.isStarted()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -111,10 +111,10 @@ public final class UpgradeQueryMonitor {
 			}
 
 			if (_log.isWarnEnabled()) {
-				_log.warn("Upgrade query monitoring is disabled");
 				_log.warn(
-					"Unable to detect locked queries: " +
-						exception.getMessage());
+					StringBundler.concat(
+						"Upgrade query monitoring is disabled: ",
+						exception.getMessage()));
 			}
 
 			if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -94,8 +94,8 @@ public final class UpgradeQueryMonitor {
 					_log.warn(
 						StringBundler.concat(
 							"Locked query \"", lockedQueryInfo.getQuery(),
-							"\" (id ", lockedQueryInfo.getId(),
-							") running for ",
+							"\" with ID ", lockedQueryInfo.getId(),
+							" has been running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								lockedQueryInfo.getDuration()),
 							" seconds"));

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.monitor;
+
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.kernel.util.NamedThreadFactory;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import java.sql.Connection;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import javax.sql.DataSource;
+
+/**
+ * @author Jorge Avalos
+ */
+public final class UpgradeQueryMonitor {
+
+	public static synchronized void start() {
+		if (!PropsValues.UPGRADE_QUERY_MONITOR_ENABLED ||
+			(_scheduledExecutorService != null)) {
+
+			return;
+		}
+
+		_scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+			new NamedThreadFactory(
+				"Liferay Upgrade Query Monitor", Thread.NORM_PRIORITY, null));
+
+		_scheduledExecutorService.scheduleWithFixedDelay(
+			UpgradeQueryMonitor::_poll, _POLLING_INTERVAL_SECONDS,
+			_POLLING_INTERVAL_SECONDS, TimeUnit.SECONDS);
+	}
+
+	public static synchronized void stop() {
+		if (_scheduledExecutorService == null) {
+			return;
+		}
+
+		_scheduledExecutorService.shutdownNow();
+
+		try {
+			if (!_scheduledExecutorService.awaitTermination(
+					_SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Upgrade query monitor did not terminate within ",
+							_SHUTDOWN_TIMEOUT_SECONDS, " seconds."));
+				}
+			}
+		}
+		catch (InterruptedException interruptedException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(interruptedException);
+			}
+
+			Thread currentThread = Thread.currentThread();
+
+			currentThread.interrupt();
+		}
+
+		_scheduledExecutorService = null;
+	}
+
+	private static void _poll() {
+		DataSource dataSource = InfrastructureUtil.getDataSource();
+
+		if (dataSource == null) {
+			return;
+		}
+
+		try (Connection connection = dataSource.getConnection()) {
+			DB db = DBManagerUtil.getDB();
+
+			List<DB.QueryInfo> lockedQueryInfos = db.getLockedQueryInfos(
+				connection);
+
+			for (DB.QueryInfo lockedQueryInfo : lockedQueryInfos) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Query \"", lockedQueryInfo.getQuery(), "\" (id ",
+							lockedQueryInfo.getId(),
+							"), which has been running for ",
+							TimeUnit.MILLISECONDS.toSeconds(
+								lockedQueryInfo.getDuration()),
+							" seconds, is locked."));
+				}
+			}
+		}
+		catch (Exception exception) {
+			Thread currentThread = Thread.currentThread();
+
+			if (currentThread.isInterrupted()) {
+				return;
+			}
+
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Upgrade query monitoring was disabled. Unable to ",
+						"detect locked queries: ", exception.getMessage()));
+			}
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			ReflectionUtil.throwException(exception);
+		}
+	}
+
+	private UpgradeQueryMonitor() {
+	}
+
+	private static final long _POLLING_INTERVAL_SECONDS = 60;
+
+	private static final long _SHUTDOWN_TIMEOUT_SECONDS = 5;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradeQueryMonitor.class);
+
+	private static ScheduledExecutorService _scheduledExecutorService;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -69,9 +69,8 @@ public final class UpgradeQueryMonitor {
 				_log.debug(interruptedException);
 			}
 
-			Thread currentThread = Thread.currentThread();
-
-			currentThread.interrupt();
+			Thread.currentThread(
+			).interrupt();
 		}
 
 		_scheduledExecutorService = null;
@@ -104,17 +103,16 @@ public final class UpgradeQueryMonitor {
 			}
 		}
 		catch (Exception exception) {
-			Thread currentThread = Thread.currentThread();
+			if (Thread.currentThread(
+				).isInterrupted()) {
 
-			if (currentThread.isInterrupted()) {
 				return;
 			}
 
 			if (_log.isWarnEnabled()) {
 				_log.warn(
-					StringBundler.concat(
-						"Upgrade query monitoring is disabled: ",
-						exception.getMessage()));
+					"Upgrade query monitoring is disabled: " +
+						exception.getMessage());
 			}
 
 			if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -59,8 +59,8 @@ public final class UpgradeQueryMonitor {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
-							"Upgrade query monitor did not terminate within ",
-							_SHUTDOWN_TIMEOUT_SECONDS, " seconds."));
+							"Unable to terminate upgrade query monitor ",
+							"within ", _SHUTDOWN_TIMEOUT_SECONDS, " seconds"));
 				}
 			}
 		}
@@ -94,12 +94,12 @@ public final class UpgradeQueryMonitor {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
-							"Query \"", lockedQueryInfo.getQuery(), "\" (id ",
-							lockedQueryInfo.getId(),
-							"), which has been running for ",
+							"Locked query \"", lockedQueryInfo.getQuery(),
+							"\" (id ", lockedQueryInfo.getId(),
+							") running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								lockedQueryInfo.getDuration()),
-							" seconds, is locked."));
+							" seconds"));
 				}
 			}
 		}
@@ -111,10 +111,10 @@ public final class UpgradeQueryMonitor {
 			}
 
 			if (_log.isWarnEnabled()) {
+				_log.warn("Upgrade query monitoring is disabled");
 				_log.warn(
-					StringBundler.concat(
-						"Upgrade query monitoring was disabled. Unable to ",
-						"detect locked queries: ", exception.getMessage()));
+					"Unable to detect locked queries: " +
+						exception.getMessage());
 			}
 
 			if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -59,8 +59,8 @@ public final class UpgradeQueryMonitor {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
-							"Unable to terminate upgrade query monitor ",
-							"within ", _SHUTDOWN_TIMEOUT_SECONDS, " seconds"));
+							"Unable to terminate upgrade query monitor within ",
+							_SHUTDOWN_TIMEOUT_SECONDS, " seconds"));
 				}
 			}
 		}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -227,6 +227,14 @@
     upgrade.log.progress.interval=300000
 
     #
+    # Set to true to enable the background thread that monitors long-running
+    # locked queries during upgrades.
+    #
+    # Env: LIFERAY_UPGRADE_PERIOD_QUERY_PERIOD_MONITOR_PERIOD_ENABLED
+    #
+    upgrade.query.monitor.enabled=true
+
+    #
     # Set the threshold in milliseconds before a query waiting on resources is
     # flagged as locked.
     #

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -1,0 +1,314 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.monitor;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.sql.DataSource;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class UpgradeQueryMonitorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@After
+	public void tearDown() {
+		UpgradeQueryMonitor.stop();
+	}
+
+	@Test
+	public void testPoll() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				UpgradeQueryMonitor.class.getName(), LoggerTestUtil.WARN)) {
+
+			Connection connection = Mockito.mock(Connection.class);
+
+			DataSource dataSource = Mockito.mock(DataSource.class);
+
+			Mockito.when(
+				dataSource.getConnection()
+			).thenReturn(
+				connection
+			);
+
+			DB db = Mockito.mock(DB.class);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			String id1 = RandomTestUtil.randomString();
+			String id2 = RandomTestUtil.randomString();
+			String id3 = RandomTestUtil.randomString();
+			String id4 = RandomTestUtil.randomString();
+			String query1 = RandomTestUtil.randomString();
+			String query2 = RandomTestUtil.randomString();
+			String query3 = RandomTestUtil.randomString();
+			String query4 = RandomTestUtil.randomString();
+
+			String expectedMessage1 = StringBundler.concat(
+				"Query \"", query1, "\" (id ", id1,
+				"), which has been running for 30 seconds, is locked.");
+			String expectedMessage2 = StringBundler.concat(
+				"Query \"", query2, "\" (id ", id2,
+				"), which has been running for 300 seconds, is locked.");
+			String expectedMessage3 = StringBundler.concat(
+				"Query \"", query3, "\" (id ", id3,
+				"), which has been running for 600 seconds, is locked.");
+			String expectedMessage4 = StringBundler.concat(
+				"Query \"", query4, "\" (id ", id4,
+				"), which has been running for 900 seconds, is locked.");
+
+			DataSource originalDataSource = InfrastructureUtil.getDataSource();
+
+			InfrastructureUtil.setDataSource(dataSource);
+
+			try {
+				Mockito.when(
+					db.getLockedQueryInfos(connection)
+				).thenReturn(
+					Collections.emptyList()
+				);
+
+				ReflectionTestUtil.invoke(
+					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+				List<LogEntry> logEntries = logCapture.getLogEntries();
+
+				Assert.assertTrue(logEntries.isEmpty());
+
+				Mockito.when(
+					db.getLockedQueryInfos(connection)
+				).thenReturn(
+					Collections.singletonList(
+						new DB.QueryInfo(
+							30000, id1, query1, RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()))
+				);
+
+				ReflectionTestUtil.invoke(
+					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+				logEntries = logCapture.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 1, logEntries.size());
+
+				LogEntry logEntry1 = logEntries.get(0);
+
+				Assert.assertEquals(expectedMessage1, logEntry1.getMessage());
+				Assert.assertEquals("WARN", logEntry1.getPriority());
+
+				Mockito.when(
+					db.getLockedQueryInfos(connection)
+				).thenReturn(
+					Arrays.asList(
+						new DB.QueryInfo(
+							300000, id2, query2, RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()),
+						new DB.QueryInfo(
+							600000, id3, query3, RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()),
+						new DB.QueryInfo(
+							900000, id4, query4, RandomTestUtil.randomString(),
+							RandomTestUtil.randomString()))
+				);
+
+				ReflectionTestUtil.invoke(
+					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+				logEntries = logCapture.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 4, logEntries.size());
+
+				LogEntry logEntry2 = logEntries.get(1);
+				LogEntry logEntry3 = logEntries.get(2);
+				LogEntry logEntry4 = logEntries.get(3);
+
+				Assert.assertEquals(expectedMessage2, logEntry2.getMessage());
+				Assert.assertEquals(expectedMessage3, logEntry3.getMessage());
+				Assert.assertEquals(expectedMessage4, logEntry4.getMessage());
+			}
+			finally {
+				InfrastructureUtil.setDataSource(originalDataSource);
+			}
+		}
+	}
+
+	@Test
+	public void testPollDisablesMonitoringOnSQLException() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				UpgradeQueryMonitor.class.getName(), LoggerTestUtil.WARN)) {
+
+			Connection connection = Mockito.mock(Connection.class);
+
+			DataSource dataSource = Mockito.mock(DataSource.class);
+
+			Mockito.when(
+				dataSource.getConnection()
+			).thenReturn(
+				connection
+			);
+
+			DB db = Mockito.mock(DB.class);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			String exceptionMessage = RandomTestUtil.randomString();
+
+			Mockito.when(
+				db.getLockedQueryInfos(connection)
+			).thenThrow(
+				new SQLException(exceptionMessage)
+			);
+
+			DataSource originalDataSource = InfrastructureUtil.getDataSource();
+
+			InfrastructureUtil.setDataSource(dataSource);
+
+			try {
+				Assert.assertThrows(
+					SQLException.class,
+					() -> ReflectionTestUtil.invoke(
+						UpgradeQueryMonitor.class, "_poll", new Class<?>[0]));
+
+				List<LogEntry> logEntries = logCapture.getLogEntries();
+
+				Assert.assertEquals(
+					logEntries.toString(), 1, logEntries.size());
+
+				LogEntry logEntry1 = logEntries.get(0);
+
+				Assert.assertEquals(
+					StringBundler.concat(
+						"Upgrade query monitoring was disabled. Unable to ",
+						"detect locked queries: ", exceptionMessage),
+					logEntry1.getMessage());
+			}
+			finally {
+				InfrastructureUtil.setDataSource(originalDataSource);
+			}
+		}
+	}
+
+	@Test
+	public void testStart() throws Exception {
+
+		// disabled
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_ENABLED", false)) {
+
+			UpgradeQueryMonitor.start();
+
+			Assert.assertNull(
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
+		}
+
+		// enabled
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_ENABLED", true)) {
+
+			UpgradeQueryMonitor.start();
+
+			ScheduledExecutorService scheduledExecutorService =
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE);
+
+			Assert.assertNotNull(scheduledExecutorService);
+
+			UpgradeQueryMonitor.start();
+
+			Assert.assertSame(
+				scheduledExecutorService,
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
+		}
+	}
+
+	@Test
+	public void testStop() throws Exception {
+
+		// not started
+
+		UpgradeQueryMonitor.stop();
+
+		Assert.assertNull(
+			ReflectionTestUtil.getFieldValue(
+				UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
+
+		// started
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_QUERY_MONITOR_ENABLED", true)) {
+
+			UpgradeQueryMonitor.start();
+
+			Assert.assertNotNull(
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
+
+			UpgradeQueryMonitor.stop();
+
+			Assert.assertNull(
+				ReflectionTestUtil.getFieldValue(
+					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
+		}
+	}
+
+	private static final String _SCHEDULED_EXECUTOR_SERVICE =
+		"_scheduledExecutorService";
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -87,17 +87,17 @@ public class UpgradeQueryMonitorTest {
 			String query4 = RandomTestUtil.randomString();
 
 			String expectedMessage1 = StringBundler.concat(
-				"Query \"", query1, "\" (id ", id1,
-				"), which has been running for 30 seconds, is locked.");
+				"Locked query \"", query1, "\" (id ", id1,
+				") running for 30 seconds");
 			String expectedMessage2 = StringBundler.concat(
-				"Query \"", query2, "\" (id ", id2,
-				"), which has been running for 300 seconds, is locked.");
+				"Locked query \"", query2, "\" (id ", id2,
+				") running for 300 seconds");
 			String expectedMessage3 = StringBundler.concat(
-				"Query \"", query3, "\" (id ", id3,
-				"), which has been running for 600 seconds, is locked.");
+				"Locked query \"", query3, "\" (id ", id3,
+				") running for 600 seconds");
 			String expectedMessage4 = StringBundler.concat(
-				"Query \"", query4, "\" (id ", id4,
-				"), which has been running for 900 seconds, is locked.");
+				"Locked query \"", query4, "\" (id ", id4,
+				") running for 900 seconds");
 
 			DataSource originalDataSource = InfrastructureUtil.getDataSource();
 
@@ -222,15 +222,19 @@ public class UpgradeQueryMonitorTest {
 				List<LogEntry> logEntries = logCapture.getLogEntries();
 
 				Assert.assertEquals(
-					logEntries.toString(), 1, logEntries.size());
+					logEntries.toString(), 2, logEntries.size());
 
 				LogEntry logEntry1 = logEntries.get(0);
 
 				Assert.assertEquals(
-					StringBundler.concat(
-						"Upgrade query monitoring was disabled. Unable to ",
-						"detect locked queries: ", exceptionMessage),
+					"Upgrade query monitoring is disabled",
 					logEntry1.getMessage());
+
+				LogEntry logEntry2 = logEntries.get(1);
+
+				Assert.assertEquals(
+					"Unable to detect locked queries: " + exceptionMessage,
+					logEntry2.getMessage());
 			}
 			finally {
 				InfrastructureUtil.setDataSource(originalDataSource);

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -96,7 +96,7 @@ public class UpgradeQueryMonitorTest {
 	@Test
 	public void testStart() throws Exception {
 
-		// disabled
+		// Disabled
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -109,7 +109,7 @@ public class UpgradeQueryMonitorTest {
 					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
 		}
 
-		// enabled
+		// Enabled
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -291,18 +291,14 @@ public class UpgradeQueryMonitorTest {
 
 		List<LogEntry> logEntries = logCapture.getLogEntries();
 
-		Assert.assertEquals(logEntries.toString(), 6, logEntries.size());
+		Assert.assertEquals(logEntries.toString(), 5, logEntries.size());
 
-		LogEntry logEntry1 = logEntries.get(4);
-
-		Assert.assertEquals(
-			"Upgrade query monitoring is disabled", logEntry1.getMessage());
-
-		LogEntry logEntry2 = logEntries.get(5);
+		LogEntry logEntry = logEntries.get(4);
 
 		Assert.assertEquals(
-			"Unable to detect locked queries: " + exceptionMessage,
-			logEntry2.getMessage());
+			StringBundler.concat(
+				"Upgrade query monitoring is disabled: ", exceptionMessage),
+			logEntry.getMessage());
 	}
 
 	private static final String _SCHEDULED_EXECUTOR_SERVICE =

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -276,12 +276,12 @@ public class UpgradeQueryMonitorTest {
 			Connection connection, DB db, LogCapture logCapture)
 		throws Exception {
 
-		String exceptionMessage = RandomTestUtil.randomString();
+		String message = RandomTestUtil.randomString();
 
 		Mockito.when(
 			db.getLockedQueryInfos(connection)
 		).thenThrow(
-			new SQLException(exceptionMessage)
+			new SQLException(message)
 		);
 
 		Assert.assertThrows(
@@ -296,8 +296,7 @@ public class UpgradeQueryMonitorTest {
 		LogEntry logEntry = logEntries.get(4);
 
 		Assert.assertEquals(
-			StringBundler.concat(
-				"Upgrade query monitoring is disabled: ", exceptionMessage),
+			"Upgrade query monitoring is disabled: " + message,
 			logEntry.getMessage());
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -129,16 +129,11 @@ public class UpgradeQueryMonitorTest {
 
 	@Test
 	public void testStop() throws Exception {
-
-		// not started
-
 		UpgradeQueryMonitor.stop();
 
 		Assert.assertNull(
 			ReflectionTestUtil.getFieldValue(
 				UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
-
-		// started
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -95,9 +95,6 @@ public class UpgradeQueryMonitorTest {
 
 	@Test
 	public void testStart() throws Exception {
-
-		// Disabled
-
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"UPGRADE_QUERY_MONITOR_ENABLED", false)) {
@@ -108,8 +105,6 @@ public class UpgradeQueryMonitorTest {
 				ReflectionTestUtil.getFieldValue(
 					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
 		}
-
-		// Enabled
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -77,164 +77,15 @@ public class UpgradeQueryMonitorTest {
 				db
 			);
 
-			String id1 = RandomTestUtil.randomString();
-			String id2 = RandomTestUtil.randomString();
-			String id3 = RandomTestUtil.randomString();
-			String id4 = RandomTestUtil.randomString();
-			String query1 = RandomTestUtil.randomString();
-			String query2 = RandomTestUtil.randomString();
-			String query3 = RandomTestUtil.randomString();
-			String query4 = RandomTestUtil.randomString();
-
-			String expectedMessage1 = StringBundler.concat(
-				"Locked query \"", query1, "\" (id ", id1,
-				") running for 30 seconds");
-			String expectedMessage2 = StringBundler.concat(
-				"Locked query \"", query2, "\" (id ", id2,
-				") running for 300 seconds");
-			String expectedMessage3 = StringBundler.concat(
-				"Locked query \"", query3, "\" (id ", id3,
-				") running for 600 seconds");
-			String expectedMessage4 = StringBundler.concat(
-				"Locked query \"", query4, "\" (id ", id4,
-				") running for 900 seconds");
-
 			DataSource originalDataSource = InfrastructureUtil.getDataSource();
 
 			InfrastructureUtil.setDataSource(dataSource);
 
 			try {
-				Mockito.when(
-					db.getLockedQueryInfos(connection)
-				).thenReturn(
-					Collections.emptyList()
-				);
-
-				ReflectionTestUtil.invoke(
-					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
-
-				List<LogEntry> logEntries = logCapture.getLogEntries();
-
-				Assert.assertTrue(logEntries.isEmpty());
-
-				Mockito.when(
-					db.getLockedQueryInfos(connection)
-				).thenReturn(
-					Collections.singletonList(
-						new DB.QueryInfo(
-							30000, id1, query1, RandomTestUtil.randomString(),
-							RandomTestUtil.randomString()))
-				);
-
-				ReflectionTestUtil.invoke(
-					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
-
-				logEntries = logCapture.getLogEntries();
-
-				Assert.assertEquals(
-					logEntries.toString(), 1, logEntries.size());
-
-				LogEntry logEntry1 = logEntries.get(0);
-
-				Assert.assertEquals(expectedMessage1, logEntry1.getMessage());
-				Assert.assertEquals("WARN", logEntry1.getPriority());
-
-				Mockito.when(
-					db.getLockedQueryInfos(connection)
-				).thenReturn(
-					Arrays.asList(
-						new DB.QueryInfo(
-							300000, id2, query2, RandomTestUtil.randomString(),
-							RandomTestUtil.randomString()),
-						new DB.QueryInfo(
-							600000, id3, query3, RandomTestUtil.randomString(),
-							RandomTestUtil.randomString()),
-						new DB.QueryInfo(
-							900000, id4, query4, RandomTestUtil.randomString(),
-							RandomTestUtil.randomString()))
-				);
-
-				ReflectionTestUtil.invoke(
-					UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
-
-				logEntries = logCapture.getLogEntries();
-
-				Assert.assertEquals(
-					logEntries.toString(), 4, logEntries.size());
-
-				LogEntry logEntry2 = logEntries.get(1);
-				LogEntry logEntry3 = logEntries.get(2);
-				LogEntry logEntry4 = logEntries.get(3);
-
-				Assert.assertEquals(expectedMessage2, logEntry2.getMessage());
-				Assert.assertEquals(expectedMessage3, logEntry3.getMessage());
-				Assert.assertEquals(expectedMessage4, logEntry4.getMessage());
-			}
-			finally {
-				InfrastructureUtil.setDataSource(originalDataSource);
-			}
-		}
-	}
-
-	@Test
-	public void testPollDisablesMonitoringOnSQLException() throws Exception {
-		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
-				Mockito.mockStatic(DBManagerUtil.class);
-			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				UpgradeQueryMonitor.class.getName(), LoggerTestUtil.WARN)) {
-
-			Connection connection = Mockito.mock(Connection.class);
-
-			DataSource dataSource = Mockito.mock(DataSource.class);
-
-			Mockito.when(
-				dataSource.getConnection()
-			).thenReturn(
-				connection
-			);
-
-			DB db = Mockito.mock(DB.class);
-
-			dbManagerUtilMockedStatic.when(
-				DBManagerUtil::getDB
-			).thenReturn(
-				db
-			);
-
-			String exceptionMessage = RandomTestUtil.randomString();
-
-			Mockito.when(
-				db.getLockedQueryInfos(connection)
-			).thenThrow(
-				new SQLException(exceptionMessage)
-			);
-
-			DataSource originalDataSource = InfrastructureUtil.getDataSource();
-
-			InfrastructureUtil.setDataSource(dataSource);
-
-			try {
-				Assert.assertThrows(
-					SQLException.class,
-					() -> ReflectionTestUtil.invoke(
-						UpgradeQueryMonitor.class, "_poll", new Class<?>[0]));
-
-				List<LogEntry> logEntries = logCapture.getLogEntries();
-
-				Assert.assertEquals(
-					logEntries.toString(), 2, logEntries.size());
-
-				LogEntry logEntry1 = logEntries.get(0);
-
-				Assert.assertEquals(
-					"Upgrade query monitoring is disabled",
-					logEntry1.getMessage());
-
-				LogEntry logEntry2 = logEntries.get(1);
-
-				Assert.assertEquals(
-					"Unable to detect locked queries: " + exceptionMessage,
-					logEntry2.getMessage());
+				_testPollWithNoLockedQueries(connection, db, logCapture);
+				_testPollWithOneLockedQuery(connection, db, logCapture);
+				_testPollWithMultipleLockedQueries(connection, db, logCapture);
+				_testPollWithSQLException(connection, db, logCapture);
 			}
 			finally {
 				InfrastructureUtil.setDataSource(originalDataSource);
@@ -310,6 +161,148 @@ public class UpgradeQueryMonitorTest {
 				ReflectionTestUtil.getFieldValue(
 					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
 		}
+	}
+
+	private void _testPollWithMultipleLockedQueries(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id1 = RandomTestUtil.randomString();
+		String id2 = RandomTestUtil.randomString();
+		String id3 = RandomTestUtil.randomString();
+		String query1 = RandomTestUtil.randomString();
+		String query2 = RandomTestUtil.randomString();
+		String query3 = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLockedQueryInfos(connection)
+		).thenReturn(
+			Arrays.asList(
+				new DB.QueryInfo(
+					300000, id1, query1, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				new DB.QueryInfo(
+					600000, id2, query2, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				new DB.QueryInfo(
+					900000, id3, query3, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 4, logEntries.size());
+
+		LogEntry logEntry1 = logEntries.get(1);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Locked query \"", query1, "\" (id ", id1,
+				") running for 300 seconds"),
+			logEntry1.getMessage());
+
+		LogEntry logEntry2 = logEntries.get(2);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Locked query \"", query2, "\" (id ", id2,
+				") running for 600 seconds"),
+			logEntry2.getMessage());
+
+		LogEntry logEntry3 = logEntries.get(3);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Locked query \"", query3, "\" (id ", id3,
+				") running for 900 seconds"),
+			logEntry3.getMessage());
+	}
+
+	private void _testPollWithNoLockedQueries(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		Mockito.when(
+			db.getLockedQueryInfos(connection)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertTrue(
+			logCapture.getLogEntries(
+			).isEmpty());
+	}
+
+	private void _testPollWithOneLockedQuery(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id = RandomTestUtil.randomString();
+		String query = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLockedQueryInfos(connection)
+		).thenReturn(
+			Collections.singletonList(
+				new DB.QueryInfo(
+					30000, id, query, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Locked query \"", query, "\" (id ", id,
+				") running for 30 seconds"),
+			logEntry.getMessage());
+		Assert.assertEquals("WARN", logEntry.getPriority());
+	}
+
+	private void _testPollWithSQLException(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String exceptionMessage = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLockedQueryInfos(connection)
+		).thenThrow(
+			new SQLException(exceptionMessage)
+		);
+
+		Assert.assertThrows(
+			SQLException.class,
+			() -> ReflectionTestUtil.invoke(
+				UpgradeQueryMonitor.class, "_poll", new Class<?>[0]));
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 6, logEntries.size());
+
+		LogEntry logEntry1 = logEntries.get(4);
+
+		Assert.assertEquals(
+			"Upgrade query monitoring is disabled", logEntry1.getMessage());
+
+		LogEntry logEntry2 = logEntries.get(5);
+
+		Assert.assertEquals(
+			"Unable to detect locked queries: " + exceptionMessage,
+			logEntry2.getMessage());
 	}
 
 	private static final String _SCHEDULED_EXECUTOR_SERVICE =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2732,6 +2732,9 @@ public interface PropsKeys {
 	public static final String UPGRADE_LOG_PROGRESS_INTERVAL =
 		"upgrade.log.progress.interval";
 
+	public static final String UPGRADE_QUERY_MONITOR_ENABLED =
+		"upgrade.query.monitor.enabled";
+
 	public static final String UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
 		"upgrade.query.monitor.lock.threshold";
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -2396,6 +2396,10 @@ public class PropsValues {
 	public static final long UPGRADE_LOG_PROGRESS_INTERVAL = GetterUtil.getLong(
 		PropsUtil.get(PropsKeys.UPGRADE_LOG_PROGRESS_INTERVAL));
 
+	public static final boolean UPGRADE_QUERY_MONITOR_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_ENABLED), true);
+
 	public static final long UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD =
 		GetterUtil.getLong(
 			PropsUtil.get(PropsKeys.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84027

**What is being fixed:** During database upgrades, queries from other sessions can block upgrade steps silently. The portal had no built-in mechanism to surface those blocking queries, making upgrade hangs caused by lock contention difficult to diagnose.

**How it is being fixed:** `UpgradeQueryMonitor` is added in `portal-impl`. When `upgrade.query.monitor.enabled` is `true` (the default), a single-threaded scheduled executor polls the database for locked queries every 60 seconds and logs each one at WARN level. The monitor lifecycle is wired through `DBUpgrader`: `start()` is called before the upgrade begins and `stop()` after it completes. Locked-query detection is delegated to `DB.getLockedQueryInfos(Connection)` so each vendor uses its own native locking view. When `DB.getLockedQueryInfos` throws an `SQLException`, the exception propagates out of the scheduled task (permanently stopping the polling thread) and is logged at WARN. `UpgradeQueryMonitorTest` covers four poll scenarios (no queries, one query, multiple queries, and SQL exception), plus idempotent start/stop lifecycle behavior.