### PR TITLE
LPD-84041 Add long-running query reporting to upgrade monitor thread

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -32,6 +32,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -736,9 +737,11 @@ public class DBTest {
 			futureTask = new FutureTask<>(
 				() -> {
 					try (Connection backgroundConnection =
-							DataAccess.getConnection()) {
+							DataAccess.getConnection();
+						Statement statement =
+							backgroundConnection.createStatement()) {
 
-						db.runSQL(backgroundConnection, slowQuery);
+						statement.execute(slowQuery);
 					}
 
 					return null;

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -738,6 +738,7 @@ public class DBTest {
 				() -> {
 					try (Connection backgroundConnection =
 							DataAccess.getConnection();
+
 						Statement statement =
 							backgroundConnection.createStatement()) {
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -116,10 +116,6 @@ public final class UpgradeQueryMonitor {
 			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
 				String id = longRunningQueryInfo.getId();
 
-				if (id == null) {
-					continue;
-				}
-
 				currentLongRunningQueryIds.add(id);
 
 				if (!_loggedLongRunningQueryIds.add(id)) {

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -77,6 +77,16 @@ public final class UpgradeQueryMonitor {
 		_scheduledExecutorService = null;
 	}
 
+	private static String _getSchemaClause(
+		String defaultSchema, String schema) {
+
+		if ((schema == null) || schema.equals(defaultSchema)) {
+			return "";
+		}
+
+		return StringBundler.concat(" in schema \"", schema, "\"");
+	}
+
 	private static void _poll() {
 		DataSource dataSource = InfrastructureUtil.getDataSource();
 
@@ -98,20 +108,13 @@ public final class UpgradeQueryMonitor {
 
 			for (DB.QueryInfo lockedQueryInfo : lockedQueryInfos) {
 				if (_log.isWarnEnabled()) {
-					String schema = lockedQueryInfo.getSchema();
-
-					String schemaClause = "";
-
-					if ((schema != null) && !schema.equals(defaultSchema)) {
-						schemaClause = StringBundler.concat(
-							" in schema \"", schema, "\"");
-					}
-
 					_log.warn(
 						StringBundler.concat(
 							"Locked query \"", lockedQueryInfo.getQuery(),
 							"\" with ID ", lockedQueryInfo.getId(),
-							schemaClause, " has been running for ",
+							_getSchemaClause(
+								defaultSchema, lockedQueryInfo.getSchema()),
+							" has been running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								lockedQueryInfo.getDuration()),
 							" seconds"));
@@ -123,21 +126,15 @@ public final class UpgradeQueryMonitor {
 
 			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
 				if (_log.isInfoEnabled()) {
-					String id = longRunningQueryInfo.getId();
-					String schema = longRunningQueryInfo.getSchema();
-
-					String schemaClause = "";
-
-					if ((schema != null) && !schema.equals(defaultSchema)) {
-						schemaClause = StringBundler.concat(
-							" in schema \"", schema, "\"");
-					}
-
 					_log.info(
 						StringBundler.concat(
 							"Long-running query \"",
-							longRunningQueryInfo.getQuery(), "\" with ID ", id,
-							schemaClause, " has been running for ",
+							longRunningQueryInfo.getQuery(), "\" with ID ",
+							longRunningQueryInfo.getId(),
+							_getSchemaClause(
+								defaultSchema,
+								longRunningQueryInfo.getSchema()),
+							" has been running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								longRunningQueryInfo.getDuration()),
 							" seconds"));

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -17,7 +17,10 @@ import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +78,8 @@ public final class UpgradeQueryMonitor {
 		}
 
 		_scheduledExecutorService = null;
+
+		_loggedLongRunningQueryIds.clear();
 	}
 
 	private static void _poll() {
@@ -102,6 +107,38 @@ public final class UpgradeQueryMonitor {
 							" seconds"));
 				}
 			}
+
+			List<DB.QueryInfo> longRunningQueryInfos =
+				db.getLongRunningQueryInfos(connection);
+
+			Set<String> currentLongRunningQueryIds = new HashSet<>();
+
+			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
+				String id = longRunningQueryInfo.getId();
+
+				if (id == null) {
+					continue;
+				}
+
+				currentLongRunningQueryIds.add(id);
+
+				if (!_loggedLongRunningQueryIds.add(id)) {
+					continue;
+				}
+
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"Long-running query \"",
+							longRunningQueryInfo.getQuery(), "\" with ID ", id,
+							" has been running for ",
+							TimeUnit.MILLISECONDS.toSeconds(
+								longRunningQueryInfo.getDuration()),
+							" seconds"));
+				}
+			}
+
+			_loggedLongRunningQueryIds.retainAll(currentLongRunningQueryIds);
 		}
 		catch (Exception exception) {
 			Thread currentThread = Thread.currentThread();
@@ -134,6 +171,8 @@ public final class UpgradeQueryMonitor {
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeQueryMonitor.class);
 
+	private static final Set<String> _loggedLongRunningQueryIds =
+		ConcurrentHashMap.newKeySet();
 	private static ScheduledExecutorService _scheduledExecutorService;
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -87,16 +87,31 @@ public final class UpgradeQueryMonitor {
 		try (Connection connection = dataSource.getConnection()) {
 			DB db = DBManagerUtil.getDB();
 
+			String defaultSchema = connection.getCatalog();
+
+			if (defaultSchema == null) {
+				defaultSchema = connection.getSchema();
+			}
+
 			List<DB.QueryInfo> lockedQueryInfos = db.getLockedQueryInfos(
 				connection);
 
 			for (DB.QueryInfo lockedQueryInfo : lockedQueryInfos) {
 				if (_log.isWarnEnabled()) {
+					String schema = lockedQueryInfo.getSchema();
+
+					String schemaClause = "";
+
+					if ((schema != null) && !schema.equals(defaultSchema)) {
+						schemaClause = StringBundler.concat(
+							" in schema \"", schema, "\"");
+					}
+
 					_log.warn(
 						StringBundler.concat(
 							"Locked query \"", lockedQueryInfo.getQuery(),
 							"\" with ID ", lockedQueryInfo.getId(),
-							" has been running for ",
+							schemaClause, " has been running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								lockedQueryInfo.getDuration()),
 							" seconds"));
@@ -109,12 +124,20 @@ public final class UpgradeQueryMonitor {
 			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
 				if (_log.isInfoEnabled()) {
 					String id = longRunningQueryInfo.getId();
+					String schema = longRunningQueryInfo.getSchema();
+
+					String schemaClause = "";
+
+					if ((schema != null) && !schema.equals(defaultSchema)) {
+						schemaClause = StringBundler.concat(
+							" in schema \"", schema, "\"");
+					}
 
 					_log.info(
 						StringBundler.concat(
 							"Long-running query \"",
 							longRunningQueryInfo.getQuery(), "\" with ID ", id,
-							" has been running for ",
+							schemaClause, " has been running for ",
 							TimeUnit.MILLISECONDS.toSeconds(
 								longRunningQueryInfo.getDuration()),
 							" seconds"));

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -17,10 +17,7 @@ import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -78,8 +75,6 @@ public final class UpgradeQueryMonitor {
 		}
 
 		_scheduledExecutorService = null;
-
-		_loggedLongRunningQueryIds.clear();
 	}
 
 	private static void _poll() {
@@ -111,18 +106,10 @@ public final class UpgradeQueryMonitor {
 			List<DB.QueryInfo> longRunningQueryInfos =
 				db.getLongRunningQueryInfos(connection);
 
-			Set<String> currentLongRunningQueryIds = new HashSet<>();
-
 			for (DB.QueryInfo longRunningQueryInfo : longRunningQueryInfos) {
-				String id = longRunningQueryInfo.getId();
-
-				currentLongRunningQueryIds.add(id);
-
-				if (!_loggedLongRunningQueryIds.add(id)) {
-					continue;
-				}
-
 				if (_log.isInfoEnabled()) {
+					String id = longRunningQueryInfo.getId();
+
 					_log.info(
 						StringBundler.concat(
 							"Long-running query \"",
@@ -133,8 +120,6 @@ public final class UpgradeQueryMonitor {
 							" seconds"));
 				}
 			}
-
-			_loggedLongRunningQueryIds.retainAll(currentLongRunningQueryIds);
 		}
 		catch (Exception exception) {
 			Thread currentThread = Thread.currentThread();
@@ -167,8 +152,6 @@ public final class UpgradeQueryMonitor {
 	private static final Log _log = LogFactoryUtil.getLog(
 		UpgradeQueryMonitor.class);
 
-	private static final Set<String> _loggedLongRunningQueryIds =
-		ConcurrentHashMap.newKeySet();
 	private static ScheduledExecutorService _scheduledExecutorService;
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -24,7 +24,6 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.sql.DataSource;
@@ -131,13 +130,8 @@ public class UpgradeQueryMonitorTest {
 
 			try {
 				_testPollWithNoLongRunningQueries(connection, db, logCapture);
-				_clearLoggedLongRunningQueryIds();
 				_testPollWithOneLongRunningQuery(connection, db, logCapture);
-				_clearLoggedLongRunningQueryIds();
 				_testPollWithMultipleLongRunningQueries(
-					connection, db, logCapture);
-				_clearLoggedLongRunningQueryIds();
-				_testPollWithLongRunningQueryThrottling(
 					connection, db, logCapture);
 			}
 			finally {
@@ -204,47 +198,6 @@ public class UpgradeQueryMonitorTest {
 				ReflectionTestUtil.getFieldValue(
 					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
 		}
-	}
-
-	private void _clearLoggedLongRunningQueryIds() {
-		Set<String> loggedLongRunningQueryIds =
-			ReflectionTestUtil.getFieldValue(
-				UpgradeQueryMonitor.class, _LOGGED_LONG_RUNNING_QUERY_IDS);
-
-		loggedLongRunningQueryIds.clear();
-	}
-
-	private void _testPollWithLongRunningQueryThrottling(
-			Connection connection, DB db, LogCapture logCapture)
-		throws Exception {
-
-		String id = RandomTestUtil.randomString();
-		String query = RandomTestUtil.randomString();
-
-		Mockito.when(
-			db.getLongRunningQueryInfos(connection)
-		).thenReturn(
-			Collections.singletonList(
-				new DB.QueryInfo(
-					630000, id, query, RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()))
-		);
-
-		List<LogEntry> logEntries = logCapture.getLogEntries();
-
-		int sizeBeforeFirstPoll = logEntries.size();
-
-		ReflectionTestUtil.invoke(
-			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
-
-		Assert.assertEquals(
-			logEntries.toString(), sizeBeforeFirstPoll + 1, logEntries.size());
-
-		ReflectionTestUtil.invoke(
-			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
-
-		Assert.assertEquals(
-			logEntries.toString(), sizeBeforeFirstPoll + 1, logEntries.size());
 	}
 
 	private void _testPollWithMultipleLockedQueries(
@@ -501,9 +454,6 @@ public class UpgradeQueryMonitorTest {
 			"Upgrade query monitoring is disabled: " + message,
 			logEntry.getMessage());
 	}
-
-	private static final String _LOGGED_LONG_RUNNING_QUERY_IDS =
-		"_loggedLongRunningQueryIds";
 
 	private static final String _SCHEDULED_EXECUTOR_SERVICE =
 		"_scheduledExecutorService";

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -210,19 +210,22 @@ public class UpgradeQueryMonitorTest {
 		String query1 = RandomTestUtil.randomString();
 		String query2 = RandomTestUtil.randomString();
 		String query3 = RandomTestUtil.randomString();
+		String schema1 = RandomTestUtil.randomString();
+		String schema2 = RandomTestUtil.randomString();
+		String schema3 = RandomTestUtil.randomString();
 
 		Mockito.when(
 			db.getLockedQueryInfos(connection)
 		).thenReturn(
 			Arrays.asList(
 				new DB.QueryInfo(
-					300000, id1, query1, RandomTestUtil.randomString(),
+					300000, id1, query1, schema1,
 					RandomTestUtil.randomString()),
 				new DB.QueryInfo(
-					600000, id2, query2, RandomTestUtil.randomString(),
+					600000, id2, query2, schema2,
 					RandomTestUtil.randomString()),
 				new DB.QueryInfo(
-					900000, id3, query3, RandomTestUtil.randomString(),
+					900000, id3, query3, schema3,
 					RandomTestUtil.randomString()))
 		);
 
@@ -238,7 +241,7 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Locked query \"", query1, "\" with ID ", id1,
-				" has been running for 300 seconds"),
+				" in schema \"", schema1, "\" has been running for 300 seconds"),
 			logEntry1.getMessage());
 
 		LogEntry logEntry2 = logEntries.get(2);
@@ -246,7 +249,7 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Locked query \"", query2, "\" with ID ", id2,
-				" has been running for 600 seconds"),
+				" in schema \"", schema2, "\" has been running for 600 seconds"),
 			logEntry2.getMessage());
 
 		LogEntry logEntry3 = logEntries.get(3);
@@ -254,7 +257,7 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Locked query \"", query3, "\" with ID ", id3,
-				" has been running for 900 seconds"),
+				" in schema \"", schema3, "\" has been running for 900 seconds"),
 			logEntry3.getMessage());
 	}
 
@@ -268,19 +271,22 @@ public class UpgradeQueryMonitorTest {
 		String query1 = RandomTestUtil.randomString();
 		String query2 = RandomTestUtil.randomString();
 		String query3 = RandomTestUtil.randomString();
+		String schema1 = RandomTestUtil.randomString();
+		String schema2 = RandomTestUtil.randomString();
+		String schema3 = RandomTestUtil.randomString();
 
 		Mockito.when(
 			db.getLongRunningQueryInfos(connection)
 		).thenReturn(
 			Arrays.asList(
 				new DB.QueryInfo(
-					630000, id1, query1, RandomTestUtil.randomString(),
+					630000, id1, query1, schema1,
 					RandomTestUtil.randomString()),
 				new DB.QueryInfo(
-					720000, id2, query2, RandomTestUtil.randomString(),
+					720000, id2, query2, schema2,
 					RandomTestUtil.randomString()),
 				new DB.QueryInfo(
-					810000, id3, query3, RandomTestUtil.randomString(),
+					810000, id3, query3, schema3,
 					RandomTestUtil.randomString()))
 		);
 
@@ -299,7 +305,8 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Long-running query \"", query1, "\" with ID ", id1,
-				" has been running for 630 seconds"),
+				" in schema \"", schema1,
+				"\" has been running for 630 seconds"),
 			logEntry1.getMessage());
 
 		LogEntry logEntry2 = logEntries.get(sizeBeforePoll + 1);
@@ -307,7 +314,8 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Long-running query \"", query2, "\" with ID ", id2,
-				" has been running for 720 seconds"),
+				" in schema \"", schema2,
+				"\" has been running for 720 seconds"),
 			logEntry2.getMessage());
 
 		LogEntry logEntry3 = logEntries.get(sizeBeforePoll + 2);
@@ -315,7 +323,8 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Long-running query \"", query3, "\" with ID ", id3,
-				" has been running for 810 seconds"),
+				" in schema \"", schema3,
+				"\" has been running for 810 seconds"),
 			logEntry3.getMessage());
 	}
 
@@ -364,14 +373,14 @@ public class UpgradeQueryMonitorTest {
 
 		String id = RandomTestUtil.randomString();
 		String query = RandomTestUtil.randomString();
+		String schema = RandomTestUtil.randomString();
 
 		Mockito.when(
 			db.getLockedQueryInfos(connection)
 		).thenReturn(
 			Collections.singletonList(
 				new DB.QueryInfo(
-					30000, id, query, RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()))
+					30000, id, query, schema, RandomTestUtil.randomString()))
 		);
 
 		ReflectionTestUtil.invoke(
@@ -385,8 +394,8 @@ public class UpgradeQueryMonitorTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Locked query \"", query, "\" with ID ", id,
-				" has been running for 30 seconds"),
+				"Locked query \"", query, "\" with ID ", id, " in schema \"",
+				schema, "\" has been running for 30 seconds"),
 			logEntry.getMessage());
 		Assert.assertEquals("WARN", logEntry.getPriority());
 	}
