### PR TITLE
LPD-90738 Grant select on v_$session and v_$sql after Oracle legacy database import

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15918,6 +15918,12 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 									#!/bin/bash
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
+
+									sqlplus ${oracle.admin.user}/${oracle.admin.password} << -'EOF'
+									grant select on sys.v_$session to ${database.username};
+									grant select on sys.v_$sql to ${database.username};
+									exit
+									EOF
 								]]>
 							</echo>
 
@@ -16133,6 +16139,13 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="dumpfile=${database.type}.dmp" />
 								<arg value="table_exists_action=replace" />
 							</exec>
+
+							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" password="${oracle.admin.password}" print="true" url="${database.oracle.url}" userid="${oracle.admin.user}">
+								<![CDATA[
+									grant select on sys.v_$session to lportal;
+									grant select on sys.v_$sql to lportal;
+								]]>
+							</sql>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />
 						</then>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90738

**What is being fixed:** The `rebuild-legacy-database` target restores an Oracle schema via `impdp`, which recreates the `lportal` user from the dump without the privileges required by `UpgradeQueryMonitor` to query `sys.v_$session` and `sys.v_$sql`. CI upgrade tests against legacy Oracle databases fail with ORA-00942 because neither import path grants those privileges after the restore.

**How it is being fixed:** Both Oracle import paths in `rebuild-legacy-database` now grant `SELECT` on `sys.v_$session` and `sys.v_$sql` after the dump restore completes. The Docker path adds a `sqlplus` call to the import bash script (using `<< -'EOF'` to handle tab-indented heredoc). The non-Docker path adds an Ant `<sql>` task immediately after the `<exec executable="impdp">` block.