### PR TITLE
LPD-88624 Scope SQL Server bulk-copy URL params to upgrade tool only

### DIFF
--- a/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
+++ b/modules/apps/batch-engine/batch-engine-service/src/main/java/com/liferay/batch/engine/internal/bundle/BatchEngineBundleTracker.java
@@ -12,7 +12,7 @@ import com.liferay.batch.engine.unit.BatchEngineUnitProcessor;
 import com.liferay.batch.engine.unit.BatchEngineUnitReader;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
-import com.liferay.portal.tools.DBUpgrader;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -72,7 +72,7 @@ public class BatchEngineBundleTracker {
 
 		@Override
 		public Bundle addingBundle(Bundle bundle, BundleEvent bundleEvent) {
-			if (DBUpgrader.isUpgradeClient()) {
+			if (UpgradeProcessUtil.isUpgradeClient()) {
 				return null;
 			}
 

--- a/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
+++ b/modules/apps/batch-engine/batch-engine-test/src/testIntegration/java/com/liferay/batch/engine/internal/test/BatchEngineBundleTrackerTest.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.test.util.ZipFileTestUtil;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -144,18 +145,15 @@ public class BatchEngineBundleTrackerTest {
 
 	@Test
 	public void testProcessBatchEngineBundleOnUpgrade() throws Exception {
-		boolean upgradeClient = ReflectionTestUtil.getAndSetFieldValue(
-			DBUpgrader.class, "_upgradeClient", false);
+		boolean upgradeClient = UpgradeProcessUtil.isUpgradeClient();
 
 		try {
-			ReflectionTestUtil.setFieldValue(
-				DBUpgrader.class, "_upgradeClient", true);
+			UpgradeProcessUtil.setUpgradeClient(true);
 
 			_testProcessBatchEngineBundle(null, "batch1");
 		}
 		finally {
-			ReflectionTestUtil.setFieldValue(
-				DBUpgrader.class, "_upgradeClient", upgradeClient);
+			UpgradeProcessUtil.setUpgradeClient(upgradeClient);
 		}
 	}
 

--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/IndexStatusManagerImpl.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/index/IndexStatusManagerImpl.java
@@ -11,9 +11,9 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.IndexStatusManagerThreadLocal;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.search.configuration.IndexStatusManagerConfiguration;
 import com.liferay.portal.search.index.IndexStatusManager;
-import com.liferay.portal.tools.DBUpgrader;
 
 import java.util.Collections;
 import java.util.Map;
@@ -35,7 +35,7 @@ public class IndexStatusManagerImpl implements IndexStatusManager {
 
 	@Override
 	public boolean isIndexReadOnly() {
-		if (DBUpgrader.isUpgradeClient() ||
+		if (UpgradeProcessUtil.isUpgradeClient() ||
 			IndexStatusManagerThreadLocal.isIndexReadOnly() || _indexReadOnly ||
 			StartupHelperUtil.isUpgrading()) {
 

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.upgrade.ReleaseManager;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeLogProgressTracker;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeSQLRecorder;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.EnvPropertiesUtil;
@@ -738,7 +739,7 @@ public class UpgradeReport {
 		}
 
 		if (reportsDir == null) {
-			if (DBUpgrader.isUpgradeClient()) {
+			if (UpgradeProcessUtil.isUpgradeClient()) {
 				reportsDir = new File(".", "reports");
 			}
 			else {

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProce
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeLogProgressTracker;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeSQLRecorder;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -57,7 +58,6 @@ import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.tools.DBUpgrader;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 
 import java.io.File;
@@ -124,8 +124,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_db.runSQL("DROP_TABLE_IF_EXISTS(UpgradeReportTable2)");
 			});
 
-		ReflectionTestUtil.setFieldValue(
-			DBUpgrader.class, "_upgradeClient", _originalUpgradeClient);
+		UpgradeProcessUtil.setUpgradeClient(_originalUpgradeClient);
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "UPGRADE_LOG_CONTEXT_ENABLED",
 			_originalUpgradeLogContextEnabled);
@@ -1120,8 +1119,9 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 		_originalNewRelease = ReflectionTestUtil.getFieldValue(
 			StartupHelperUtil.class, "_newRelease");
 
-		_originalUpgradeClient = ReflectionTestUtil.getAndSetFieldValue(
-			DBUpgrader.class, "_upgradeClient", upgradeClient);
+		_originalUpgradeClient = UpgradeProcessUtil.isUpgradeClient();
+
+		UpgradeProcessUtil.setUpgradeClient(upgradeClient);
 
 		_originalUpgradeLogContextEnabled =
 			ReflectionTestUtil.getAndSetFieldValue(

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/ClientExtensionConfigBundleTracker.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-impl/src/main/java/com/liferay/portal/k8s/agent/internal/ClientExtensionConfigBundleTracker.java
@@ -12,10 +12,10 @@ import com.liferay.portal.configuration.persistence.InMemoryOnlyConfigurationThr
 import com.liferay.portal.k8s.agent.internal.util.ConfigurationUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.URLUtil;
-import com.liferay.portal.tools.DBUpgrader;
 
 import java.net.URL;
 
@@ -53,7 +53,7 @@ public class ClientExtensionConfigBundleTracker {
 	protected void activate(
 		BundleContext bundleContext, Map<String, Object> properties) {
 
-		if (DBUpgrader.isUpgradeClient()) {
+		if (UpgradeProcessUtil.isUpgradeClient()) {
 			return;
 		}
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceComponentLocalServiceUtil;
 import com.liferay.portal.kernel.service.configuration.ServiceComponentConfiguration;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeLogProgressTracker;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -141,11 +142,11 @@ public class DBUpgrader {
 	}
 
 	public static boolean isUpgradeClient() {
-		return _upgradeClient;
+		return UpgradeProcessUtil.isUpgradeClient();
 	}
 
 	public static boolean isUpgradeDatabaseAutoRunEnabled() {
-		if (_upgradeClient) {
+		if (isUpgradeClient()) {
 			return true;
 		}
 
@@ -174,7 +175,7 @@ public class DBUpgrader {
 	public static void main(String[] args) {
 		String result = "Completed";
 
-		_upgradeClient = true;
+		UpgradeProcessUtil.setUpgradeClient(true);
 
 		try {
 			PortalClassPathUtil.initializeClassPaths(null);
@@ -341,14 +342,14 @@ public class DBUpgrader {
 		_registerModuleServiceLifecycle(
 			moduleServiceLifecyclePortalInitialized);
 
-		if (_upgradeClient) {
+		if (isUpgradeClient()) {
 			DependencyManagerSyncUtil.sync();
 		}
 
 		PortalCacheHelperUtil.clearPortalCaches(
 			PortalCacheManagerNames.MULTI_VM);
 
-		if (_upgradeClient || StartupHelperUtil.isNewRelease()) {
+		if (isUpgradeClient() || StartupHelperUtil.isNewRelease()) {
 			IndexUpdaterUtil.updateAllIndexes();
 		}
 
@@ -656,7 +657,6 @@ public class DBUpgrader {
 	private static volatile Appender _appender;
 	private static volatile ServiceRegistration<?> _serviceRegistration;
 	private static volatile StopWatch _stopWatch;
-	private static volatile boolean _upgradeClient;
 	private static Boolean _upgradeDatabaseAutoRun;
 
 }

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -141,12 +141,8 @@ public class DBUpgrader {
 		return _stopWatch.getTime();
 	}
 
-	public static boolean isUpgradeClient() {
-		return UpgradeProcessUtil.isUpgradeClient();
-	}
-
 	public static boolean isUpgradeDatabaseAutoRunEnabled() {
-		if (isUpgradeClient()) {
+		if (UpgradeProcessUtil.isUpgradeClient()) {
 			return true;
 		}
 
@@ -342,14 +338,16 @@ public class DBUpgrader {
 		_registerModuleServiceLifecycle(
 			moduleServiceLifecyclePortalInitialized);
 
-		if (isUpgradeClient()) {
+		if (UpgradeProcessUtil.isUpgradeClient()) {
 			DependencyManagerSyncUtil.sync();
 		}
 
 		PortalCacheHelperUtil.clearPortalCaches(
 			PortalCacheManagerNames.MULTI_VM);
 
-		if (isUpgradeClient() || StartupHelperUtil.isNewRelease()) {
+		if (UpgradeProcessUtil.isUpgradeClient() ||
+			StartupHelperUtil.isNewRelease()) {
+
 			IndexUpdaterUtil.updateAllIndexes();
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryUtil.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.jndi.JNDIUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaDetector;
@@ -473,6 +474,10 @@ public class DataSourceFactoryUtil {
 		}
 
 		if (url.startsWith("jdbc:sqlserver://")) {
+			if (!UpgradeProcessUtil.isUpgradeClient()) {
+				return url;
+			}
+
 			try {
 				Driver driver = DriverManager.getDriver(url);
 
@@ -503,6 +508,8 @@ public class DataSourceFactoryUtil {
 
 			return _rewriteJDBCURL(
 				HashMapBuilder.put(
+					"bulkCopyForBatchInsertTableLock", "true"
+				).put(
 					"useBulkCopyForBatchInsert", "true"
 				).build(),
 				CharPool.SEMICOLON, url, CharPool.SEMICOLON);

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/UpgradeProcessUtil.java
@@ -133,10 +133,18 @@ public class UpgradeProcessUtil {
 		return false;
 	}
 
+	public static boolean isUpgradeClient() {
+		return _upgradeClient;
+	}
+
 	public static void setCreateIGImageDocumentType(
 		boolean createIGImageDocumentType) {
 
 		_createIGImageDocumentType = createIGImageDocumentType;
+	}
+
+	public static void setUpgradeClient(boolean upgradeClient) {
+		_upgradeClient = upgradeClient;
 	}
 
 	public static boolean upgradeProcess(
@@ -195,5 +203,6 @@ public class UpgradeProcessUtil {
 
 	private static boolean _createIGImageDocumentType;
 	private static final Map<Long, String> _languageIds = new HashMap<>();
+	private static boolean _upgradeClient;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 15.1.0
+version 15.2.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/jdbc/DataSourceFactoryTest.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.dao.jdbc;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -55,10 +56,14 @@ public class DataSourceFactoryTest {
 	public void setUp() throws Exception {
 		_path = Files.createTempDirectory(
 			DataSourceFactoryTest.class.getName());
+
+		UpgradeProcessUtil.setUpgradeClient(true);
 	}
 
 	@After
 	public void tearDown() throws Exception {
+		UpgradeProcessUtil.setUpgradeClient(false);
+
 		if (_path == null) {
 			return;
 		}
@@ -174,7 +179,9 @@ public class DataSourceFactoryTest {
 			_JDBC_URL_POSTGRESQL + "?" + _DEFAULT_PARAMETERS_POSTGRESQL);
 		_assertRewrittenJDBCURL(
 			_JDBC_URL_SQL_SERVER,
-			_JDBC_URL_SQL_SERVER + ";" + _DEFAULT_PARAMETERS_SQL_SERVER, 12, 4);
+			_JDBC_URL_SQL_SERVER_WITHOUT_DATABASE_NAME + ";" +
+				_DEFAULT_PARAMETERS_SQL_SERVER,
+			12, 4);
 	}
 
 	@Test
@@ -187,11 +194,22 @@ public class DataSourceFactoryTest {
 			_JDBC_URL_SQL_SERVER, _JDBC_URL_SQL_SERVER, 12, 3);
 
 		String jdbcURL =
-			_JDBC_URL_SQL_SERVER + ";" + _DEFAULT_PARAMETERS_SQL_SERVER;
+			_JDBC_URL_SQL_SERVER_WITHOUT_DATABASE_NAME + ";" +
+				_DEFAULT_PARAMETERS_SQL_SERVER;
 
 		_assertRewrittenJDBCURL(_JDBC_URL_SQL_SERVER, jdbcURL, 12, 4);
 		_assertRewrittenJDBCURL(_JDBC_URL_SQL_SERVER, jdbcURL, 12, 5);
 		_assertRewrittenJDBCURL(_JDBC_URL_SQL_SERVER, jdbcURL, 13, 0);
+	}
+
+	@Test
+	public void testRewriteJDBCURLForSQLServerWithRuntimeClient()
+		throws Exception {
+
+		UpgradeProcessUtil.setUpgradeClient(false);
+
+		_assertRewrittenJDBCURL(
+			_JDBC_URL_SQL_SERVER, _JDBC_URL_SQL_SERVER, 12, 4);
 	}
 
 	@Test
@@ -231,8 +249,8 @@ public class DataSourceFactoryTest {
 		_assertRewrittenJDBCURL(
 			_JDBC_URL_SQL_SERVER + ";" + parameter,
 			StringBundler.concat(
-				_JDBC_URL_SQL_SERVER, ";", _DEFAULT_PARAMETERS_SQL_SERVER, ";",
-				parameter),
+				_JDBC_URL_SQL_SERVER_WITHOUT_DATABASE_NAME, ";",
+				_DEFAULT_PARAMETERS_SQL_SERVER, ";", parameter),
 			12, 4);
 	}
 
@@ -252,7 +270,13 @@ public class DataSourceFactoryTest {
 
 		jdbcURL = _JDBC_URL_SQL_SERVER + ";useBulkCopyForBatchInsert=false";
 
-		_assertRewrittenJDBCURL(jdbcURL, jdbcURL, 12, 4);
+		_assertRewrittenJDBCURL(
+			jdbcURL,
+			StringBundler.concat(
+				_JDBC_URL_SQL_SERVER_WITHOUT_DATABASE_NAME,
+				";bulkCopyForBatchInsertTableLock=true;databaseName=lportal3;",
+				"useBulkCopyForBatchInsert=false"),
+			12, 4);
 	}
 
 	@Test
@@ -274,8 +298,8 @@ public class DataSourceFactoryTest {
 		_assertRewrittenJDBCURL(
 			_JDBC_URL_SQL_SERVER + ";" + parameter,
 			StringBundler.concat(
-				_JDBC_URL_SQL_SERVER, ";", _DEFAULT_PARAMETERS_SQL_SERVER, ";",
-				parameter),
+				_JDBC_URL_SQL_SERVER_WITHOUT_DATABASE_NAME, ";",
+				_DEFAULT_PARAMETERS_SQL_SERVER, ";", parameter),
 			12, 4);
 	}
 
@@ -345,7 +369,8 @@ public class DataSourceFactoryTest {
 		"reWriteBatchedInserts=true";
 
 	private static final String _DEFAULT_PARAMETERS_SQL_SERVER =
-		"useBulkCopyForBatchInsert=true";
+		"bulkCopyForBatchInsertTableLock=true;databaseName=lportal3;" +
+			"useBulkCopyForBatchInsert=true";
 
 	private static final String _JDBC_URL_MYSQL =
 		"jdbc:mysql://localhost/lportal1";
@@ -354,7 +379,11 @@ public class DataSourceFactoryTest {
 		"jdbc:postgresql://localhost/lportal2";
 
 	private static final String _JDBC_URL_SQL_SERVER =
-		"jdbc:sqlserver://localhost;databaseName=lportal3";
+		DataSourceFactoryTest._JDBC_URL_SQL_SERVER_WITHOUT_DATABASE_NAME +
+			";databaseName=lportal3";
+
+	private static final String _JDBC_URL_SQL_SERVER_WITHOUT_DATABASE_NAME =
+		"jdbc:sqlserver://localhost";
 
 	private Path _path;
 


### PR DESCRIPTION
## Summary

Fixes [LPD-88624](https://liferay.atlassian.net/browse/LPD-88624) — nightly `ci:test:upgrade` runs on SQL Server 2019 have been failing every night since 2026-04-29 with writer↔writer page-lock deadlocks during portal boot, and analogous failures fire in parallel `BaseDBProcess` inserts during the upgrade itself. Trigger: the mssql-jdbc 7.4.1 → 13.4.0 bump from LRCI-7310 activated the `useBulkCopyForBatchInsert=true` URL parameter that LPD-65587 had set in 2025-11 but 7.4.1 had silently ignored.

- **Runtime portal:** the rewriter now leaves SQL Server URLs alone, restoring per-row INSERT semantics and Hikari's row-level write parallelism.
- **Upgrade tool:** injects both `useBulkCopyForBatchInsert=true` and `bulkCopyForBatchInsertTableLock=true` so parallel writers queue on a single BU lock per target table instead of forming page-lock cycles; the TABLOCK path also activates minimal logging under SIMPLE / BULK_LOGGED recovery.

`DataSourceFactoryUtil` reads the new mode flag via `UpgradeProcessUtil`, where the previously `DBUpgrader`-private `_upgradeClient` field now lives so portal-kernel can branch on it without a layering violation. `DBUpgrader.isUpgradeClient()` is kept as a delegate so the four existing external callers (`UpgradeReport`, `IndexStatusManagerImpl`, `ClientExtensionConfigBundleTracker`, `BatchEngineBundleTracker`) stay untouched.

Three commits:

1. `LPD-88624 Move _upgradeClient state into UpgradeProcessUtil` — refactor (no behavior change).
2. `LPD-88624 Scope SQL Server bulk-copy URL params to upgrade tool only` — the behavior change.
3. `LPD-88624 Add tests for scoping SQL Server bulk-copy URL params to upgrade tool only` — test coverage for both modes.

Related: #3535 (deadlock-graph capture + CI hardening — the diagnostic side of the same investigation).

## Test plan

- [x] Unit: `ant test-unit -Dtest.class=DataSourceFactoryTest` — 9/9 pass.
- [x] End-to-end upgrade-tool smoke against the QA `data-archive-portal-sqlserver.zip` dump on SQL Server 2019: upgrade completed in 156 s with 0 deadlocks in `/var/opt/mssql/log/errorlog` and "Nothing registered" failed-SQLs in `upgrade_report_diagnostics.txt`. Verified the rewriter log shows both params: `Rewrote JDBC URL from ... to ...;bulkCopyForBatchInsertTableLock=true;...;useBulkCopyForBatchInsert=true`.
- [x] Runtime portal Tomcat startup against the upgraded DB: zero `Rewrote JDBC URL` log lines in `liferay.<date>.log` after startup (short-circuit fires as designed).
- [ ] CI `ci:test:upgrade` on sqlserver2019 over several nights to confirm the nightly flake clears.

[LPD-88624]: https://liferay.atlassian.net/browse/LPD-88624?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