### PR TITLE
LPD-90740 Fix Oracle ORA-30009 in DBTest slow-query daemon

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -1261,8 +1261,8 @@ public class DBTest {
 			return "select sleep(2)";
 		}
 		else if (dbType == DBType.ORACLE) {
-			return "select count(*) from (select level from dual connect by " +
-				"level <= 100000000)";
+			return "select sum(dbms_random.value) from (select level from " +
+				"dual connect by level <= 200000)";
 		}
 		else if (dbType == DBType.POSTGRESQL) {
 			return "select pg_sleep(2)";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90740

**What is being fixed:** The Oracle slow-query daemon used by
DBTest.testGetLongRunningQueryInfos runs
`SELECT COUNT(*) FROM (SELECT LEVEL FROM DUAL CONNECT BY LEVEL <= 100000000)`,
which exhausts the PGA work area on the CI Oracle 19.3 container and
fails with ORA-30009: Not enough memory for CONNECT BY operation.

**How it is being fixed:** The query is replaced with
`SELECT SUM(DBMS_RANDOM.VALUE) FROM (SELECT LEVEL FROM DUAL CONNECT BY LEVEL <= 200000)`.
Wrapping the aggregate in DBMS_RANDOM.VALUE — a non-deterministic
function — prevents Oracle from short-circuiting the evaluation, so all
200,000 rows are actually processed. This gives reliable 1–5 s execution
time on CI hardware using ~10x less PGA than the previous approach,
while keeping the "connect by" fragment that _getSlowQueryFragment()
matches and passing the ACTIVE / non-enqueue session filters in
OracleDB.getLongRunningQueryInfosSQL().