### PR TITLE
LPD-84022 Rename handlerId to queryId in the progress identifier

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTracker.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTracker.java
@@ -433,11 +433,11 @@ public class UpgradeLogProgressTracker {
 		UpgradeLogProgressTracker.class);
 
 	private static volatile boolean _enabled;
-	private static final AtomicLong _handlerCounter = new AtomicLong();
 	private static final Map<String, Long> _lastKnownProgresses =
 		new ConcurrentHashMap<>();
 	private static final Map<String, Long> _lastKnownTotalCounts =
 		new ConcurrentHashMap<>();
+	private static final AtomicLong _queryCounter = new AtomicLong();
 	private static final Set<String> _unsafeSetters = new HashSet<>(
 		Arrays.asList(
 			"setAsciiStream", "setBinaryStream", "setBlob",
@@ -502,17 +502,17 @@ public class UpgradeLogProgressTracker {
 			_statementProxy = statementProxy;
 			_totalRowCountSupplier = totalRowCountSupplier;
 
-			long handlerId = _handlerCounter.incrementAndGet();
+			long queryId = _queryCounter.incrementAndGet();
 
 			if (PropsValues.DATABASE_PARTITION_ENABLED) {
 				_progressId = StringBundler.concat(
 					upgradeProcessClassName, " {companyId=",
-					CompanyThreadLocal.getCompanyId(), ", handlerId=",
-					handlerId, "}");
+					CompanyThreadLocal.getCompanyId(), ", queryId=", queryId,
+					"}");
 			}
 			else {
 				_progressId = StringBundler.concat(
-					upgradeProcessClassName, " {handlerId=", handlerId, "}");
+					upgradeProcessClassName, " {queryId=", queryId, "}");
 			}
 
 			_lastLogTime = System.currentTimeMillis();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-84022

## What is being fixed

The progress identifier embedded in upgrade log lines uses `handlerId=`, which leaks an implementation detail of the JDBC proxy wrapping the iterated `ResultSet`. From a reader's perspective, what each line identifies is the SQL query being executed, not the handler that wraps its result set.

## How it is being fixed

Renames the field, local, and embedded literal so the progress identifier uses `queryId=` instead. The underlying counter is renamed to match (`_queryCounter`). The change is mechanical and limited to `UpgradeLogProgressTracker`; tests build progress IDs through `_getProgressId(...)` rather than hardcoding the literal, so no test edits are needed.