@@ -397,14 +406,14 @@ public class UpgradeQueryMonitorTest {
 
 		String id = RandomTestUtil.randomString();
 		String query = RandomTestUtil.randomString();
+		String schema = RandomTestUtil.randomString();
 
 		Mockito.when(
 			db.getLongRunningQueryInfos(connection)
 		).thenReturn(
 			Collections.singletonList(
 				new DB.QueryInfo(
-					630000, id, query, RandomTestUtil.randomString(),
-					RandomTestUtil.randomString()))
+					630000, id, query, schema, RandomTestUtil.randomString()))
 		);
 
 		List<LogEntry> logEntries = logCapture.getLogEntries();
@@ -422,7 +431,7 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				"Long-running query \"", query, "\" with ID ", id,
-				" has been running for 630 seconds"),
+				" in schema \"", schema, "\" has been running for 630 seconds"),
 			logEntry.getMessage());
 		Assert.assertEquals("INFO", logEntry.getPriority());
 	}

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -240,24 +240,24 @@ public class UpgradeQueryMonitorTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Locked query \"", query1, "\" with ID ", id1,
-				" in schema \"", schema1, "\" has been running for 300 seconds"),
+				"Locked query \"", query1, "\" with ID ", id1, " in schema \"",
+				schema1, "\" has been running for 300 seconds"),
 			logEntry1.getMessage());
 
 		LogEntry logEntry2 = logEntries.get(2);
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Locked query \"", query2, "\" with ID ", id2,
-				" in schema \"", schema2, "\" has been running for 600 seconds"),
+				"Locked query \"", query2, "\" with ID ", id2, " in schema \"",
+				schema2, "\" has been running for 600 seconds"),
 			logEntry2.getMessage());
 
 		LogEntry logEntry3 = logEntries.get(3);
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Locked query \"", query3, "\" with ID ", id3,
-				" in schema \"", schema3, "\" has been running for 900 seconds"),
+				"Locked query \"", query3, "\" with ID ", id3, " in schema \"",
+				schema3, "\" has been running for 900 seconds"),
 			logEntry3.getMessage());
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -24,6 +24,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 import javax.sql.DataSource;
@@ -94,6 +95,58 @@ public class UpgradeQueryMonitorTest {
 	}
 
 	@Test
