### PR TITLE
LPD-86798 Fix testGetLongRunningQueryInfos to use Statement.execute for SELECT slow query

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -736,9 +737,11 @@ public class DBTest {
 			futureTask = new FutureTask<>(
 				() -> {
 					try (Connection backgroundConnection =
-							DataAccess.getConnection()) {
+							DataAccess.getConnection();
+						Statement statement =
+							backgroundConnection.createStatement()) {
 
-						db.runSQL(backgroundConnection, slowQuery);
+						statement.execute(slowQuery);
 					}
 
 					return null;

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -738,6 +738,7 @@ public class DBTest {
 				() -> {
 					try (Connection backgroundConnection =
 							DataAccess.getConnection();
+
 						Statement statement =
 							backgroundConnection.createStatement()) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86798

**What is being fixed:** `testGetLongRunningQueryInfos` was failing on PostgreSQL and MariaDB because the slow query used in the test is a `SELECT` statement, but `db.runSQL()` routes execution through `Statement.executeUpdate()`, which those databases reject when the query returns a result set.

**How it is being fixed:** The background thread that runs the slow query is changed to open a `Statement` directly from the connection and call `statement.execute()` instead of `db.runSQL()`. This avoids the `executeUpdate()` path and allows the `SELECT` slow query to run correctly on all supported databases.