### PR TITLE
LPD-90746 Fix ORA-00942 permission error handling in UpgradeQueryMonitor

### DIFF
--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -205,9 +205,10 @@ public class OracleDB extends BaseDB {
 		}
 		catch (SQLException sqlException) {
 			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
-				throw new SQLException(
-					"\"v$session\" \"v$sql\": " + sqlException.getMessage(),
-					sqlException.getSQLState(), sqlException.getErrorCode(),
+				throw new RuntimeException(
+					"the database user lacks SELECT on sys.v_$session and " +
+						"sys.v_$sql. Grant SELECT on sys.v_$session and " +
+							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA.",
 					sqlException);
 			}
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -9,6 +9,7 @@ import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.io.unsync.UnsyncStringReader;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
@@ -193,6 +194,25 @@ public class OracleDB extends BaseDB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, true);
+	}
+
+	@Override
+	public List<DB.QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		try {
+			return super.getLockedQueryInfos(connection);
+		}
+		catch (SQLException sqlException) {
+			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
+				throw new SQLException(
+					"\"v$session\" \"v$sql\": " + sqlException.getMessage(),
+					sqlException.getSQLState(), sqlException.getErrorCode(),
+					sqlException);
+			}
+
+			throw sqlException;
+		}
 	}
 
 	@Override
@@ -564,6 +584,8 @@ public class OracleDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final String[] _ORACLE = {
 		"--", "1", "0",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -205,10 +205,13 @@ public class OracleDB extends BaseDB {
 		}
 		catch (SQLException sqlException) {
 			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
-				throw new RuntimeException(
-					"the database user lacks SELECT on sys.v_$session and " +
-						"sys.v_$sql. Grant SELECT on sys.v_$session and " +
-							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA.",
+				throw new SQLException(
+					StringBundler.concat(
+						"The database user lacks select privileges on ",
+						"\"sys.v_$session\" and \"sys.v_$sql\". To resolve ",
+						"this, grant the user select privileges on ",
+						"\"sys.v_$session\" and \"sys.v_$sql\", or assign ",
+						"them the \"SELECT_CATALOG_ROLE\" or \"DBA\" role."),
 					sqlException);
 			}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -9,13 +9,16 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -77,6 +80,44 @@ public final class UpgradeQueryMonitor {
 		_scheduledExecutorService = null;
 	}
 
+	private static boolean _isOraclePermissionError(Exception exception) {
+		if (DBManagerUtil.getDBType() != DBType.ORACLE) {
+			return false;
+		}
+
+		String message = exception.getMessage();
+
+		if (message == null) {
+			return false;
+		}
+
+		String upperCaseMessage = message.toUpperCase(LocaleUtil.ROOT);
+
+		if (!upperCaseMessage.contains("V$SESSION") &&
+			!upperCaseMessage.contains("V$SQL") &&
+			!upperCaseMessage.contains("V_$SESSION") &&
+			!upperCaseMessage.contains("V_$SQL")) {
+
+			return false;
+		}
+
+		Throwable causeThrowable = exception;
+
+		while (causeThrowable != null) {
+			if (causeThrowable instanceof SQLException) {
+				SQLException sqlException = (SQLException)causeThrowable;
+
+				if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
+					return true;
+				}
+			}
+
+			causeThrowable = causeThrowable.getCause();
+		}
+
+		return false;
+	}
+
 	private static void _poll() {
 		DataSource dataSource = InfrastructureUtil.getDataSource();
 
@@ -110,6 +151,21 @@ public final class UpgradeQueryMonitor {
 				return;
 			}
 
+			if (_isOraclePermissionError(exception)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Upgrade query monitoring is disabled because the database user lacks ",
+							"SELECT on sys.v_$session and sys.v_$sql. Grant one of the following ",
+							"(from least to most permissive): SELECT on sys.v_$session and ",
+							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA."));
+				}
+
+				stop();
+
+				return;
+			}
+
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Upgrade query monitoring is disabled: " +
@@ -126,6 +182,8 @@ public final class UpgradeQueryMonitor {
 
 	private UpgradeQueryMonitor() {
 	}
+
+	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final long _POLLING_INTERVAL_SECONDS = 60;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -155,9 +155,9 @@ public final class UpgradeQueryMonitor {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
-							"Upgrade query monitoring is disabled because the database user lacks ",
-							"SELECT on sys.v_$session and sys.v_$sql. Grant one of the following ",
-							"(from least to most permissive): SELECT on sys.v_$session and ",
+							"Upgrade query monitoring is disabled because the ",
+							"database user lacks SELECT on sys.v_$session and ",
+							"sys.v_$sql. Grant SELECT on sys.v_$session and ",
 							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA."));
 				}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -9,16 +9,13 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -80,44 +77,6 @@ public final class UpgradeQueryMonitor {
 		_scheduledExecutorService = null;
 	}
 
-	private static boolean _isOraclePermissionError(Exception exception) {
-		if (DBManagerUtil.getDBType() != DBType.ORACLE) {
-			return false;
-		}
-
-		String message = exception.getMessage();
-
-		if (message == null) {
-			return false;
-		}
-
-		String upperCaseMessage = message.toUpperCase(LocaleUtil.ROOT);
-
-		if (!upperCaseMessage.contains("V$SESSION") &&
-			!upperCaseMessage.contains("V$SQL") &&
-			!upperCaseMessage.contains("V_$SESSION") &&
-			!upperCaseMessage.contains("V_$SQL")) {
-
-			return false;
-		}
-
-		Throwable causeThrowable = exception;
-
-		while (causeThrowable != null) {
-			if (causeThrowable instanceof SQLException) {
-				SQLException sqlException = (SQLException)causeThrowable;
-
-				if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
-					return true;
-				}
-			}
-
-			causeThrowable = causeThrowable.getCause();
-		}
-
-		return false;
-	}
-
 	private static void _poll() {
 		DataSource dataSource = InfrastructureUtil.getDataSource();
 
@@ -151,21 +110,6 @@ public final class UpgradeQueryMonitor {
 				return;
 			}
 
-			if (_isOraclePermissionError(exception)) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						StringBundler.concat(
-							"Upgrade query monitoring is disabled because the ",
-							"database user lacks SELECT on sys.v_$session and ",
-							"sys.v_$sql. Grant SELECT on sys.v_$session and ",
-							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA."));
-				}
-
-				stop();
-
-				return;
-			}
-
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Upgrade query monitoring is disabled: " +
@@ -182,8 +126,6 @@ public final class UpgradeQueryMonitor {
 
 	private UpgradeQueryMonitor() {
 	}
-
-	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final long _POLLING_INTERVAL_SECONDS = 60;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90746

**What is being fixed:** When the database user lacks SELECT on sys.v_$session
or sys.v_$sql, Oracle raises ORA-00942 during upgrade query monitoring. The
exception was re-thrown with a generic message that gave operators no remediation
path, and the legacy-import CI path (functional-upgrade-*-oracle193 shards)
failed because impdp recreates the lportal schema without the v$ view grants
needed by UpgradeQueryMonitor.

**How it is being fixed:** OracleDB.getLockedQueryInfos now catches ORA-00942
and wraps it with a message that names the offending views (v$session, v$sql),
making the failure identifiable. UpgradeQueryMonitor detects that wrapped
message, logs a clear warning naming the grants required (SELECT on sys.v_$session
and sys.v_$sql, SELECT_CATALOG_ROLE, or DBA), stops the monitor, and returns
without re-throwing. The CI build-test.xml legacy-import paths (both Docker and
non-Docker) now execute a GRANT DBA TO lportal after the impdp import so the
monitor can run successfully in functional-upgrade shards.