### PR TITLE
LPD-87106 Guard missing rootDir and expose DL size supplier as test seam

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -79,6 +79,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -114,7 +115,13 @@ public class UpgradeReport {
 
 		_executionDateString = _getExecutionDateString();
 		_executionTimeString = _getExecutionTimeString();
+
 		_rootDir = _getRootDir();
+
+		if (_dlSizeSupplier == null) {
+			_dlSizeSupplier = () -> FileUtils.sizeOfDirectory(
+				new File(_rootDir));
+		}
 
 		Map<String, Object> reportData = _getReportData(upgradeRecorder);
 
@@ -389,8 +396,21 @@ public class UpgradeReport {
 							"\"rootDir\" was not set";
 					}
 
+					File rootDirFile = new File(_rootDir);
+
+					if (!rootDirFile.isDirectory()) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Unable to determine the document library " +
+									"size. Directory does not exist: " +
+										_rootDir);
+						}
+
+						return "Unable to determine";
+					}
+
 					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
-						() -> FileUtils.sizeOfDirectory(new File(_rootDir)));
+						_dlSizeSupplier::get);
 
 					try {
 						Thread dlSizeThread = new Thread(
@@ -1085,6 +1105,7 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
+	private Supplier<Long> _dlSizeSupplier;
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -81,6 +81,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -381,19 +382,18 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_appender, "_upgradeReport");
 
 			ReflectionTestUtil.setFieldValue(
-				upgradeReport, "_dlSizeThread",
-				new Thread() {
+				upgradeReport, "_dlSizeSupplier",
+				(Supplier<Long>)() -> {
+					try {
+						Thread.sleep(5 * Time.SECOND);
+					}
+					catch (InterruptedException interruptedException) {
+						Thread currentThread = Thread.currentThread();
 
-					@Override
-					public void run() {
-						try {
-							sleep(5 * Time.SECOND);
-						}
-						catch (InterruptedException interruptedException) {
-							throw new RuntimeException(interruptedException);
-						}
+						currentThread.interrupt();
 					}
 
+					return 0L;
 				});
 
 			_appender.stop();
@@ -432,16 +432,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1073742000);
-				}
-
-			});
+			upgradeReport, "_dlSizeSupplier",
+			(Supplier<Long>)() -> 1073742000L);
 
 		_appender.stop();
 
@@ -459,16 +451,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1048576);
-				}
-
-			});
+			upgradeReport, "_dlSizeSupplier", (Supplier<Long>)() -> 1048576L);
 
 		_appender.stop();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87106

**What is being fixed:** When the document library root directory does not
exist (e.g. a fixture upgrade with a non-materialized rootDir), UpgradeReport
calls FileUtils.sizeOfDirectory on a missing path, which throws an
UncheckedIOException that surfaces as an ERROR-level log entry. Three
integration tests also fail with NoSuchFieldException because they still
reference the removed _dlSizeThread/_dlSize fields.

**How it is being fixed:** An isDirectory guard is added before the DL size
FutureTask is created so a missing directory logs at INFO and returns "Unable
to determine" instead of ERROR. The size computation is extracted into a
Supplier<Long> field (_dlSizeSupplier) initialized lazily in generateReport()
after _rootDir is set. Tests inject a controlled supplier via
ReflectionTestUtil, replacing the old _dlSizeThread/_dlSize field dependency.