### PR TITLE
LPD-87106 Fix DL-size integration and Poshi test failures after FutureTask refactor

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -79,6 +79,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -389,8 +390,21 @@ public class UpgradeReport {
 							"\"rootDir\" was not set";
 					}
 
+					File rootDirFile = new File(_rootDir);
+
+					if (!rootDirFile.isDirectory()) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Unable to determine the document library " +
+									"size. Directory does not exist: " +
+										_rootDir);
+						}
+
+						return "Unable to determine";
+					}
+
 					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
-						() -> FileUtils.sizeOfDirectory(new File(_rootDir)));
+						() -> _dlSizeFunction.apply(rootDirFile));
 
 					try {
 						Thread dlSizeThread = new Thread(
@@ -1085,6 +1099,8 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
+	private final Function<File, Long> _dlSizeFunction =
+		FileUtils::sizeOfDirectory;
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -199,9 +199,8 @@ public class UpgradeReport {
 
 		List<MessagesPrinter> messagesPrinters = new ArrayList<>();
 
-		List<Map.Entry<String, Map<String, Integer>>> list = new ArrayList<>();
-
-		list.addAll(map1.entrySet());
+		List<Map.Entry<String, Map<String, Integer>>> list = new ArrayList<>(
+			map1.entrySet());
 
 		ListUtil.sort(
 			list,

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -115,6 +115,7 @@ public class UpgradeReport {
 
 		_executionDateString = _getExecutionDateString();
 		_executionTimeString = _getExecutionTimeString();
+
 		_rootDir = _getRootDir();
 
 		Map<String, Object> reportData = _getReportData(upgradeRecorder);

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -150,7 +150,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			StartupHelperUtil.class, "_newRelease", true);
 
 		_updatePortalRelease(
-			new Version(1, 0, 0), ReleaseInfo.RELEASE_7_1_0_BUILD_NUMBER);
+			ReleaseInfo.RELEASE_7_1_0_BUILD_NUMBER, new Version(1, 0, 0));
 
 		_upgradeReportLogger = (Logger)LogManager.getLogger(
 			"com.liferay.portal.upgrade.internal.report.UpgradeReport");
@@ -532,10 +532,10 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_appender.start();
 
 		LogEvent logEvent = Log4jLogEvent.newBuilder(
-		).setLoggerName(
-			"Warn"
 		).setLevel(
 			Level.WARN
+		).setLoggerName(
+			"Warn"
 		).setMessage(
 			new SimpleMessage("Warning")
 		).build();
@@ -1046,9 +1046,9 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_appender.stop();
 
 				_assertUpgradeReportDirectoryWriteProtected(
-					logCapture, reportDir, "upgrade_report.txt");
+					reportDir, logCapture, "upgrade_report.txt");
 				_assertUpgradeReportDirectoryWriteProtected(
-					logCapture, reportDir, "upgrade_report_diagnostics.txt");
+					reportDir, logCapture, "upgrade_report_diagnostics.txt");
 			}
 		}
 		finally {
@@ -1118,12 +1118,12 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			StartupHelperUtil.class, "_newRelease", _originalNewRelease);
 
 		_updatePortalRelease(
-			PortalUpgradeProcess.getLatestSchemaVersion(),
-			ReleaseInfo.getBuildNumber());
+			ReleaseInfo.getBuildNumber(),
+			PortalUpgradeProcess.getLatestSchemaVersion());
 	}
 
 	private static void _updatePortalRelease(
-			Version schemaVersion, int buildNumber)
+			int buildNumber, Version schemaVersion)
 		throws Exception {
 
 		try (Connection connection = DataAccess.getConnection();
@@ -1241,7 +1241,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 	}
 
 	private void _assertUpgradeReportDirectoryWriteProtected(
-			LogCapture logCapture, File reportDir, String reportFileName)
+			File reportDir, LogCapture logCapture, String reportFileName)
 		throws Exception {
 
 		File reportFile = new File(reportDir, reportFileName);
@@ -1282,9 +1282,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		int index = _getLogContent().indexOf(
 			"INFO - Upgrade report generated in " + file.getAbsolutePath());
 
-		String substringLogContextContent = _getLogContent().substring(index);
-
-		Matcher matcher = pattern.matcher(substringLogContextContent);
+		Matcher matcher = pattern.matcher(_getLogContent().substring(index));
 
 		Assert.assertTrue(matcher.matches());
 
@@ -1453,10 +1451,10 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		@Override
 		protected void doUpgrade() throws Exception {
 			LogEvent logEvent = Log4jLogEvent.newBuilder(
-			).setLoggerName(
-				TestDataCleanupPreupgradeProcess.class.getName()
 			).setLevel(
 				Level.WARN
+			).setLoggerName(
+				TestDataCleanupPreupgradeProcess.class.getName()
 			).setMessage(
 				new SimpleMessage(_CLEANUP_WARNING_MESSAGE)
 			).build();
@@ -1464,10 +1462,10 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender.append(logEvent);
 
 			logEvent = Log4jLogEvent.newBuilder(
-			).setLoggerName(
-				TestDataCleanupPreupgradeProcess.class.getName()
 			).setLevel(
 				Level.INFO
+			).setLoggerName(
+				TestDataCleanupPreupgradeProcess.class.getName()
 			).setMessage(
 				new SimpleMessage(_CLEANUP_INFO_MESSAGE)
 			).build();
@@ -1489,10 +1487,10 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		@Override
 		protected void doUpgrade() throws Exception {
 			LogEvent logEvent = Log4jLogEvent.newBuilder(
-			).setLoggerName(
-				DuplicateUniqueFinderRowsCleaner.class.getName()
 			).setLevel(
 				Level.INFO
+			).setLoggerName(
+				DuplicateUniqueFinderRowsCleaner.class.getName()
 			).setMessage(
 				new SimpleMessage(_DELETE_DUPLICATES_FINDER_WARNING_MESSAGE)
 			).build();

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -388,7 +388,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 						Thread.sleep(5 * Time.SECOND);
 					}
 					catch (InterruptedException interruptedException) {
-						Thread.currentThread().interrupt();
+						Thread.currentThread(
+						).interrupt();
 					}
 
 					return 0L;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -81,6 +81,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -381,19 +382,16 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_appender, "_upgradeReport");
 
 			ReflectionTestUtil.setFieldValue(
-				upgradeReport, "_dlSizeThread",
-				new Thread() {
-
-					@Override
-					public void run() {
-						try {
-							sleep(5 * Time.SECOND);
-						}
-						catch (InterruptedException interruptedException) {
-							throw new RuntimeException(interruptedException);
-						}
+				upgradeReport, "_dlSizeFunction",
+				(Function<File, Long>)file -> {
+					try {
+						Thread.sleep(5 * Time.SECOND);
+					}
+					catch (InterruptedException interruptedException) {
+						Thread.currentThread().interrupt();
 					}
 
+					return 0L;
 				});
 
 			_appender.stop();
@@ -432,16 +430,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1073742000);
-				}
-
-			});
+			upgradeReport, "_dlSizeFunction",
+			(Function<File, Long>)file -> 1073742000L);
 
 		_appender.stop();
 
@@ -459,16 +449,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1048576);
-				}
-
-			});
+			upgradeReport, "_dlSizeFunction",
+			(Function<File, Long>)file -> 1048576L);
 
 		_appender.stop();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87106

The LPD-86109 refactor replaced `_dlSizeThread` and `_dlSize` instance fields with a local `FutureTask`, breaking three integration tests that stubbed those fields and a Poshi test whose fixture configures a `rootDir` not materialized on disk.

Introduce a `_dlSizeFunction` field (`Function<File, Long>`, defaulting to `FileUtils::sizeOfDirectory`) so tests can inject a stub without touching the filesystem. Add a `rootDir` existence check before scheduling the `FutureTask` so a missing directory logs at INFO and returns `"Unable to determine"` instead of propagating an `ExecutionException` logged at ERROR.