### PR TITLE
LPD-90738 Wrap ORA-00942 with actionable message in OracleDB.getQueryInfos

### DIFF
--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -205,9 +205,10 @@ public class OracleDB extends BaseDB {
 		}
 		catch (SQLException sqlException) {
 			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
-				throw new SQLException(
-					"\"v$session\" \"v$sql\": " + sqlException.getMessage(),
-					sqlException.getSQLState(), sqlException.getErrorCode(),
+				throw new RuntimeException(
+					"the database user lacks SELECT on sys.v_$session and " +
+						"sys.v_$sql. Grant SELECT on sys.v_$session and " +
+							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA.",
 					sqlException);
 			}
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -9,7 +9,6 @@ import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.io.unsync.UnsyncStringReader;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
@@ -407,7 +406,7 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
-	protected List<DB.QueryInfo> getQueryInfos(
+	protected List<QueryInfo> getQueryInfos(
 			Connection connection, String sql, long threshold)
 		throws SQLException {
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -9,6 +9,7 @@ import com.liferay.petra.io.unsync.UnsyncBufferedReader;
 import com.liferay.petra.io.unsync.UnsyncStringReader;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.db.Index;
@@ -193,6 +194,25 @@ public class OracleDB extends BaseDB {
 		return databaseMetaData.getIndexInfo(
 			dbInspector.getCatalog(), dbInspector.getSchema(), tableName,
 			onlyUnique, true);
+	}
+
+	@Override
+	public List<DB.QueryInfo> getLockedQueryInfos(Connection connection)
+		throws SQLException {
+
+		try {
+			return super.getLockedQueryInfos(connection);
+		}
+		catch (SQLException sqlException) {
+			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
+				throw new SQLException(
+					"\"v$session\" \"v$sql\": " + sqlException.getMessage(),
+					sqlException.getSQLState(), sqlException.getErrorCode(),
+					sqlException);
+			}
+
+			throw sqlException;
+		}
 	}
 
 	@Override
@@ -564,6 +584,8 @@ public class OracleDB extends BaseDB {
 			return sb.toString();
 		}
 	}
+
+	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final String[] _ORACLE = {
 		"--", "1", "0",

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -420,8 +420,8 @@ public class OracleDB extends BaseDB {
 					StringBundler.concat(
 						"Grant select privileges on \"sys.v_$session\" and ",
 						"\"sys.v_$sql\", or assign \"SELECT_CATALOG_ROLE\" or ",
-						"\"DBA\", because the database user lacks the required ",
-						"select privileges"),
+						"\"DBA\", because the database user lacks the ",
+						"required select privileges"),
 					sqlException.getSQLState(), sqlException.getErrorCode(),
 					sqlException);
 			}

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -197,29 +197,6 @@ public class OracleDB extends BaseDB {
 	}
 
 	@Override
-	public List<DB.QueryInfo> getLockedQueryInfos(Connection connection)
-		throws SQLException {
-
-		try {
-			return super.getLockedQueryInfos(connection);
-		}
-		catch (SQLException sqlException) {
-			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
-				throw new SQLException(
-					StringBundler.concat(
-						"The database user lacks select privileges on ",
-						"\"sys.v_$session\" and \"sys.v_$sql\". To resolve ",
-						"this, grant the user select privileges on ",
-						"\"sys.v_$session\" and \"sys.v_$sql\", or assign ",
-						"them the \"SELECT_CATALOG_ROLE\" or \"DBA\" role."),
-					sqlException);
-			}
-
-			throw sqlException;
-		}
-	}
-
-	@Override
 	public String getPopulateSQL(String databaseName, String sqlContent) {
 		return "connect &1/&2;\nset define off;\n\n" + sqlContent + "quit";
 	}
@@ -427,6 +404,30 @@ public class OracleDB extends BaseDB {
 			"'ACTIVE' and v$session.type = 'USER' and (v$session.event is ",
 			"null or (v$session.event not like 'enq:%' and v$session.event ",
 			"not like '%library cache%'))");
