### PR TITLE
LPD-84039 LPD-86798 Add integration tests and fix getLongRunningQueryInfos

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -736,9 +737,11 @@ public class DBTest {
 			futureTask = new FutureTask<>(
 				() -> {
 					try (Connection backgroundConnection =
-							DataAccess.getConnection()) {
+							DataAccess.getConnection();
+						Statement statement =
+							backgroundConnection.createStatement()) {
 
-						db.runSQL(backgroundConnection, slowQuery);
+						statement.execute(slowQuery);
 					}
 
 					return null;

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -737,11 +737,13 @@ public class DBTest {
 			futureTask = new FutureTask<>(
 				() -> {
 					try (Connection backgroundConnection =
-							DataAccess.getConnection();
-						Statement statement =
-							backgroundConnection.createStatement()) {
+							DataAccess.getConnection()) {
 
-						statement.execute(slowQuery);
+						try (Statement statement =
+								backgroundConnection.createStatement()) {
+
+							statement.execute(slowQuery);
+						}
 					}
 
 					return null;

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -116,6 +116,10 @@ public final class UpgradeQueryMonitor {
 			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
 				String id = longRunningQueryInfo.getId();
 
+				if (id == null) {
+					continue;
+				}
+
 				currentLongRunningQueryIds.add(id);
 
 				if (!_loggedLongRunningQueryIds.add(id)) {

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -20,6 +20,7 @@ import java.sql.Connection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -110,10 +111,14 @@ public final class UpgradeQueryMonitor {
 			List<DB.QueryInfo> longRunningQueryInfos =
 				db.getLongRunningQueryInfos(connection);
 
-			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
-				if (!_loggedLongRunningQueryIds.add(
-						longRunningQueryInfo.getId())) {
+			Set<String> currentLongRunningQueryIds = new HashSet<>();
 
+			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
+				String id = longRunningQueryInfo.getId();
+
+				currentLongRunningQueryIds.add(id);
+
+				if (!_loggedLongRunningQueryIds.add(id)) {
 					continue;
 				}
 
@@ -128,6 +133,8 @@ public final class UpgradeQueryMonitor {
 							" seconds"));
 				}
 			}
+
+			_loggedLongRunningQueryIds.retainAll(currentLongRunningQueryIds);
 		}
 		catch (Exception exception) {
 			Thread currentThread = Thread.currentThread();
@@ -161,7 +168,7 @@ public final class UpgradeQueryMonitor {
 		UpgradeQueryMonitor.class);
 
 	private static final Set<String> _loggedLongRunningQueryIds =
-		new HashSet<>();
+		ConcurrentHashMap.newKeySet();
 
 	private static ScheduledExecutorService _scheduledExecutorService;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -17,7 +17,9 @@ import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +77,8 @@ public final class UpgradeQueryMonitor {
 		}
 
 		_scheduledExecutorService = null;
+
+		_loggedLongRunningQueryIds.clear();
 	}
 
 	private static void _poll() {
@@ -99,6 +103,28 @@ public final class UpgradeQueryMonitor {
 							" has been running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								lockedQueryInfo.getDuration()),
+							" seconds"));
+				}
+			}
+
+			List<DB.QueryInfo> longRunningQueryInfos =
+				db.getLongRunningQueryInfos(connection);
+
+			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
+				if (!_loggedLongRunningQueryIds.add(
+						longRunningQueryInfo.getId())) {
+
+					continue;
+				}
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Long-running query \"",
+							longRunningQueryInfo.getQuery(),
+							"\" has been running for ",
+							TimeUnit.MILLISECONDS.toSeconds(
+								longRunningQueryInfo.getDuration()),
 							" seconds"));
 				}
 			}
