### PR TITLE
LPD-91995 Fix export failure when a configuration has groupId=0

### DIFF
--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/operation/ExportPortalInstanceOperation.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/operation/ExportPortalInstanceOperation.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.instances.internal.operation;
 
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -183,8 +184,21 @@ public class ExportPortalInstanceOperation extends BasePortalInstanceOperation {
 				scopedConfiguration.getScope(),
 				ExtendedObjectClassDefinition.Scope.GROUP)) {
 
-			Group group = _groupLocalService.getGroup(
-				(long)scopedConfiguration.getScopePK());
+			long groupId = (long)scopedConfiguration.getScopePK();
+
+			Group group = _groupLocalService.fetchGroup(groupId);
+
+			if (group == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Skipping configuration ",
+							scopedConfiguration.getConfigurationId(),
+							" because group ", groupId, " does not exist"));
+				}
+
+				return false;
+			}
 
 			if (group.getCompanyId() == companyId) {
 				return true;

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionExportPortalInstanceOperationTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/internal/operation/test/DBPartitionExportPortalInstanceOperationTest.java
@@ -7,15 +7,29 @@ package com.liferay.portal.db.partition.internal.operation.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
 
+import java.io.Serializable;
+
+import java.lang.reflect.Constructor;
+
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
 
 /**
  * @author Mariano Álvaro Sáiz
@@ -109,8 +123,65 @@ public class DBPartitionExportPortalInstanceOperationTest
 		}
 	}
 
+	@Test
+	public void testIsApplicableWhenGroupDoesNotExist() throws Exception {
+		Bundle bundle = BundleUtil.getBundle(
+			SystemBundleUtil.getBundleContext(),
+			"com.liferay.portal.instances.service");
+
+		Class<?> exportPortalInstanceOperationClass = bundle.loadClass(
+			"com.liferay.portal.instances.internal.operation." +
+				"ExportPortalInstanceOperation");
+
+		Object exportPortalInstanceOperation =
+			exportPortalInstanceOperationClass.newInstance();
+
+		ReflectionTestUtil.setFieldValue(
+			exportPortalInstanceOperation, "_groupLocalService",
+			_groupLocalService);
+
+		Class<?> scopedConfigurationClass =
+			exportPortalInstanceOperationClass.getDeclaredClasses()[0];
+
+		Constructor<?> scopedConfigurationConstructor =
+			scopedConfigurationClass.getDeclaredConstructor(
+				exportPortalInstanceOperationClass, String.class, String.class,
+				Serializable.class, ExtendedObjectClassDefinition.Scope.class);
+
+		scopedConfigurationConstructor.setAccessible(true);
+
+		Object scopedConfiguration = scopedConfigurationConstructor.newInstance(
+			exportPortalInstanceOperation, _SCOPED_CONFIGURATION_PID, "",
+			GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			ExtendedObjectClassDefinition.Scope.GROUP);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				exportPortalInstanceOperationClass.getName(),
+				LoggerTestUtil.WARN)) {
+
+			Assert.assertFalse(
+				ReflectionTestUtil.invoke(
+					exportPortalInstanceOperation, "_isApplicable",
+					new Class<?>[] {long.class, scopedConfigurationClass},
+					PortalInstancePool.getDefaultCompanyId(),
+					scopedConfiguration));
+
+			assertLog(
+				logCapture,
+				"Skipping configuration " + _SCOPED_CONFIGURATION_PID +
+					" because group 0 does not exist");
+		}
+	}
+
 	private static final String _PID =
 		"com.liferay.portal.instances.internal.configuration." +
 			"ExportPortalInstanceConfiguration";
+
+	private static final String _SCOPED_CONFIGURATION_PID =
+		DBPartitionExportPortalInstanceOperationTest.class.getName() +
+			"ScopedConfiguration";
+
+	@Inject
+	private GroupLocalService _groupLocalService;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91995

## What is being fixed

ExportPortalInstanceOperation aborts the virtual-instance export when a configuration in the source `Configuration_` table references a group that no longer exists. The operation calls `GroupLocalService.getGroup(scopePK)` without checking whether the group exists first; if the `scopePK` is `0` (the framework's sentinel for "not group-scoped" per `ConfigurationModel.hasScopeConfiguration` and `DLConfigurationUpgradeHelper`) or any orphaned group ID, the operation throws `NoSuchGroupException` and the entire export halts. This blocks customer migrations (see LPP-64157).

## How it is being fixed

Replace `GroupLocalService.getGroup` with `fetchGroup` plus a null check so orphaned group references skip with a warn log instead of throwing. The warning message mirrors `ConfigurationDBPartitionUpgradeProcess`'s existing "Skipping configuration … because group … does not exist" pattern. Adds an integration test that invokes `_isApplicable` directly via reflection (using `BundleUtil` to bypass internal-package visibility) and verifies both the `false` return and the audit warn-log fire.