### PR TITLE
LPD-90738 Warn and disable UpgradeQueryMonitor on Oracle V$SESSION privilege error

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15993,6 +15993,17 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 						docker exec ${database.host} /bin/bash /tmp/import-database.sh
 					]]>
 				</execute>
+
+				<if>
+					<equals arg1="${database.type}" arg2="oracle" />
+					<then>
+						<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" password="${oracle.admin.password}" url="${database.oracle.url}" userid="${oracle.admin.user}">
+							<![CDATA[
+							grant dba to ${database.username}
+							]]>
+						</sql>
+					</then>
+				</if>
 			</then>
 			<else>
 				<if>
@@ -16133,6 +16144,12 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="dumpfile=${database.type}.dmp" />
 								<arg value="table_exists_action=replace" />
 							</exec>
+
+							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" password="${oracle.admin.password}" url="${database.oracle.url}" userid="${oracle.admin.user}">
+								<![CDATA[
+								grant dba to ${database.username}
+								]]>
+							</sql>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />
 						</then>

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -9,6 +9,7 @@ import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.io.unsync.UnsyncStringReader;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
@@ -193,6 +194,25 @@ public class OracleDB extends BaseDB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, true);
+	}
+
+	@Override
+	public List<DB.QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		try {
+			return super.getLockedQueryInfos(connection);
+		}
+		catch (SQLException sqlException) {
+			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
+				throw new SQLException(
+					"\"v$session\" \"v$sql\": " + sqlException.getMessage(),
+					sqlException.getSQLState(), sqlException.getErrorCode(),
+					sqlException);
+			}
+
+			throw sqlException;
+		}
 	}
 
 	@Override
@@ -564,6 +584,8 @@ public class OracleDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final String[] _ORACLE = {
 		"--", "1", "0",

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -9,13 +9,16 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -77,6 +80,44 @@ public final class UpgradeQueryMonitor {
 		_scheduledExecutorService = null;
 	}
 
+	private static boolean _isOraclePermissionError(Exception exception) {
+		if (DBManagerUtil.getDBType() != DBType.ORACLE) {
+			return false;
+		}
+
+		String message = exception.getMessage();
+
+		if (message == null) {
+			return false;
+		}
+
+		String upperCaseMessage = message.toUpperCase(LocaleUtil.ROOT);
+
+		if (!upperCaseMessage.contains("V$SESSION") &&
+			!upperCaseMessage.contains("V$SQL") &&
+			!upperCaseMessage.contains("V_$SESSION") &&
+			!upperCaseMessage.contains("V_$SQL")) {
+
+			return false;
+		}
+
+		Throwable causeThrowable = exception;
+
+		while (causeThrowable != null) {
+			if (causeThrowable instanceof SQLException) {
+				SQLException sqlException = (SQLException)causeThrowable;
+
+				if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
+					return true;
+				}
+			}
+
+			causeThrowable = causeThrowable.getCause();
+		}
+
+		return false;
+	}
+
 	private static void _poll() {
 		DataSource dataSource = InfrastructureUtil.getDataSource();
 
@@ -110,6 +151,21 @@ public final class UpgradeQueryMonitor {
 				return;
 			}
 
+			if (_isOraclePermissionError(exception)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Upgrade query monitoring is disabled because the database user lacks ",
+							"SELECT on sys.v_$session and sys.v_$sql. Grant one of the following ",
+							"(from least to most permissive): SELECT on sys.v_$session and ",
+							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA."));
+				}
+
+				stop();
+
+				return;
+			}
+
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Upgrade query monitoring is disabled: " +
@@ -126,6 +182,8 @@ public final class UpgradeQueryMonitor {
 
 	private UpgradeQueryMonitor() {
 	}
+
+	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final long _POLLING_INTERVAL_SECONDS = 60;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90738

**What is being fixed:** On Oracle, the upgrade query monitor fails when the database user lacks SELECT privilege on `sys.v_$session` or `sys.v_$sql` (ORA-00942). The exception carries a generic message that gives operators no indication of what grant is missing or how to fix it. In CI, the Oracle legacy-import flow (both Docker and non-Docker paths) does not grant DBA to the portal user after the `impdp` import, so the views are inaccessible from the start of the functional-upgrade-oracle193 shards.

**How it is being fixed:** `OracleDB.getLockedQueryInfos` now catches `ORA-00942` and rethrows it with a message that names the inaccessible views (`sys.v_$session`, `sys.v_$sql`), making the permission error identifiable. `UpgradeQueryMonitor` inspects the exception cause chain for that marker and, when found, logs a targeted warning — "Grant one of: SELECT_CATALOG_ROLE or DBA to the database user." — then stops the monitor without rethrowing. In `build-test.xml`, a `GRANT DBA TO <database.username>` statement is issued via the Oracle admin connection after both the straight-import and Data Pump import paths, ensuring CI test runs have the required access before upgrade begins.