### PR TITLE
LPD-87106 Guard missing rootDir and expose DL size supplier as test seam

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -276,16 +276,16 @@ public class UpgradeReport {
 
 				if (releaseManager == null) {
 					if (upgradeRecorder.isPreupgradeVerifyFailure()) {
-						return "No changes have been made to the system";
+						return "no changes have been made to the system";
 					}
 
-					return "Upgrade failed to complete";
+					return "upgrade failed to complete";
 				}
 
 				String statusMessage = releaseManager.getStatusMessage(false);
 
 				if (statusMessage.isEmpty()) {
-					return "There are no pending upgrades";
+					return "there are no pending upgrades";
 				}
 
 				return statusMessage;
@@ -297,7 +297,7 @@ public class UpgradeReport {
 			LinkedHashMapBuilder.put(
 				"initial.build.number",
 				(_initialBuildNumber != 0) ?
-					String.valueOf(_initialBuildNumber) : "Unable to determine"
+					String.valueOf(_initialBuildNumber) : "unable to determine"
 			).put(
 				"initial.schema.version",
 				() -> {
@@ -311,7 +311,7 @@ public class UpgradeReport {
 						return initialSchemaVersion;
 					}
 
-					return "Unable to determine";
+					return "unable to determine";
 				}
 			).put(
 				"final.build.number",
@@ -322,7 +322,7 @@ public class UpgradeReport {
 						return String.valueOf(buildNumber);
 					}
 
-					return "Unable to determine";
+					return "unable to determine";
 				}
 			).put(
 				"final.schema.version",
@@ -335,7 +335,7 @@ public class UpgradeReport {
 						return schemaVersion;
 					}
 
-					return "Unable to determine";
+					return "unable to determine";
 				}
 			).put(
 				"expected.build.number",
@@ -346,7 +346,7 @@ public class UpgradeReport {
 						return String.valueOf(buildNumber);
 					}
 
-					return "Unable to determine";
+					return "unable to determine";
 				}
 			).put(
 				"expected.schema.version",
@@ -358,7 +358,7 @@ public class UpgradeReport {
 						return schemaVersion;
 					}
 
-					return "Unable to determine";
+					return "unable to determine";
 				}
 			).build()
 		).put(
@@ -382,17 +382,17 @@ public class UpgradeReport {
 					if (PropsValues.UPGRADE_REPORT_DL_STORAGE_SIZE_TIMEOUT ==
 							0) {
 
-						return "Disabled";
+						return "disabled";
 					}
 
 					if (!StringUtil.endsWith(
 							PropsValues.DL_STORE_IMPL, "FileSystemStore")) {
 
-						return "Check externally";
+						return "check externally";
 					}
 
 					if (_rootDir == null) {
-						return "Unable to determine. Document library " +
+						return "unable to determine. Document library " +
 							"\"rootDir\" was not set";
 					}
 
@@ -406,7 +406,7 @@ public class UpgradeReport {
 										_rootDir);
 						}
 
-						return "Unable to determine";
+						return "unable to determine";
 					}
 
 					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
@@ -452,7 +452,7 @@ public class UpgradeReport {
 							exception);
 					}
 
