### PR TITLE
LPD-84022 Verify the row total with a delayed second count query

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTracker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTracker.java
@@ -17,7 +17,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -523,24 +522,23 @@ public class UpgradeLogProgressTracker {
 
 			_logged = true;
 
-			if (!_totalRowCountComputed && (_totalRowCountSupplier != null)) {
-				_totalRowCount = GetterUtil.getLong(
-					_totalRowCountSupplier.get());
-				_totalRowCountComputed = true;
-			}
-
-			if (_totalRowCount == 0) {
+			if (_totalRowCountSupplier == null) {
 				return;
 			}
 
-			if (_rowCount > _totalRowCount) {
-				_totalRowCount = 0;
-				_lastKnownTotalCounts.remove(_progressId);
-
-				return;
+			if (_totalRowCountComputed) {
+				_removeExceededTotal();
+			}
+			else if (_firstCount == null) {
+				_setTentativeTotal();
+			}
+			else {
+				_verifyTotal();
 			}
 
-			_lastKnownTotalCounts.put(_progressId, _totalRowCount);
+			if (_totalRowCount > 0) {
+				_lastKnownTotalCounts.put(_progressId, _totalRowCount);
+			}
 		}
 
 		private void _finishProgress() {
@@ -578,7 +576,48 @@ public class UpgradeLogProgressTracker {
 					" rows."));
 		}
 
+		private void _removeExceededTotal() {
+			if ((_totalRowCount > 0) && (_rowCount > _totalRowCount)) {
+				_totalRowCount = 0;
+				_lastKnownTotalCounts.remove(_progressId);
+			}
+		}
+
+		private void _setTentativeTotal() {
+			Long count = _totalRowCountSupplier.get();
+
+			if (count == null) {
+				_totalRowCountComputed = true;
+
+				return;
+			}
+
+			_firstCount = count;
+			_totalRowCount = count + _rowCount;
+		}
+
+		private void _verifyTotal() {
+			_totalRowCountComputed = true;
+
+			Long count = _totalRowCountSupplier.get();
+
+			if (count == null) {
+				_totalRowCount = Math.max(_totalRowCount, _rowCount);
+
+				return;
+			}
+
+			if (Objects.equals(_firstCount, count)) {
+				_totalRowCount = Math.max(count, _rowCount);
+
+				return;
+			}
+
+			_totalRowCount = count + _rowCount;
+		}
+
 		private boolean _finished;
+		private Long _firstCount;
 		private long _lastLogTime;
 		private boolean _logged;
 		private final String _progressId;

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
@@ -132,44 +132,10 @@ public class UpgradeLogProgressTrackerTest {
 
 			UpgradeLogProgressTracker.start();
 
-			PreparedStatement[] preparedStatements = _mockPreparedStatements(
-				_SELECT_SQL);
-
-			PreparedStatement countPreparedStatement = preparedStatements[0];
-			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
-
-			ResultSet countResultSet = Mockito.mock(ResultSet.class);
-
-			Mockito.when(
-				countPreparedStatement.executeQuery()
-			).thenReturn(
-				countResultSet
-			);
-
-			Mockito.when(
-				countResultSet.next()
-			).thenReturn(
-				true
-			);
-
 			long driftedCount = _TOTAL_ROW_COUNT / 2;
 
-			Mockito.when(
-				countResultSet.getLong(1)
-			).thenReturn(
-				_TOTAL_ROW_COUNT, driftedCount
-			);
-
-			ResultSet resultSet = _mockResultSet();
-
-			Mockito.when(
-				wrappedPreparedStatement.executeQuery()
-			).thenReturn(
-				resultSet
-			);
-
-			ResultSet wrappedResultSet =
-				wrappedPreparedStatement.executeQuery();
+			ResultSet wrappedResultSet = _executeQueryWithCount(
+				_TOTAL_ROW_COUNT, driftedCount);
 
 			_resetLogTime(wrappedResultSet);
 
@@ -179,26 +145,7 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			long correctedTotal = driftedCount + 2;
-
-			long percentage = (2 * 100L) / correctedTotal;
-
-			Mockito.verify(
-				log
-			).info(
-				StringBundler.concat(
-					progressId, " is still executing. Processed 2 of ",
-					correctedTotal, " rows. (", percentage, "%)")
-			);
-
-			Map<String, Long> lastKnownTotalCounts =
-				UpgradeLogProgressTracker.getLastKnownTotalCounts();
-
-			Assert.assertEquals(
-				Long.valueOf(correctedTotal),
-				lastKnownTotalCounts.get(progressId));
+			_assertProgress(log, 2, driftedCount + 2, wrappedResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -218,63 +165,14 @@ public class UpgradeLogProgressTrackerTest {
 
 			UpgradeLogProgressTracker.start();
 
-			PreparedStatement[] preparedStatements = _mockPreparedStatements(
-				_SELECT_SQL);
-
-			PreparedStatement countPreparedStatement = preparedStatements[0];
-			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
-
-			ResultSet countResultSet = Mockito.mock(ResultSet.class);
-
-			Mockito.when(
-				countPreparedStatement.executeQuery()
-			).thenReturn(
-				countResultSet
-			);
-
-			Mockito.when(
-				countResultSet.next()
-			).thenReturn(
-				true
-			);
-
-			Mockito.when(
-				countResultSet.getLong(1)
-			).thenReturn(
-				_TOTAL_ROW_COUNT
-			);
-
-			ResultSet resultSet = _mockResultSet();
-
-			Mockito.when(
-				wrappedPreparedStatement.executeQuery()
-			).thenReturn(
-				resultSet
-			);
-
-			ResultSet wrappedResultSet =
-				wrappedPreparedStatement.executeQuery();
+			ResultSet wrappedResultSet = _executeQueryWithCount(
+				_TOTAL_ROW_COUNT);
 
 			_resetLogTime(wrappedResultSet);
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Mockito.verify(
-				log
-			).info(
-				StringBundler.concat(
-					progressId, " is still executing. Processed 1 of ",
-					_TOTAL_ROW_COUNT + 1, " rows. (0%)")
-			);
-
-			Map<String, Long> lastKnownTotalCounts =
-				UpgradeLogProgressTracker.getLastKnownTotalCounts();
-
-			Assert.assertEquals(
-				Long.valueOf(_TOTAL_ROW_COUNT + 1),
-				lastKnownTotalCounts.get(progressId));
+			_assertProgress(log, 1, _TOTAL_ROW_COUNT + 1, wrappedResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -296,42 +194,8 @@ public class UpgradeLogProgressTrackerTest {
 
 			UpgradeLogProgressTracker.start();
 
-			PreparedStatement[] preparedStatements = _mockPreparedStatements(
-				_SELECT_SQL);
-
-			PreparedStatement countPreparedStatement = preparedStatements[0];
-			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
-
-			ResultSet countResultSet = Mockito.mock(ResultSet.class);
-
-			Mockito.when(
-				countPreparedStatement.executeQuery()
-			).thenReturn(
-				countResultSet
-			);
-
-			Mockito.when(
-				countResultSet.next()
-			).thenReturn(
-				true
-			);
-
-			Mockito.when(
-				countResultSet.getLong(1)
-			).thenReturn(
-				_TOTAL_ROW_COUNT
-			);
-
-			ResultSet resultSet = _mockResultSet();
-
-			Mockito.when(
-				wrappedPreparedStatement.executeQuery()
-			).thenReturn(
-				resultSet
-			);
-
-			ResultSet wrappedResultSet =
-				wrappedPreparedStatement.executeQuery();
+			ResultSet wrappedResultSet = _executeQueryWithCount(
+				_TOTAL_ROW_COUNT, _TOTAL_ROW_COUNT);
 
 			_resetLogTime(wrappedResultSet);
 
@@ -341,24 +205,7 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			long percentage = (2 * 100L) / _TOTAL_ROW_COUNT;
-
-			Mockito.verify(
-				log
-			).info(
-				StringBundler.concat(
-					progressId, " is still executing. Processed 2 of ",
-					_TOTAL_ROW_COUNT, " rows. (", percentage, "%)")
-			);
-
-			Map<String, Long> lastKnownTotalCounts =
-				UpgradeLogProgressTracker.getLastKnownTotalCounts();
-
-			Assert.assertEquals(
-				Long.valueOf(_TOTAL_ROW_COUNT),
-				lastKnownTotalCounts.get(progressId));
+			_assertProgress(log, 2, _TOTAL_ROW_COUNT, wrappedResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -465,26 +312,17 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			Long expectedRowCount = 1L;
-
-			Map<String, Long> lastKnownProgresses =
-				UpgradeLogProgressTracker.getLastKnownProgresses();
-
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(progressId));
+			_assertLastKnownProgress(1, wrappedResultSet);
 
 			wrappedResultSet.close();
 			wrappedResultSet.close();
 
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(progressId));
+			_assertLastKnownProgress(1, wrappedResultSet);
 
 			Mockito.verify(
 				log, Mockito.times(1)
 			).info(
-				progressId + " is finished."
+				_getProgressId(wrappedResultSet) + " is finished."
 			);
 		}
 		finally {
@@ -861,32 +699,21 @@ public class UpgradeLogProgressTrackerTest {
 			Assert.assertTrue(wrappedInnerResultSet.next());
 			Assert.assertTrue(wrappedOuterResultSet.next());
 
-			String innerProgressId = _getProgressId(wrappedInnerResultSet);
-			String outerProgressId = _getProgressId(wrappedOuterResultSet);
+			Assert.assertNotEquals(
+				_getProgressId(wrappedInnerResultSet),
+				_getProgressId(wrappedOuterResultSet));
 
-			Assert.assertNotEquals(innerProgressId, outerProgressId);
-
-			Long expectedRowCount = 1L;
-
-			Map<String, Long> lastKnownProgresses =
-				UpgradeLogProgressTracker.getLastKnownProgresses();
-
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(innerProgressId));
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(outerProgressId));
+			_assertLastKnownProgress(1, wrappedInnerResultSet);
+			_assertLastKnownProgress(1, wrappedOuterResultSet);
 
 			wrappedInnerResultSet.close();
 
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(innerProgressId));
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(outerProgressId));
+			_assertLastKnownProgress(1, wrappedInnerResultSet);
+			_assertLastKnownProgress(1, wrappedOuterResultSet);
 
 			wrappedOuterResultSet.close();
 
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(outerProgressId));
+			_assertLastKnownProgress(1, wrappedOuterResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -1013,20 +840,13 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Mockito.verify(
-				log
-			).info(
-				StringBundler.concat(
-					progressId, " is still executing. Processed ",
-					_TOTAL_ROW_COUNT + 1, " rows.")
-			);
+			_assertProgress(log, _TOTAL_ROW_COUNT + 1, wrappedResultSet);
 
 			Map<String, Long> lastKnownTotalCounts =
 				UpgradeLogProgressTracker.getLastKnownTotalCounts();
 
-			Assert.assertNull(lastKnownTotalCounts.get(progressId));
+			Assert.assertNull(
+				lastKnownTotalCounts.get(_getProgressId(wrappedResultSet)));
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -1097,21 +917,8 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Mockito.verify(
-				log
-			).info(
-				progressId + " is still executing. Processed 1 rows."
-			);
-
-			Long expectedRowCount = 1L;
-
-			Map<String, Long> lastKnownProgresses =
-				UpgradeLogProgressTracker.getLastKnownProgresses();
-
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(progressId));
+			_assertProgress(log, 1, wrappedResultSet);
+			_assertLastKnownProgress(1, wrappedResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -1144,19 +951,8 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Mockito.verify(
-				log
-			).info(
-				progressId + " is still executing. Processed 1 rows."
-			);
-
-			Mockito.verify(
-				log
-			).info(
-				progressId + " is still executing. Processed 2 rows."
-			);
+			_assertProgress(log, 1, wrappedResultSet);
+			_assertProgress(log, 2, wrappedResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -1203,13 +999,7 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Mockito.verify(
-				log
-			).info(
-				progressId + " is still executing. Processed 1 rows."
-			);
+			_assertProgress(log, 1, wrappedResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -1317,22 +1107,13 @@ public class UpgradeLogProgressTrackerTest {
 
 			Assert.assertTrue(wrappedResultSet.next());
 
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Long expectedRowCount = 1L;
-
-			Map<String, Long> lastKnownProgresses =
-				UpgradeLogProgressTracker.getLastKnownProgresses();
-
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(progressId));
+			_assertLastKnownProgress(1, wrappedResultSet);
 
 			Statement wrappedStatement = wrappedResultSet.getStatement();
 
 			wrappedStatement.close();
 
-			Assert.assertEquals(
-				expectedRowCount, lastKnownProgresses.get(progressId));
+			_assertLastKnownProgress(1, wrappedResultSet);
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();
@@ -1658,6 +1439,95 @@ public class UpgradeLogProgressTrackerTest {
 		finally {
 			UpgradeLogProgressTracker.stop();
 		}
+	}
+
+	private void _assertLastKnownProgress(
+		long expectedRowCount, ResultSet wrappedResultSet) {
+
+		Map<String, Long> lastKnownProgresses =
+			UpgradeLogProgressTracker.getLastKnownProgresses();
+
+		Assert.assertEquals(
+			Long.valueOf(expectedRowCount),
+			lastKnownProgresses.get(_getProgressId(wrappedResultSet)));
+	}
+
+	private void _assertProgress(
+		Log log, long rowCount, long totalCount, ResultSet wrappedResultSet) {
+
+		long percentage = (rowCount * 100L) / totalCount;
+
+		String progressId = _getProgressId(wrappedResultSet);
+
+		Mockito.verify(
+			log
+		).info(
+			StringBundler.concat(
+				progressId, " is still executing. Processed ", rowCount, " of ",
+				totalCount, " rows. (", percentage, "%)")
+		);
+
+		Map<String, Long> lastKnownTotalCounts =
+			UpgradeLogProgressTracker.getLastKnownTotalCounts();
+
+		Assert.assertEquals(
+			Long.valueOf(totalCount), lastKnownTotalCounts.get(progressId));
+	}
+
+	private void _assertProgress(
+		Log log, long rowCount, ResultSet wrappedResultSet) {
+
+		Mockito.verify(
+			log
+		).info(
+			StringBundler.concat(
+				_getProgressId(wrappedResultSet),
+				" is still executing. Processed ", rowCount, " rows.")
+		);
+	}
+
+	private ResultSet _executeQueryWithCount(long... counts) throws Exception {
+		PreparedStatement[] preparedStatements = _mockPreparedStatements(
+			_SELECT_SQL);
+
+		PreparedStatement countPreparedStatement = preparedStatements[0];
+		PreparedStatement wrappedPreparedStatement = preparedStatements[1];
+
+		ResultSet countResultSet = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			countPreparedStatement.executeQuery()
+		).thenReturn(
+			countResultSet
+		);
+
+		Mockito.when(
+			countResultSet.next()
+		).thenReturn(
+			true
+		);
+
+		Long[] additionalCounts = new Long[counts.length - 1];
+
+		for (int i = 0; i < additionalCounts.length; i++) {
+			additionalCounts[i] = counts[i + 1];
+		}
+
+		Mockito.when(
+			countResultSet.getLong(1)
+		).thenReturn(
+			counts[0], additionalCounts
+		);
+
+		ResultSet resultSet = _mockResultSet();
+
+		Mockito.when(
+			wrappedPreparedStatement.executeQuery()
+		).thenReturn(
+			resultSet
+		);
+
+		return wrappedPreparedStatement.executeQuery();
 	}
 
 	private Log _getLog() {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
@@ -118,6 +118,254 @@ public class UpgradeLogProgressTrackerTest {
 	}
 
 	@Test
+	public void testCaptureProgressCorrectsTotalWhenCountDrops()
+		throws Exception {
+
+		try (SafeCloseable enabledSafeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_LOG_PROGRESS_ENABLED", true);
+			SafeCloseable intervalSafeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_LOG_PROGRESS_INTERVAL", _LOG_PROGRESS_INTERVAL)) {
+
+			Log log = _getLog();
+
+			UpgradeLogProgressTracker.start();
+
+			PreparedStatement[] preparedStatements = _mockPreparedStatements(
+				_SELECT_SQL);
+
+			PreparedStatement countPreparedStatement = preparedStatements[0];
+			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
+
+			ResultSet countResultSet = Mockito.mock(ResultSet.class);
+
+			Mockito.when(
+				countPreparedStatement.executeQuery()
+			).thenReturn(
+				countResultSet
+			);
+
+			Mockito.when(
+				countResultSet.next()
+			).thenReturn(
+				true
+			);
+
+			long driftedCount = _TOTAL_ROW_COUNT / 2;
+
+			Mockito.when(
+				countResultSet.getLong(1)
+			).thenReturn(
+				_TOTAL_ROW_COUNT, driftedCount
+			);
+
+			ResultSet resultSet = _mockResultSet();
+
+			Mockito.when(
+				wrappedPreparedStatement.executeQuery()
+			).thenReturn(
+				resultSet
+			);
+
+			ResultSet wrappedResultSet =
+				wrappedPreparedStatement.executeQuery();
+
+			_resetLogTime(wrappedResultSet);
+
+			Assert.assertTrue(wrappedResultSet.next());
+
+			_resetLogTime(wrappedResultSet);
+
+			Assert.assertTrue(wrappedResultSet.next());
+
+			String progressId = _getProgressId(wrappedResultSet);
+
+			long correctedTotal = driftedCount + 2;
+
+			long percentage = (2 * 100L) / correctedTotal;
+
+			Mockito.verify(
+				log
+			).info(
+				StringBundler.concat(
+					progressId, " is still executing. Processed 2 of ",
+					correctedTotal, " rows. (", percentage, "%)")
+			);
+
+			Map<String, Long> lastKnownTotalCounts =
+				UpgradeLogProgressTracker.getLastKnownTotalCounts();
+
+			Assert.assertEquals(
+				Long.valueOf(correctedTotal),
+				lastKnownTotalCounts.get(progressId));
+		}
+		finally {
+			UpgradeLogProgressTracker.stop();
+		}
+	}
+
+	@Test
+	public void testCaptureProgressLogsTentativeTotal() throws Exception {
+		try (SafeCloseable enabledSafeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_LOG_PROGRESS_ENABLED", true);
+			SafeCloseable intervalSafeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_LOG_PROGRESS_INTERVAL", _LOG_PROGRESS_INTERVAL)) {
+
+			Log log = _getLog();
+
+			UpgradeLogProgressTracker.start();
+
+			PreparedStatement[] preparedStatements = _mockPreparedStatements(
+				_SELECT_SQL);
+
+			PreparedStatement countPreparedStatement = preparedStatements[0];
+			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
+
+			ResultSet countResultSet = Mockito.mock(ResultSet.class);
+
+			Mockito.when(
+				countPreparedStatement.executeQuery()
+			).thenReturn(
+				countResultSet
+			);
+
+			Mockito.when(
+				countResultSet.next()
+			).thenReturn(
+				true
+			);
+
+			Mockito.when(
+				countResultSet.getLong(1)
+			).thenReturn(
+				_TOTAL_ROW_COUNT
+			);
+
+			ResultSet resultSet = _mockResultSet();
+
+			Mockito.when(
+				wrappedPreparedStatement.executeQuery()
+			).thenReturn(
+				resultSet
+			);
+
+			ResultSet wrappedResultSet =
+				wrappedPreparedStatement.executeQuery();
+
+			_resetLogTime(wrappedResultSet);
+
+			Assert.assertTrue(wrappedResultSet.next());
+
+			String progressId = _getProgressId(wrappedResultSet);
+
+			Mockito.verify(
+				log
+			).info(
+				StringBundler.concat(
+					progressId, " is still executing. Processed 1 of ",
+					_TOTAL_ROW_COUNT + 1, " rows. (0%)")
+			);
+
+			Map<String, Long> lastKnownTotalCounts =
+				UpgradeLogProgressTracker.getLastKnownTotalCounts();
+
+			Assert.assertEquals(
+				Long.valueOf(_TOTAL_ROW_COUNT + 1),
+				lastKnownTotalCounts.get(progressId));
+		}
+		finally {
+			UpgradeLogProgressTracker.stop();
+		}
+	}
+
+	@Test
+	public void testCaptureProgressLogsTotalWhenCountIsStable()
+		throws Exception {
+
+		try (SafeCloseable enabledSafeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_LOG_PROGRESS_ENABLED", true);
+			SafeCloseable intervalSafeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"UPGRADE_LOG_PROGRESS_INTERVAL", _LOG_PROGRESS_INTERVAL)) {
+
+			Log log = _getLog();
+
+			UpgradeLogProgressTracker.start();
+
+			PreparedStatement[] preparedStatements = _mockPreparedStatements(
+				_SELECT_SQL);
+
+			PreparedStatement countPreparedStatement = preparedStatements[0];
+			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
+
+			ResultSet countResultSet = Mockito.mock(ResultSet.class);
+
+			Mockito.when(
+				countPreparedStatement.executeQuery()
+			).thenReturn(
+				countResultSet
+			);
+
+			Mockito.when(
+				countResultSet.next()
+			).thenReturn(
+				true
+			);
+
+			Mockito.when(
+				countResultSet.getLong(1)
+			).thenReturn(
+				_TOTAL_ROW_COUNT
+			);
+
+			ResultSet resultSet = _mockResultSet();
+
+			Mockito.when(
+				wrappedPreparedStatement.executeQuery()
+			).thenReturn(
+				resultSet
+			);
+
+			ResultSet wrappedResultSet =
+				wrappedPreparedStatement.executeQuery();
+
+			_resetLogTime(wrappedResultSet);
+
+			Assert.assertTrue(wrappedResultSet.next());
+
+			_resetLogTime(wrappedResultSet);
+
+			Assert.assertTrue(wrappedResultSet.next());
+
+			String progressId = _getProgressId(wrappedResultSet);
+
+			long percentage = (2 * 100L) / _TOTAL_ROW_COUNT;
+
+			Mockito.verify(
+				log
+			).info(
+				StringBundler.concat(
+					progressId, " is still executing. Processed 2 of ",
+					_TOTAL_ROW_COUNT, " rows. (", percentage, "%)")
+			);
+
+			Map<String, Long> lastKnownTotalCounts =
+				UpgradeLogProgressTracker.getLastKnownTotalCounts();
+
+			Assert.assertEquals(
+				Long.valueOf(_TOTAL_ROW_COUNT),
+				lastKnownTotalCounts.get(progressId));
+		}
+		finally {
+			UpgradeLogProgressTracker.stop();
+		}
+	}
+
+	@Test
 	public void testClearParametersResetsUnsafeFlag() throws Exception {
 		try (SafeCloseable enabledSafeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -736,28 +984,7 @@ public class UpgradeLogProgressTrackerTest {
 			PreparedStatement[] preparedStatements = _mockPreparedStatements(
 				_SELECT_SQL);
 
-			PreparedStatement countPreparedStatement = preparedStatements[0];
 			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
-
-			ResultSet countResultSet = Mockito.mock(ResultSet.class);
-
-			Mockito.when(
-				countPreparedStatement.executeQuery()
-			).thenReturn(
-				countResultSet
-			);
-
-			Mockito.when(
-				countResultSet.next()
-			).thenReturn(
-				true
-			);
-
-			Mockito.when(
-				countResultSet.getLong(1)
-			).thenReturn(
-				_TOTAL_ROW_COUNT
-			);
 
 			ResultSet resultSet = _mockResultSet();
 
@@ -772,9 +999,17 @@ public class UpgradeLogProgressTrackerTest {
 
 			_resetLogTime(wrappedResultSet);
 
+			Object invocationHandler = ProxyUtil.getInvocationHandler(
+				wrappedResultSet);
+
 			ReflectionTestUtil.setFieldValue(
-				ProxyUtil.getInvocationHandler(wrappedResultSet), "_rowCount",
-				_TOTAL_ROW_COUNT);
+				invocationHandler, "_firstCount", _TOTAL_ROW_COUNT);
+			ReflectionTestUtil.setFieldValue(
+				invocationHandler, "_rowCount", _TOTAL_ROW_COUNT);
+			ReflectionTestUtil.setFieldValue(
+				invocationHandler, "_totalRowCount", _TOTAL_ROW_COUNT);
+			ReflectionTestUtil.setFieldValue(
+				invocationHandler, "_totalRowCountComputed", true);
 
 			Assert.assertTrue(wrappedResultSet.next());
 
@@ -922,82 +1157,6 @@ public class UpgradeLogProgressTrackerTest {
 			).info(
 				progressId + " is still executing. Processed 2 rows."
 			);
-		}
-		finally {
-			UpgradeLogProgressTracker.stop();
-		}
-	}
-
-	@Test
-	public void testNextLogsWithTotalAndPercentage() throws Exception {
-		try (SafeCloseable enabledSafeCloseable =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"UPGRADE_LOG_PROGRESS_ENABLED", true);
-			SafeCloseable intervalSafeCloseable =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"UPGRADE_LOG_PROGRESS_INTERVAL", _LOG_PROGRESS_INTERVAL)) {
-
-			Log log = _getLog();
-
-			UpgradeLogProgressTracker.start();
-
-			PreparedStatement[] preparedStatements = _mockPreparedStatements(
-				_SELECT_SQL);
-
-			PreparedStatement countPreparedStatement = preparedStatements[0];
-			PreparedStatement wrappedPreparedStatement = preparedStatements[1];
-
-			ResultSet countResultSet = Mockito.mock(ResultSet.class);
-
-			Mockito.when(
-				countPreparedStatement.executeQuery()
-			).thenReturn(
-				countResultSet
-			);
-
-			Mockito.when(
-				countResultSet.next()
-			).thenReturn(
-				true
-			);
-
-			Mockito.when(
-				countResultSet.getLong(1)
-			).thenReturn(
-				_TOTAL_ROW_COUNT
-			);
-
-			ResultSet resultSet = _mockResultSet();
-
-			Mockito.when(
-				wrappedPreparedStatement.executeQuery()
-			).thenReturn(
-				resultSet
-			);
-
-			ResultSet wrappedResultSet =
-				wrappedPreparedStatement.executeQuery();
-
-			_resetLogTime(wrappedResultSet);
-
-			Assert.assertTrue(wrappedResultSet.next());
-
-			String progressId = _getProgressId(wrappedResultSet);
-
-			Mockito.verify(
-				log
-			).info(
-				StringBundler.concat(
-					progressId, " is still executing. Processed 1 of ",
-					_TOTAL_ROW_COUNT, " rows. (0%)")
-			);
-
-			Map<String, Long> lastKnownTotalCounts =
-				UpgradeLogProgressTracker.getLastKnownTotalCounts();
-
-			Assert.assertEquals(
-				Long.valueOf(_TOTAL_ROW_COUNT),
-				lastKnownTotalCounts.get(progressId));
 		}
 		finally {
 			UpgradeLogProgressTracker.stop();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84022

## What is being fixed

The previous implementation took a single count at the first periodic-log tick and froze it for the rest of the cursor. When the upgrade commits batched UPDATEs that move processed rows out of the predicate (e.g., `UpgradeDLFileEntry` setting `externalReferenceCode` so the row no longer matches `WHERE externalReferenceCode IS NULL`), the cursor's true total drifts from that single count, producing inaccurate percentages and potentially dropping to row-only output when `_rowCount` overflows the frozen total.

## How it is being fixed

Tick 1 fires at the first periodic-log emission and sets a tentative total `firstCount + _rowCount`, so percentages remain visible from the first log line. Tick 2 fires at the second periodic-log emission and either confirms or corrects the total. When the two counts are equal (Case A, stable predicate), the total becomes `max(count, _rowCount)`. When they differ (Case B, drift), the total becomes `count + _rowCount`.

Failures degrade gracefully: a tick-1 null gives up and falls back to row-only, a tick-2 null freezes the tentative with a defensive max, and a post-verification safety net catches any case where `_rowCount` exceeds the frozen total.

Cursors that do not survive past the second periodic-log emission pay no verification overhead. Only cursors that have demonstrated long-running behavior incur the second count's cost.