+	public void testPollLongRunning() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				UpgradeQueryMonitor.class.getName(), LoggerTestUtil.INFO)) {
+
+			Connection connection = Mockito.mock(Connection.class);
+
+			DataSource dataSource = Mockito.mock(DataSource.class);
+
+			Mockito.when(
+				dataSource.getConnection()
+			).thenReturn(
+				connection
+			);
+
+			DB db = Mockito.mock(DB.class);
+
+			Mockito.when(
+				db.getLockedQueryInfos(connection)
+			).thenReturn(
+				Collections.emptyList()
+			);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			DataSource originalDataSource = InfrastructureUtil.getDataSource();
+
+			InfrastructureUtil.setDataSource(dataSource);
+
+			try {
+				_testPollWithNoLongRunningQueries(connection, db, logCapture);
+				_clearLoggedLongRunningQueryIds();
+				_testPollWithOneLongRunningQuery(connection, db, logCapture);
+				_clearLoggedLongRunningQueryIds();
+				_testPollWithMultipleLongRunningQueries(
+					connection, db, logCapture);
+				_clearLoggedLongRunningQueryIds();
+				_testPollWithLongRunningQueryThrottling(
+					connection, db, logCapture);
+			}
+			finally {
+				InfrastructureUtil.setDataSource(originalDataSource);
+			}
+		}
+	}
+
+	@Test
 	public void testStart() throws Exception {
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -151,6 +204,47 @@ public class UpgradeQueryMonitorTest {
 				ReflectionTestUtil.getFieldValue(
 					UpgradeQueryMonitor.class, _SCHEDULED_EXECUTOR_SERVICE));
 		}