+	}
+
+	@Override
+	protected List<DB.QueryInfo> getQueryInfos(
+			Connection connection, String sql, long threshold)
+		throws SQLException {
+
+		try {
+			return super.getQueryInfos(connection, sql, threshold);
+		}
+		catch (SQLException sqlException) {
+			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
+				throw new SQLException(
+					StringBundler.concat(
+						"Grant select privileges on \"sys.v_$session\" and ",
+						"\"sys.v_$sql\", or assign \"SELECT_CATALOG_ROLE\" or ",
+						"\"DBA\", because the database user lacks the required ",
+						"select privileges"),
+					sqlException.getSQLState(), sqlException.getErrorCode(),
+					sqlException);
+			}
+
+			throw sqlException;
+		}
 	}
 
 	@Override

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/OracleDB.java
@@ -205,10 +205,13 @@ public class OracleDB extends BaseDB {
 		}
 		catch (SQLException sqlException) {
 			if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
-				throw new RuntimeException(
-					"the database user lacks SELECT on sys.v_$session and " +
-						"sys.v_$sql. Grant SELECT on sys.v_$session and " +
-							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA.",
+				throw new SQLException(
+					StringBundler.concat(
+						"The database user lacks select privileges on ",
+						"\"sys.v_$session\" and \"sys.v_$sql\". To resolve ",
+						"this, grant the user select privileges on ",
+						"\"sys.v_$session\" and \"sys.v_$sql\", or assign ",
+						"them the \"SELECT_CATALOG_ROLE\" or \"DBA\" role."),
 					sqlException);
 			}
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
@@ -345,10 +345,15 @@ public class OracleDBTest extends BaseDBTestCase {
 	}
 
 	@Test
+	public void testGetLongDefaultValue() {
+		Assert.assertEquals("10", db.getDefaultValue("10 "));
+	}
+
+	@Test
 	public void testGetQueryInfosORA942() throws Exception {
 		OracleDB oracleDB = new OracleDB(0, 0);
 
-		SQLException originalException = new SQLException(
+		SQLException sqlException1 = new SQLException(
 			"ORA-00942: table or view does not exist", "42000", 942);
 
 		Connection connection = Mockito.mock(Connection.class);
@@ -365,7 +370,7 @@ public class OracleDBTest extends BaseDBTestCase {
 		Mockito.when(
 			preparedStatement.executeQuery()
 		).thenThrow(
-			originalException
+			sqlException1
 		);
 
 		try {
@@ -373,24 +378,19 @@ public class OracleDBTest extends BaseDBTestCase {
 
 			Assert.fail();
 		}
-		catch (SQLException sqlException) {
+		catch (SQLException sqlException2) {
 			Assert.assertEquals(
-				originalException.getErrorCode(), sqlException.getErrorCode());
+				sqlException1.getErrorCode(), sqlException2.getErrorCode());
 			Assert.assertEquals(
 				StringBundler.concat(
 					"Grant select privileges on \"sys.v_$session\" and ",
 					"\"sys.v_$sql\", or assign \"SELECT_CATALOG_ROLE\" or ",
 					"\"DBA\", because the database user lacks the required ",
 					"select privileges"),
-				sqlException.getMessage());
+				sqlException2.getMessage());
 			Assert.assertEquals(
-				originalException.getSQLState(), sqlException.getSQLState());
+				sqlException1.getSQLState(), sqlException2.getSQLState());
 		}
-	}
-
-	@Test
-	public void testGetLongDefaultValue() {
-		Assert.assertEquals("10", db.getDefaultValue("10 "));
 	}
 
 	@Test

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.dao.db;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.test.BaseDBTestCase;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -350,11 +351,8 @@ public class OracleDBTest extends BaseDBTestCase {
 	}
 
 	@Test
-	public void testGetQueryInfosORA942() throws Exception {
+	public void testGetQueryInfos() throws Exception {
 		OracleDB oracleDB = new OracleDB(0, 0);
-
-		SQLException sqlException1 = new SQLException(
-			"ORA-00942: table or view does not exist", "42000", 942);
 
 		Connection connection = Mockito.mock(Connection.class);
 
@@ -366,6 +364,9 @@ public class OracleDBTest extends BaseDBTestCase {
 		).thenReturn(
 			preparedStatement
 		);
+
+		SQLException sqlException1 = new SQLException(
+			StringPool.BLANK, _SQL_STATE_SYNTAX_ERROR, _ORA_100_NO_DATA_FOUND);
 
 		Mockito.when(
 			preparedStatement.executeQuery()
@@ -379,17 +380,36 @@ public class OracleDBTest extends BaseDBTestCase {
 			Assert.fail();
 		}
 		catch (SQLException sqlException2) {
+			Assert.assertSame(sqlException1, sqlException2);
+		}
+
+		SQLException sqlException2 = new SQLException(
+			_ORA_942_MESSAGE, _SQL_STATE_OBJECT_NOT_FOUND,
+			_ORA_942_TABLE_NOT_FOUND);
+
+		Mockito.doThrow(
+			sqlException2
+		).when(
+			preparedStatement
+		).executeQuery();
+
+		try {
+			oracleDB.getQueryInfos(connection, "select 1 from dual", 0);
+
+			Assert.fail();
+		}
+		catch (SQLException sqlException3) {
 			Assert.assertEquals(
-				sqlException1.getErrorCode(), sqlException2.getErrorCode());
+				sqlException2.getErrorCode(), sqlException3.getErrorCode());
 			Assert.assertEquals(
 				StringBundler.concat(
 					"Grant select privileges on \"sys.v_$session\" and ",
 					"\"sys.v_$sql\", or assign \"SELECT_CATALOG_ROLE\" or ",
 					"\"DBA\", because the database user lacks the required ",
 					"select privileges"),
-				sqlException2.getMessage());
+				sqlException3.getMessage());
 			Assert.assertEquals(
-				sqlException1.getSQLState(), sqlException2.getSQLState());
+				sqlException2.getSQLState(), sqlException3.getSQLState());
 		}
 	}
 
@@ -559,6 +579,17 @@ public class OracleDBTest extends BaseDBTestCase {
 
 		};
 	}