-					return "Unable to determine";
+					return "unable to determine";
 				}
 			).build()
 		).put(

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -401,9 +401,8 @@ public class UpgradeReport {
 					if (!rootDirFile.isDirectory()) {
 						if (_log.isInfoEnabled()) {
 							_log.info(
-								"Unable to determine the document library " +
-									"size. Directory does not exist: " +
-										_rootDir);
+								"Document library directory does not exist: " +
+									_rootDir);
 						}
 
 						return "unable to determine";

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/report/UpgradeReport.java
@@ -79,6 +79,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.felix.cm.PersistenceManager;
@@ -114,7 +115,13 @@ public class UpgradeReport {
 
 		_executionDateString = _getExecutionDateString();
 		_executionTimeString = _getExecutionTimeString();
+
 		_rootDir = _getRootDir();
+
+		if (_dlSizeSupplier == null) {
+			_dlSizeSupplier = () -> FileUtils.sizeOfDirectory(
+				new File(_rootDir));
+		}
 
 		Map<String, Object> reportData = _getReportData(upgradeRecorder);
 
@@ -389,8 +396,21 @@ public class UpgradeReport {
 							"\"rootDir\" was not set";
 					}
 
+					File rootDirFile = new File(_rootDir);
+
+					if (!rootDirFile.isDirectory()) {
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Unable to determine the document library " +
+									"size. Directory does not exist: " +
+										_rootDir);
+						}
+
+						return "Unable to determine";
+					}
+
 					FutureTask<Long> dlSizeFutureTask = new FutureTask<>(
-						() -> FileUtils.sizeOfDirectory(new File(_rootDir)));
+						_dlSizeSupplier::get);
 
 					try {
 						Thread dlSizeThread = new Thread(
@@ -1085,6 +1105,7 @@ public class UpgradeReport {
 	private static final Snapshot<ReleaseManager> _releaseManagerSnapshot =
 		new Snapshot<>(UpgradeReport.class, ReleaseManager.class);
 
+	private Supplier<Long> _dlSizeSupplier;
 	private String _executionDateString;
 	private String _executionTimeString;
 	private final int _initialBuildNumber;

--- a/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/test/java/com/liferay/portal/upgrade/internal/report/UpgradeReportTest.java
@@ -232,7 +232,7 @@ public class UpgradeReportTest {
 				(Map<String, Object>)reportData.get("document.library");
 
 			Assert.assertEquals(
-				"Unable to determine", documentLibrary.get("storage.size"));
+				"unable to determine", documentLibrary.get("storage.size"));
 		}
 		finally {
 			Files.deleteIfExists(tempFilePath);

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -404,8 +404,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 						"Increase the timeout or check it manually."));
 			_assertLogContext(
 				"upgrade.report.document.library.storage.size",
-				"Unable to determine");
-			_assertReport("Document library storage size: Unable to determine");
+				"unable to determine");
+			_assertReport("Document library storage size: unable to determine");
 		}
 	}
 
@@ -419,8 +419,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender.stop();
 
 			_assertLogContext(
-				"upgrade.report.document.library.storage.size", "Disabled");
-			_assertReport("Document library storage size: Disabled");
+				"upgrade.report.document.library.storage.size", "disabled");
+			_assertReport("Document library storage size: disabled");
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -81,6 +81,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -381,19 +382,18 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 				_appender, "_upgradeReport");
 
 			ReflectionTestUtil.setFieldValue(
-				upgradeReport, "_dlSizeThread",
-				new Thread() {
+				upgradeReport, "_dlSizeSupplier",
+				(Supplier<Long>)() -> {
+					try {
+						Thread.sleep(5 * Time.SECOND);
+					}
+					catch (InterruptedException interruptedException) {
+						Thread currentThread = Thread.currentThread();
 
-					@Override
-					public void run() {
-						try {
-							sleep(5 * Time.SECOND);
-						}
-						catch (InterruptedException interruptedException) {
-							throw new RuntimeException(interruptedException);
-						}
+						currentThread.interrupt();
 					}
 
+					return 0L;
 				});
 
 			_appender.stop();
@@ -432,16 +432,8 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1073742000);
-				}
-
-			});
+			upgradeReport, "_dlSizeSupplier",
+			(Supplier<Long>)() -> 1073742000L);
 
 		_appender.stop();
 
@@ -459,16 +451,7 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 			_appender, "_upgradeReport");
 
 		ReflectionTestUtil.setFieldValue(
-			upgradeReport, "_dlSizeThread",
-			new Thread() {
-
-				@Override
-				public void run() {
-					ReflectionTestUtil.setFieldValue(
-						upgradeReport, "_dlSize", 1048576);
-				}
-
-			});
+			upgradeReport, "_dlSizeSupplier", (Supplier<Long>)() -> 1048576L);
 
 		_appender.stop();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89694

**What is being fixed:** After the LPD-86109 refactor changed `UpgradeReport`'s DL-size computation from `DLSizeThread`/`_dlSize` fields to a local `FutureTask<Long>`, two test harnesses broke. Integration tests in `BaseUpgradeLogAppenderTestCase` failed with `NoSuchFieldException` because they injected values via `ReflectionTestUtil.setFieldValue` targeting the removed fields. The AFSStoreUpgrade Poshi test failed because a missing document library directory now reached the `FutureTask`'s `ExecutionException` catch block and was logged at ERROR, which Poshi's `assertNoPoshiWarnings` treats as a test failure.

**How it is being fixed:** A `Supplier<Long>` field (`_dlSizeSupplier`) is introduced on `UpgradeReport`, initialized lazily in `generateReport()` to call `FileUtils.sizeOfDirectory` on the configured root directory. The existing `FutureTask` delegates to this supplier, so integration tests can inject a controlled value via `ReflectionTestUtil.setFieldValue("_dlSizeSupplier", ...)` without depending on the removed fields. An `isDirectory` check is added before the supplier is invoked: when the root directory is absent, `generateReport()` logs at INFO and returns early, preventing the ERROR-level log that tripped the Poshi assertion.