### PR TITLE
LPD-87106 Skip DL size calculation when the root directory does not exist

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -79,6 +79,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -389,8 +390,20 @@ public class UpgradeReport {
 							"\"rootDir\" was not set";
 					}
 
+					File rootDirFile = new File(_rootDir);
+
+					if (!rootDirFile.isDirectory()) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								"Unable to determine the document library " +
+									"size in " + _rootDir);
+						}
+
+						return "Unable to determine. Directory does not exist";
+					}
+
 					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
-						() -> FileUtils.sizeOfDirectory(new File(_rootDir)));
+						() -> _dlSizeFunction.apply(rootDirFile));
 
 					try {
 						Thread dlSizeThread = new Thread(
@@ -1085,6 +1098,8 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
+	private final Function<File, Long> _dlSizeFunction =
+		FileUtils::sizeOfDirectory;
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -396,7 +396,7 @@ public class UpgradeReport {
 						if (_log.isWarnEnabled()) {
 							_log.warn(
 								"Unable to determine the document library " +
-									"size in " + _rootDir);
+									"size in \"" + _rootDir + "\"");
 						}
 
 						return "Unable to determine. Directory does not exist";

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -395,8 +395,9 @@ public class UpgradeReport {
 					if (!rootDirFile.isDirectory()) {
 						if (_log.isWarnEnabled()) {
 							_log.warn(
-								"Unable to determine the document library " +
-									"size in \"" + _rootDir + "\"");
+								StringBundler.concat(
+									"Unable to get document library size in \"",
+									_rootDir, "\""));
 						}
 
 						return "Unable to determine. Directory does not exist";

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -81,6 +81,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -381,19 +382,16 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_appender, "_upgradeReport");
 
 			ReflectionTestUtil.setFieldValue(
-				upgradeReport, "_dlSizeThread",
-				new Thread() {
-
-					@Override
-					public void run() {
-						try {
-							sleep(5 * Time.SECOND);
-						}
-						catch (InterruptedException interruptedException) {
-							throw new RuntimeException(interruptedException);
-						}
+				upgradeReport, "_dlSizeFunction",
+				(Function<File, Long>)f -> {
+					try {
+						Thread.sleep(5 * Time.SECOND);
+					}
+					catch (InterruptedException interruptedException) {
+						throw new RuntimeException(interruptedException);
 					}
 
+					return 0L;
 				});
 
 			_appender.stop();
@@ -432,16 +430,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1073742000);
-				}
-
-			});
+			upgradeReport, "_dlSizeFunction",
+			(Function<File, Long>)f -> 1073742000L);
 
 		_appender.stop();
 
@@ -459,16 +449,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1048576);
-				}
-
-			});
+			upgradeReport, "_dlSizeFunction",
+			(Function<File, Long>)f -> 1048576L);
 
 		_appender.stop();
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -383,7 +383,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 			ReflectionTestUtil.setFieldValue(
 				upgradeReport, "_dlSizeFunction",
-				(Function<File, Long>)f -> {
+				(Function<File, Long>)file -> {
 					try {
 						Thread.sleep(5 * Time.SECOND);
 					}
@@ -431,7 +431,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			upgradeReport, "_dlSizeFunction",
-			(Function<File, Long>)f -> 1073742000L);
+			(Function<File, Long>)file -> 1073742000L);
 
 		_appender.stop();
 
@@ -450,7 +450,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 		ReflectionTestUtil.setFieldValue(
 			upgradeReport, "_dlSizeFunction",
-			(Function<File, Long>)f -> 1048576L);
+			(Function<File, Long>)file -> 1048576L);
 
 		_appender.stop();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87106

**What is being fixed:** UpgradeReport was calling FileUtils.sizeOfDirectory
unconditionally on _rootDir, which caused failures when the DL root directory
did not exist on the filesystem — leading to integration and Poshi test failures.

**How it is being fixed:** A directory-existence check is added before kicking
off the FutureTask. When the root directory is not a real directory, a warning
is logged and the report shows "Unable to determine. Directory does not exist".
The DL-size logic is also extracted into a Function<File, Long> field
(_dlSizeFunction), replacing the previous _dlSizeThread approach. This lets
tests inject a stub function instead of a stub Thread, eliminating the
anonymous Thread subclasses in BaseUpgradeLogAppenderTestCase and simplifying
three test helpers to single-line lambdas.