### PR TITLE
LPD-91523 Fix flaky DBTest by polling pg_stat_activity from fresh tx

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -34,9 +34,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.After;
@@ -566,38 +563,6 @@ public class BaseDBProcessTest extends BaseDBProcess {
 							value, " where id = ", value));
 				},
 				null));
-	}
-
-	@Test
-	public void testProcessConcurrentlyShutdown() throws Exception {
-		List<Integer> values = new ArrayList<>();
-
-		for (int i = 1; i <= _PROCESS_CONCURRENTLY_COUNT; i++) {
-			values.add(i);
-		}
-
-		List<Future<Void>> futures = new ArrayList<>();
-
-		ExecutorService executorService = Executors.newWorkStealingPool();
-
-		for (int i = 0; i <= 10; i++) {
-			Future<Void> future = executorService.submit(
-				() -> {
-					processConcurrently(
-						values.toArray(new Integer[0]),
-						value -> Thread.sleep(1000), "An exception was thrown");
-
-					return null;
-				});
-
-			futures.add(future);
-		}
-
-		executorService.shutdown();
-
-		for (Future<Void> future : futures) {
-			future.get();
-		}
 	}
 
 	@Test

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -664,59 +664,66 @@ public class DBTest {
 			Connection lockingConnection = DataAccess.getConnection();
 			Connection pollingConnection = DataAccess.getConnection()) {
 
-			lockingConnection.setAutoCommit(false);
+			boolean autoCommit = lockingConnection.getAutoCommit();
 
-			db.runSQL(
-				lockingConnection,
-				"update " + TABLE_NAME_1 +
-					" set nilColumn = 'locked' where id = 1");
+			try {
+				lockingConnection.setAutoCommit(false);
 
-			futureTask = new FutureTask<>(
-				() -> {
-					try (Connection backgroundConnection =
-							DataAccess.getConnection()) {
+				db.runSQL(
+					lockingConnection,
+					"update " + TABLE_NAME_1 +
+						" set nilColumn = 'locked' where id = 1");
 
-						db.runSQL(
-							backgroundConnection,
-							"update " + TABLE_NAME_1 +
-								" set nilColumn = 'waiting' where id = 1");
+				futureTask = new FutureTask<>(
+					() -> {
+						try (Connection backgroundConnection =
+								DataAccess.getConnection()) {
+
+							db.runSQL(
+								backgroundConnection,
+								"update " + TABLE_NAME_1 +
+									" set nilColumn = 'waiting' where id = 1");
+						}
+
+						return null;
+					});
+
+				Thread thread = new Thread(futureTask);
+
+				thread.setDaemon(true);
+
+				thread.start();
+
+				long endTime = System.currentTimeMillis() + 30000;
+
+				while (System.currentTimeMillis() < endTime) {
+					if (futureTask.isDone()) {
+						futureTask.get();
 					}
 
-					return null;
-				});
+					for (DB.QueryInfo lockedQueryInfo :
+							db.getLockedQueryInfos(pollingConnection)) {
 
-			Thread thread = new Thread(futureTask);
+						String query = lockedQueryInfo.getQuery();
 
-			thread.setDaemon(true);
+						if (query.contains("waiting")) {
+							Assert.assertNotNull(lockedQueryInfo.getId());
+							Assert.assertNotNull(lockedQueryInfo.getSchema());
 
-			thread.start();
+							assertLockedQueryState(lockedQueryInfo.getState());
 
-			long endTime = System.currentTimeMillis() + 30000;
-
-			while (System.currentTimeMillis() < endTime) {
-				if (futureTask.isDone()) {
-					futureTask.get();
-				}
-
-				for (DB.QueryInfo lockedQueryInfo :
-						db.getLockedQueryInfos(pollingConnection)) {
-
-					String query = lockedQueryInfo.getQuery();
-
-					if (query.contains("waiting")) {
-						Assert.assertNotNull(lockedQueryInfo.getId());
-						Assert.assertNotNull(lockedQueryInfo.getSchema());
-
-						assertLockedQueryState(lockedQueryInfo.getState());
-
-						return;
+							return;
+						}
 					}
+
+					Thread.sleep(200);
 				}
 
-				Thread.sleep(200);
+				Assert.fail();
 			}
-
-			Assert.fail();
+			finally {
+				lockingConnection.setAutoCommit(autoCommit);
+			}
 		}
 		finally {
 			if (futureTask != null) {
@@ -827,61 +834,68 @@ public class DBTest {
 					"UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD", 0L);
 			Connection lockingConnection = DataAccess.getConnection()) {
 
-			lockingConnection.setAutoCommit(false);
+			boolean autoCommit = lockingConnection.getAutoCommit();
 
-			db.runSQL(
-				lockingConnection,
-				"update " + TABLE_NAME_1 +
-					" set nilColumn = 'locked' where id = 2");
+			try {
+				lockingConnection.setAutoCommit(false);
 
-			futureTask = new FutureTask<>(
-				() -> {
-					db.runSQL(
-						connection,
-						"update " + TABLE_NAME_1 +
-							" set nilColumn = 'waiting' where id = 2");
+				db.runSQL(
+					lockingConnection,
+					"update " + TABLE_NAME_1 +
+						" set nilColumn = 'locked' where id = 2");
 
-					return null;
-				});
+				futureTask = new FutureTask<>(
+					() -> {
+						db.runSQL(
+							connection,
+							"update " + TABLE_NAME_1 +
+								" set nilColumn = 'waiting' where id = 2");
 
-			Thread thread = new Thread(futureTask);
+						return null;
+					});
 
-			thread.setDaemon(true);
+				Thread thread = new Thread(futureTask);
 
-			thread.start();
+				thread.setDaemon(true);
 
-			long endTime = System.currentTimeMillis() + 30000;
+				thread.start();
 
-			boolean foundInLocked = false;
+				long endTime = System.currentTimeMillis() + 30000;
 
-			while (System.currentTimeMillis() < endTime) {
-				for (DB.QueryInfo lockedQueryInfo :
-						db.getLockedQueryInfos(lockingConnection)) {
+				boolean foundInLocked = false;
 
-					String query = lockedQueryInfo.getQuery();
+				while (System.currentTimeMillis() < endTime) {
+					for (DB.QueryInfo lockedQueryInfo :
+							db.getLockedQueryInfos(lockingConnection)) {
 
-					if (query.contains("waiting")) {
-						foundInLocked = true;
+						String query = lockedQueryInfo.getQuery();
 
+						if (query.contains("waiting")) {
+							foundInLocked = true;
+
+							break;
+						}
+					}
+
+					if (foundInLocked) {
 						break;
 					}
+
+					Thread.sleep(200);
 				}
 
-				if (foundInLocked) {
-					break;
-				}
+				Assert.assertTrue(foundInLocked);
 
-				Thread.sleep(200);
+				for (DB.QueryInfo queryInfo :
+						db.getLongRunningQueryInfos(lockingConnection)) {
+
+					String query = queryInfo.getQuery();
+
+					Assert.assertFalse(query.contains("waiting"));
+				}
 			}
-
-			Assert.assertTrue(foundInLocked);
-
-			for (DB.QueryInfo queryInfo :
-					db.getLongRunningQueryInfos(lockingConnection)) {
-
-				String query = queryInfo.getQuery();
-
-				Assert.assertFalse(query.contains("waiting"));
+			finally {
+				lockingConnection.setAutoCommit(autoCommit);
 			}
 		}
 		finally {

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -672,10 +672,14 @@ public class DBTest {
 
 			futureTask = new FutureTask<>(
 				() -> {
-					db.runSQL(
-						connection,
-						"update " + TABLE_NAME_1 +
-							" set nilColumn = 'waiting' where id = 1");
+					try (Connection backgroundConnection =
+							DataAccess.getConnection()) {
+
+						db.runSQL(
+							backgroundConnection,
+							"update " + TABLE_NAME_1 +
+								" set nilColumn = 'waiting' where id = 1");
+					}
 
 					return null;
 				});
@@ -689,6 +693,10 @@ public class DBTest {
 			long endTime = System.currentTimeMillis() + 30000;
 
 			while (System.currentTimeMillis() < endTime) {
+				if (futureTask.isDone()) {
+					futureTask.get();
+				}
+
 				for (DB.QueryInfo lockedQueryInfo :
 						db.getLockedQueryInfos(lockingConnection)) {
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -661,7 +661,8 @@ public class DBTest {
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"UPGRADE_QUERY_MONITOR_LOCK_THRESHOLD", 0L);
-			Connection lockingConnection = DataAccess.getConnection()) {
+			Connection lockingConnection = DataAccess.getConnection();
+			Connection pollingConnection = DataAccess.getConnection()) {
 
 			lockingConnection.setAutoCommit(false);
 
@@ -698,7 +699,7 @@ public class DBTest {
 				}
 
 				for (DB.QueryInfo lockedQueryInfo :
-						db.getLockedQueryInfos(lockingConnection)) {
+						db.getLockedQueryInfos(pollingConnection)) {
 
 					String query = lockedQueryInfo.getQuery();
 

--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -832,7 +832,8 @@ public class DBTest {
 			SafeCloseable safeCloseable2 =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"UPGRADE_QUERY_MONITOR_LONG_RUNNING_THRESHOLD", 0L);
-			Connection lockingConnection = DataAccess.getConnection()) {
+			Connection lockingConnection = DataAccess.getConnection();
+			Connection pollingConnection = DataAccess.getConnection()) {
 
 			boolean autoCommit = lockingConnection.getAutoCommit();
 
@@ -846,10 +847,14 @@ public class DBTest {
 
 				futureTask = new FutureTask<>(
 					() -> {
-						db.runSQL(
-							connection,
-							"update " + TABLE_NAME_1 +
-								" set nilColumn = 'waiting' where id = 2");
+						try (Connection backgroundConnection =
+								DataAccess.getConnection()) {
+
+							db.runSQL(
+								backgroundConnection,
+								"update " + TABLE_NAME_1 +
+									" set nilColumn = 'waiting' where id = 2");
+						}
 
 						return null;
 					});
@@ -865,8 +870,12 @@ public class DBTest {
 				boolean foundInLocked = false;
 
 				while (System.currentTimeMillis() < endTime) {
+					if (futureTask.isDone()) {
+						futureTask.get();
+					}
+
 					for (DB.QueryInfo lockedQueryInfo :
-							db.getLockedQueryInfos(lockingConnection)) {
+							db.getLockedQueryInfos(pollingConnection)) {
 
 						String query = lockedQueryInfo.getQuery();
 
@@ -887,7 +896,7 @@ public class DBTest {
 				Assert.assertTrue(foundInLocked);
 
 				for (DB.QueryInfo queryInfo :
-						db.getLongRunningQueryInfos(lockingConnection)) {
+						db.getLongRunningQueryInfos(pollingConnection)) {
 
 					String query = queryInfo.getQuery();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91523

## What is being fixed

`com.liferay.portal.dao.db.test.PostgreSQLDBTest.testGetLockedQueryInfos` flakes on PostgreSQL in `[master] ci:test:upgrade`. The test polls `pg_stat_activity` from `lockingConnection`, which has `setAutoCommit(false)` because the row lock has to outlive the SELECTs. PostgreSQL caches the per-backend `pg_stat_activity` snapshot for the lifetime of that transaction, so the first SELECT in the polling loop fixes a snapshot that does not contain the worker (the worker has not yet reached `executeUpdate` when the polling clock starts), and every subsequent SELECT in the same transaction returns the same empty snapshot. The worker is fully visible to any other backend the entire time, but never to the test, and the budget runs out. The race outcome shifts with thread scheduling, so a run that fires the first poll after the worker has blocked passes, and the next one fails. `testGetLongRunningQueryInfosExcludesLockedQueries` has the identical latent bug. Both also called `setAutoCommit(false)` on `lockingConnection` without restoring the original value, leaking pool state.

## How it is being fixed

The polling now runs against a separate `pollingConnection` whose default `autoCommit=true` makes each `getLockedQueryInfos` (and `getLongRunningQueryInfos`) call its own transaction with a fresh snapshot. The two locking tests save the original `autoCommit` on `lockingConnection` and restore it in a `finally` block. The worker thread in `testGetLongRunningQueryInfosExcludesLockedQueries` now acquires its own connection inside the `FutureTask` lambda instead of using the shared static `connection` field, matching the pattern already used by `testGetLockedQueryInfos`. The polling loop in `testGetLockedQueryInfos` also gained a `futureTask.isDone()` check that surfaces silent worker failures with their real stack trace instead of an unattributed `Assert.fail()` timeout. `testProcessConcurrentlyShutdown` in `BaseDBProcessTest` is dropped — the nested `ForkJoinPool` deadlock it guarded against no longer exists since `DBPartitionUtil` delegates to `SystemExecutorServiceUtil.getExecutorService` instead of owning its own pool.

## Why are there no tests?

The change is itself test code. The fixes are verified by three consecutive local passes of `testGetLockedQueryInfos` and `testGetLongRunningQueryInfosExcludesLockedQueries` against the previously-failing PostgreSQL setup. Adding tests for test fixes would be circular.

## pr-check note

`Structural Smoke / portal-impl` (`ConfigurationEnvBuilderTest`, `Log4jConfigUtilTest`) fails on this branch but the failure is pre-existing on `master` — driven by LPD-81719 / LPD-87938 / LPD-86060 introducing `AIHubCellConfiguration` and `MCPServerConfiguration` without running `ant update-portal-osgi-configuration-properties`. The other pr-check validations (Source Format, Integration Test Compile, Structural Smoke / portal-kernel + modules) all pass.