+	}
+
+	private void _clearLoggedLongRunningQueryIds() {
+		Set<String> loggedLongRunningQueryIds =
+			ReflectionTestUtil.getFieldValue(
+				UpgradeQueryMonitor.class, _LOGGED_LONG_RUNNING_QUERY_IDS);
+
+		loggedLongRunningQueryIds.clear();
+	}
+
+	private void _testPollWithLongRunningQueryThrottling(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id = RandomTestUtil.randomString();
+		String query = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Collections.singletonList(
+				new DB.QueryInfo(
+					630000, id, query, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		int sizeBeforeFirstPoll = logEntries.size();
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforeFirstPoll + 1, logEntries.size());
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforeFirstPoll + 1, logEntries.size());
 	}
 
 	private void _testPollWithMultipleLockedQueries(
@@ -211,6 +305,67 @@ public class UpgradeQueryMonitorTest {
 			logEntry3.getMessage());
 	}
 
+	private void _testPollWithMultipleLongRunningQueries(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id1 = RandomTestUtil.randomString();
+		String id2 = RandomTestUtil.randomString();
+		String id3 = RandomTestUtil.randomString();
+		String query1 = RandomTestUtil.randomString();
+		String query2 = RandomTestUtil.randomString();
+		String query3 = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Arrays.asList(
+				new DB.QueryInfo(
+					630000, id1, query1, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				new DB.QueryInfo(
+					720000, id2, query2, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()),
+				new DB.QueryInfo(
+					810000, id3, query3, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		int sizeBeforePoll = logEntries.size();
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforePoll + 3, logEntries.size());
+
+		LogEntry logEntry1 = logEntries.get(sizeBeforePoll);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query1, "\" with ID ", id1,
+				" has been running for 630 seconds"),
+			logEntry1.getMessage());
+
+		LogEntry logEntry2 = logEntries.get(sizeBeforePoll + 1);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query2, "\" with ID ", id2,
+				" has been running for 720 seconds"),
+			logEntry2.getMessage());
+
+		LogEntry logEntry3 = logEntries.get(sizeBeforePoll + 2);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query3, "\" with ID ", id3,
+				" has been running for 810 seconds"),
+			logEntry3.getMessage());
+	}
+
 	private void _testPollWithNoLockedQueries(
 			Connection connection, DB db, LogCapture logCapture)
 		throws Exception {
@@ -227,6 +382,27 @@ public class UpgradeQueryMonitorTest {
 		List<LogEntry> logEntries = logCapture.getLogEntries();
 
 		Assert.assertTrue(logEntries.isEmpty());
+	}
+
+	private void _testPollWithNoLongRunningQueries(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Collections.emptyList()
+		);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		int sizeBeforePoll = logEntries.size();
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforePoll, logEntries.size());
 	}
 
 	private void _testPollWithOneLockedQuery(
@@ -262,6 +438,42 @@ public class UpgradeQueryMonitorTest {
 		Assert.assertEquals("WARN", logEntry.getPriority());
 	}
 
+	private void _testPollWithOneLongRunningQuery(
+			Connection connection, DB db, LogCapture logCapture)
+		throws Exception {
+
+		String id = RandomTestUtil.randomString();
+		String query = RandomTestUtil.randomString();
+
+		Mockito.when(
+			db.getLongRunningQueryInfos(connection)
+		).thenReturn(
+			Collections.singletonList(
+				new DB.QueryInfo(
+					630000, id, query, RandomTestUtil.randomString(),
+					RandomTestUtil.randomString()))
+		);
+
+		List<LogEntry> logEntries = logCapture.getLogEntries();
+
+		int sizeBeforePoll = logEntries.size();
+
+		ReflectionTestUtil.invoke(
+			UpgradeQueryMonitor.class, "_poll", new Class<?>[0]);
+
+		Assert.assertEquals(
+			logEntries.toString(), sizeBeforePoll + 1, logEntries.size());
+
+		LogEntry logEntry = logEntries.get(sizeBeforePoll);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Long-running query \"", query, "\" with ID ", id,
+				" has been running for 630 seconds"),
+			logEntry.getMessage());
+		Assert.assertEquals("INFO", logEntry.getPriority());
+	}
+
 	private void _testPollWithSQLException(
 			Connection connection, DB db, LogCapture logCapture)
 		throws Exception {
@@ -289,6 +501,9 @@ public class UpgradeQueryMonitorTest {
 			"Upgrade query monitoring is disabled: " + message,
 			logEntry.getMessage());
 	}