+
+	private static final int _ORA_100_NO_DATA_FOUND = 100;
+
+	private static final String _ORA_942_MESSAGE =
+		"ORA-00942: table or view does not exist";
+
+	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
+
+	private static final String _SQL_STATE_OBJECT_NOT_FOUND = "42000";
+
+	private static final String _SQL_STATE_SYNTAX_ERROR = "42001";
 
 	private boolean _nullable;
 

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.dao.db;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.test.BaseDBTestCase;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -14,10 +15,16 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.lang.reflect.Method;
 
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.Mockito;
 
 /**
  * @author Shinn Lok
@@ -335,6 +342,50 @@ public class OracleDBTest extends BaseDBTestCase {
 				db,
 				"create index IX on Test (cola, colb[$COLUMN_LENGTH:4000$], " +
 					"colc[$COLUMN_LENGTH:4000$]);"));
+	}
+
+	@Test
+	public void testGetQueryInfosORA942() throws Exception {
+		OracleDB oracleDB = new OracleDB(0, 0);
+
+		SQLException originalException = new SQLException(
+			"ORA-00942: table or view does not exist", "42000", 942);
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		PreparedStatement preparedStatement = Mockito.mock(
+			PreparedStatement.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		Mockito.when(
+			preparedStatement.executeQuery()
+		).thenThrow(
+			originalException
+		);
+
+		try {
+			oracleDB.getQueryInfos(connection, "select 1 from dual", 0);
+
+			Assert.fail();
+		}
+		catch (SQLException sqlException) {
+			Assert.assertEquals(
+				originalException.getErrorCode(), sqlException.getErrorCode());
+			Assert.assertEquals(
+				StringBundler.concat(
+					"Grant select privileges on \"sys.v_$session\" and ",
+					"\"sys.v_$sql\", or assign \"SELECT_CATALOG_ROLE\" or ",
+					"\"DBA\", because the database user lacks the required ",
+					"select privileges"),
+				sqlException.getMessage());
+			Assert.assertEquals(
+				originalException.getSQLState(), sqlException.getSQLState());
+		}
 	}
 
 	@Test

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/OracleDBTest.java
@@ -351,7 +351,7 @@ public class OracleDBTest extends BaseDBTestCase {
 	}
 
 	@Test
-	public void testGetQueryInfos() throws Exception {
+	public void testGetQueryInfosSQLExceptionHandling() throws Exception {
 		OracleDB oracleDB = new OracleDB(0, 0);
 
 		Connection connection = Mockito.mock(Connection.class);

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -549,7 +549,7 @@ public abstract class BaseDB implements DB {
 	public List<QueryInfo> getLockedQueryInfos(Connection connection)
 		throws SQLException {
 
-		return _getQueryInfos(
+		return getQueryInfos(
 			connection, getLockedQueryInfosSQL(),
 			PropsValues.UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD);
 	}
@@ -558,7 +558,7 @@ public abstract class BaseDB implements DB {
 	public List<QueryInfo> getLongRunningQueryInfos(Connection connection)
 		throws SQLException {
 
-		return _getQueryInfos(
+		return getQueryInfos(
 			connection, getLongRunningQueryInfosSQL(),
 			PropsValues.UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD);
 	}
@@ -1771,7 +1771,7 @@ public abstract class BaseDB implements DB {
 		return primaryKeys;
 	}
 
-	private List<QueryInfo> _getQueryInfos(
+	protected List<QueryInfo> getQueryInfos(
 			Connection connection, String sql, long threshold)
 		throws SQLException {
 

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -1534,6 +1534,43 @@ public abstract class BaseDB implements DB {
 		return null;
 	}
 
+	protected List<QueryInfo> getQueryInfos(
+			Connection connection, String sql, long threshold)
+		throws SQLException {
+
+		if (sql == null) {
+			return Collections.emptyList();
+		}
+
+		List<QueryInfo> queryInfos = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setLong(1, threshold);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String query = resultSet.getString("query");
+
+					if (query == null) {
+						continue;
+					}
+
+					long duration = resultSet.getLong("duration");
+					String id = resultSet.getString("id");
+					String schema = resultSet.getString("schema_");
+					String state = resultSet.getString("state");
+
+					queryInfos.add(
+						new QueryInfo(duration, id, query, schema, state));
+				}
+			}
+		}
+
+		return queryInfos;
+	}
+
 	protected String getRenameTableSQL(
 		String oldTableName, String newTableName) {
 
@@ -1769,43 +1806,6 @@ public abstract class BaseDB implements DB {
 		}
 
 		return primaryKeys;
-	}
-
-	protected List<QueryInfo> getQueryInfos(
-			Connection connection, String sql, long threshold)
-		throws SQLException {
-
-		if (sql == null) {
-			return Collections.emptyList();
-		}
-
-		List<QueryInfo> queryInfos = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				sql)) {
-
-			preparedStatement.setLong(1, threshold);
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String query = resultSet.getString("query");
-
-					if (query == null) {
-						continue;
-					}
-
-					long duration = resultSet.getLong("duration");
-					String id = resultSet.getString("id");
-					String schema = resultSet.getString("schema_");
-					String state = resultSet.getString("state");
-
-					queryInfos.add(
-						new QueryInfo(duration, id, query, schema, state));
-				}
-			}
-		}
-
-		return queryInfos;
 	}
 
 	private boolean _isSkipIndexOperation(

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -9,13 +9,16 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -87,6 +90,44 @@ public final class UpgradeQueryMonitor {
 		return StringBundler.concat(" in schema \"", schema, "\"");
 	}
 
+	private static boolean _isOraclePermissionError(Exception exception) {
+		if (DBManagerUtil.getDBType() != DBType.ORACLE) {
+			return false;
+		}
+
+		String message = exception.getMessage();
+
+		if (message == null) {
+			return false;
+		}
+
+		String upperCaseMessage = message.toUpperCase(LocaleUtil.ROOT);
+
+		if (!upperCaseMessage.contains("V$SESSION") &&
+			!upperCaseMessage.contains("V$SQL") &&
+			!upperCaseMessage.contains("V_$SESSION") &&
+			!upperCaseMessage.contains("V_$SQL")) {
+
+			return false;
+		}
+
+		Throwable causeThrowable = exception;
+
+		while (causeThrowable != null) {
+			if (causeThrowable instanceof SQLException) {
+				SQLException sqlException = (SQLException)causeThrowable;
+
+				if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
+					return true;
+				}
+			}
+
+			causeThrowable = causeThrowable.getCause();
+		}
+
+		return false;
+	}
+
 	private static void _poll() {
 		DataSource dataSource = InfrastructureUtil.getDataSource();
 
@@ -149,6 +190,21 @@ public final class UpgradeQueryMonitor {
 				return;
 			}
 
+			if (_isOraclePermissionError(exception)) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Upgrade query monitoring is disabled because the database user lacks ",
+							"SELECT on sys.v_$session and sys.v_$sql. Grant one of the following ",
+							"(from least to most permissive): SELECT on sys.v_$session and ",
+							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA."));
+				}
+
+				stop();
+
+				return;
+			}
+
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Upgrade query monitoring is disabled: " +
@@ -165,6 +221,8 @@ public final class UpgradeQueryMonitor {
 
 	private UpgradeQueryMonitor() {
 	}
+
+	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final long _POLLING_INTERVAL_SECONDS = 60;
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -194,9 +194,9 @@ public final class UpgradeQueryMonitor {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
-							"Upgrade query monitoring is disabled because the database user lacks ",
-							"SELECT on sys.v_$session and sys.v_$sql. Grant one of the following ",
-							"(from least to most permissive): SELECT on sys.v_$session and ",
+							"Upgrade query monitoring is disabled because the ",
+							"database user lacks SELECT on sys.v_$session and ",
+							"sys.v_$sql. Grant SELECT on sys.v_$session and ",
 							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA."));
 				}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitor.java
@@ -9,16 +9,13 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InfrastructureUtil;
-import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -90,44 +87,6 @@ public final class UpgradeQueryMonitor {
 		return StringBundler.concat(" in schema \"", schema, "\"");
 	}
 
-	private static boolean _isOraclePermissionError(Exception exception) {
-		if (DBManagerUtil.getDBType() != DBType.ORACLE) {
-			return false;
-		}
-
-		String message = exception.getMessage();
-
-		if (message == null) {
-			return false;
-		}
-
-		String upperCaseMessage = message.toUpperCase(LocaleUtil.ROOT);
-
-		if (!upperCaseMessage.contains("V$SESSION") &&
-			!upperCaseMessage.contains("V$SQL") &&
-			!upperCaseMessage.contains("V_$SESSION") &&
-			!upperCaseMessage.contains("V_$SQL")) {
-
-			return false;
-		}
-
-		Throwable causeThrowable = exception;
-
-		while (causeThrowable != null) {
-			if (causeThrowable instanceof SQLException) {
-				SQLException sqlException = (SQLException)causeThrowable;
-
-				if (sqlException.getErrorCode() == _ORA_942_TABLE_NOT_FOUND) {
-					return true;
-				}
-			}
-
-			causeThrowable = causeThrowable.getCause();
-		}
-
-		return false;
-	}
-
 	private static void _poll() {
 		DataSource dataSource = InfrastructureUtil.getDataSource();
 
@@ -190,21 +149,6 @@ public final class UpgradeQueryMonitor {
 				return;
 			}
 
-			if (_isOraclePermissionError(exception)) {
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						StringBundler.concat(
-							"Upgrade query monitoring is disabled because the ",
-							"database user lacks SELECT on sys.v_$session and ",
-							"sys.v_$sql. Grant SELECT on sys.v_$session and ",
-							"sys.v_$sql, SELECT_CATALOG_ROLE, or DBA."));
-				}
-
-				stop();
-
-				return;
-			}
-
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Upgrade query monitoring is disabled: " +
@@ -221,8 +165,6 @@ public final class UpgradeQueryMonitor {
 
 	private UpgradeQueryMonitor() {
 	}
-
-	private static final int _ORA_942_TABLE_NOT_FOUND = 942;
 
 	private static final long _POLLING_INTERVAL_SECONDS = 60;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90738

**What is being fixed:** When the Oracle database user lacks SELECT on sys.v_$session or sys.v_$sql, upgrade query monitoring fails silently with ORA-00942 — a generic "table or view does not exist" error that gives operators no indication of which privileges are needed.

**How it is being fixed:** BaseDB promotes _getQueryInfos from a private method to a protected getQueryInfos so subclasses can override it. OracleDB overrides getQueryInfos to catch any SQLException with error code 942 and rethrow a new SQLException whose message explicitly names sys.v_$session, sys.v_$sql, and the SELECT_CATALOG_ROLE and DBA roles as remediation options, while preserving the original SQL state and error code. OracleDBTest verifies that a non-942 SQLException passes through unchanged and that an ORA-942 thrown from a mocked PreparedStatement is replaced with the actionable message, using doThrow().when() to safely re-stub a mock already configured to throw a checked exception.