@@ -133,6 +159,9 @@ public final class UpgradeQueryMonitor {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeQueryMonitor.class);
+
+	private static final Set<String> _loggedLongRunningQueryIds =
+		new HashSet<>();
 
 	private static ScheduledExecutorService _scheduledExecutorService;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -131,7 +131,7 @@ public final class UpgradeQueryMonitor {
 						StringBundler.concat(
 							"Long-running query \"",
 							longRunningQueryInfo.getQuery(),
-							"\" has been running for ",
+							"\" with ID ", id, " has been running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								longRunningQueryInfo.getDuration()),
 							" seconds"));

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.sql.DataSource;
@@ -86,6 +87,58 @@ public class UpgradeQueryMonitorTest {
 				_testPollWithOneLockedQuery(connection, db, logCapture);
 				_testPollWithMultipleLockedQueries(connection, db, logCapture);
 				_testPollWithSQLException(connection, db, logCapture);
+			}
+			finally {
+				InfrastructureUtil.setDataSource(originalDataSource);
+			}
+		}
+	}
+
+	@Test
+	public void testPollLongRunning() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				UpgradeQueryMonitor.class.getName(), LoggerTestUtil.INFO)) {
+
+			Connection connection = Mockito.mock(Connection.class);
+
+			DataSource dataSource = Mockito.mock(DataSource.class);
+
+			Mockito.when(
+				dataSource.getConnection()
+			).thenReturn(
+				connection
+			);
+
+			DB db = Mockito.mock(DB.class);
+
+			Mockito.when(
+				db.getLockedQueryInfos(connection)
+			).thenReturn(
+				Collections.emptyList()
+			);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			DataSource originalDataSource = InfrastructureUtil.getDataSource();
+
+			InfrastructureUtil.setDataSource(dataSource);
+
+			try {
+				_testPollWithNoLongRunningQueries(connection, db, logCapture);
+				_clearLoggedLongRunningQueryIds();
+				_testPollWithOneLongRunningQuery(connection, db, logCapture);
+				_clearLoggedLongRunningQueryIds();
+				_testPollWithMultipleLongRunningQueries(
+					connection, db, logCapture);
+				_clearLoggedLongRunningQueryIds();
+				_testPollWithLongRunningQueryThrottling(
+					connection, db, logCapture);
 			}
 			finally {
 				InfrastructureUtil.setDataSource(originalDataSource);
@@ -289,6 +342,162 @@ public class UpgradeQueryMonitorTest {
 			"Upgrade query monitoring is disabled: " + message,
 			logEntry.getMessage());
 	}
+
+	private void _clearLoggedLongRunningQueryIds() {
+		Set<String> loggedLongRunningQueryIds =
+			ReflectionTestUtil.getFieldValue(
+				UpgradeQueryMonitor.class, _LOGGED_LONG_RUNNING_QUERY_IDS);
+
+		loggedLongRunningQueryIds.clear();
+	}
+
+	private void _testPollWithLongRunningQueryThrottling(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id = RandomTestUtil.randomString();
+		String query = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Collections.singletonList(
+				new DB.QueryInfo(
+					630000, id, query, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		int sizeBeforeFirstPoll = logEntries.size();
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforeFirstPoll + 1, logEntries.size());
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforeFirstPoll + 1, logEntries.size());
+	}
+
+	private void _testPollWithMultipleLongRunningQueries(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id1 = RandomTestUtil.randomString();
+		String id2 = RandomTestUtil.randomString();
+		String id3 = RandomTestUtil.randomString();
+		String query1 = RandomTestUtil.randomString();
+		String query2 = RandomTestUtil.randomString();
+		String query3 = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Arrays.asList(
+				new DB.QueryInfo(
+					630000, id1, query1, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				new DB.QueryInfo(
+					720000, id2, query2, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				new DB.QueryInfo(
+					810000, id3, query3, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		int sizeBeforePoll = logEntries.size();
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforePoll + 3, logEntries.size());
+
+		LogEntry logEntry1 = logEntries.get(sizeBeforePoll);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query1,
+				"\" has been running for 630 seconds"),
+			logEntry1.getMessage());
+
+		LogEntry logEntry2 = logEntries.get(sizeBeforePoll + 1);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query2,
+				"\" has been running for 720 seconds"),
+			logEntry2.getMessage());
+
+		LogEntry logEntry3 = logEntries.get(sizeBeforePoll + 2);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query3,
+				"\" has been running for 810 seconds"),
+			logEntry3.getMessage());
+	}
+
+	private void _testPollWithNoLongRunningQueries(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertTrue(logEntries.isEmpty());
+	}
+
+	private void _testPollWithOneLongRunningQuery(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id = RandomTestUtil.randomString();
+		String query = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Collections.singletonList(
+				new DB.QueryInfo(
+					630000, id, query, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		Assert.assertEquals(logEntries.toString(), 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(0);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query,
+				"\" has been running for 630 seconds"),
+			logEntry.getMessage());
+		Assert.assertEquals("INFO", logEntry.getPriority());
+	}
+
+	private static final String _LOGGED_LONG_RUNNING_QUERY_IDS =
+		"_loggedLongRunningQueryIds";
 
 	private static final String _SCHEDULED_EXECUTOR_SERVICE =
 		"_scheduledExecutorService";

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -424,24 +424,24 @@ public class UpgradeQueryMonitorTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Long-running query \"", query1,
-				"\" has been running for 630 seconds"),
+				"Long-running query \"", query1, "\" with ID ", id1,
+				" has been running for 630 seconds"),
 			logEntry1.getMessage());
 
 		LogEntry logEntry2 = logEntries.get(sizeBeforePoll + 1);
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Long-running query \"", query2,
-				"\" has been running for 720 seconds"),
+				"Long-running query \"", query2, "\" with ID ", id2,
+				" has been running for 720 seconds"),
 			logEntry2.getMessage());
 
 		LogEntry logEntry3 = logEntries.get(sizeBeforePoll + 2);
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Long-running query \"", query3,
-				"\" has been running for 810 seconds"),
+				"Long-running query \"", query3, "\" with ID ", id3,
+				" has been running for 810 seconds"),
 			logEntry3.getMessage());
 	}
 
@@ -490,8 +490,8 @@ public class UpgradeQueryMonitorTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Long-running query \"", query,
-				"\" has been running for 630 seconds"),
+				"Long-running query \"", query, "\" with ID ", id,
+				" has been running for 630 seconds"),
 			logEntry.getMessage());
 		Assert.assertEquals("INFO", logEntry.getPriority());
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84039

**What is being fixed:** The original `getLongRunningQueryInfos` implementation across all supported databases (DB2, MySQL, Oracle, PostgreSQL, SQL Server) landed without integration test coverage, and the one test that was added in follow-up failed on PostgreSQL and MariaDB because `db.runSQL()` routes through `Statement.executeUpdate()`, which those databases reject when the query returns a result set.

**How it is being fixed:** Integration tests for `getLongRunningQueryInfos` are added to `DBTest`, covering the method against each supported database. The test helper that seeds a slow query is switched from `db.runSQL()` to `Statement.execute()` directly, which handles both DDL/DML and SELECT statements and is accepted by every supported vendor.