+
+	private static final String _LOGGED_LONG_RUNNING_QUERY_IDS =
+		"_loggedLongRunningQueryIds";
 
 	private static final String _SCHEDULED_EXECUTOR_SERVICE =
 		"_scheduledExecutorService";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84041

## What is being fixed

During database upgrades on large data sets, a single process can appear to hang for hours with no visibility into whether it is waiting on locks or executing an extraordinarily slow query. The existing `UpgradeQueryMonitor` (LPD-84027) reports locked queries only; it has no path for long-running active queries above a configurable threshold.

## How it is being fixed

Extends `UpgradeQueryMonitor._poll()` to also call `db.getLongRunningQueryInfos(connection)` each cycle and log matching entries at `INFO`. Filtering happens at the SQL layer via the existing `upgrade.query.monitor.long.running.threshold` property (default 600000 ms, shipped earlier under LPD-84039). Each entry now reports the query text, session ID, duration in seconds, and the schema name when it differs from the connection's default — resolved once per poll via `connection.getCatalog()` with a fallback to `connection.getSchema()` for Oracle. The same schema clause is added to the existing locked-query WARN message so the two traces stay consistent. The schema clause is centralized in a small private helper to keep both loops aligned. Behavior under earlier review iterations (a per-ID throttle, a null guard, separate code paths) was simplified after discussion. New unit tests cover the long-running path; the existing locked-query assertions were updated to match the new message format.