### PR TITLE
LPD-86905 Use CompanyInheritableThreadLocalCallable in ai-hub

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngine.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngine.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Feliphe Marinho
@@ -50,12 +49,12 @@ public class LiferayWebSearchEngine implements WebSearchEngine {
 		_userToken = userToken;
 
 		_searchCallable = new CompanyInheritableThreadLocalCallable<>(
-			() -> _search(_webSearchRequestAtomicReference.get()));
+			() -> _search(_webSearchRequest));
 	}
 
 	@Override
 	public WebSearchResults search(WebSearchRequest webSearchRequest) {
-		_webSearchRequestAtomicReference.set(webSearchRequest);
+		_webSearchRequest = webSearchRequest;
 
 		try {
 			return _searchCallable.call();
@@ -154,7 +153,6 @@ public class LiferayWebSearchEngine implements WebSearchEngine {
 	private final long _oAuth2ApplicationId;
 	private final Callable<WebSearchResults> _searchCallable;
 	private final String _userToken;
-	private final AtomicReference<WebSearchRequest>
-		_webSearchRequestAtomicReference = new AtomicReference<>();
+	private WebSearchRequest _webSearchRequest;
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngine.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngine.java
@@ -7,11 +7,10 @@ package com.liferay.ai.hub.internal.web.search;
 
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
@@ -34,6 +33,8 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Feliphe Marinho
@@ -41,21 +42,23 @@ import java.util.Map;
 public class LiferayWebSearchEngine implements WebSearchEngine {
 
 	public LiferayWebSearchEngine(
-		String blueprintExternalReferenceCode, long companyId,
-		long oAuth2ApplicationId, String userToken) {
+		String blueprintExternalReferenceCode, long oAuth2ApplicationId,
+		String userToken) {
 
 		_blueprintExternalReferenceCode = blueprintExternalReferenceCode;
-		_companyId = companyId;
 		_oAuth2ApplicationId = oAuth2ApplicationId;
 		_userToken = userToken;
+
+		_searchCallable = new CompanyInheritableThreadLocalCallable<>(
+			() -> _search(_webSearchRequestAtomicReference.get()));
 	}
 
 	@Override
 	public WebSearchResults search(WebSearchRequest webSearchRequest) {
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(_companyId)) {
+		_webSearchRequestAtomicReference.set(webSearchRequest);
 
-			return _search(webSearchRequest);
+		try {
+			return _searchCallable.call();
 		}
 		catch (Exception exception) {
 			return ReflectionUtil.throwException(exception);
@@ -148,8 +151,10 @@ public class LiferayWebSearchEngine implements WebSearchEngine {
 	}
 
 	private final String _blueprintExternalReferenceCode;
-	private final long _companyId;
 	private final long _oAuth2ApplicationId;
+	private final Callable<WebSearchResults> _searchCallable;
 	private final String _userToken;
+	private final AtomicReference<WebSearchRequest>
+		_webSearchRequestAtomicReference = new AtomicReference<>();
 
 }

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -17,12 +17,12 @@ import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.ToolsUtil;
 import com.liferay.ai.hub.internal.workflow.kaleo.runtime.node.util.VariablesUtil;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
-import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.CompanyInheritableThreadLocalCallable;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -52,6 +52,8 @@ import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -69,6 +71,36 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 
 	public class Tools {
 
+		public Tools() {
+			_completeWorkflowNodeCallable =
+				new CompanyInheritableThreadLocalCallable<>(
+					() -> {
+						InvocationParameters invocationParameters =
+							_invocationParametersAtomicReference.get();
+
+						ExecutionContext executionContext =
+							invocationParameters.get("executionContext");
+
+						KaleoInstanceToken kaleoInstanceToken =
+							executionContext.getKaleoInstanceToken();
+
+						Map<String, Serializable> workflowContext =
+							executionContext.getWorkflowContext();
+
+						workflowContext.put(
+							"reason", _reasonAtomicReference.get());
+
+						_workflowNodeManager.completeWorkflowNode(
+							kaleoInstanceToken.getCompanyId(),
+							kaleoInstanceToken.getUserId(),
+							kaleoInstanceToken.getKaleoInstanceTokenId(),
+							_transitionNameAtomicReference.get(),
+							workflowContext, false);
+
+						return null;
+					});
+		}
+
 		@Tool(
 			"Complete the workflow node by proceeding to the chosen transition"
 		)
@@ -81,28 +113,25 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 				@P("Transition name") String transitionName)
 			throws PortalException {
 
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						invocationParameters.get("companyId"))) {
+			_invocationParametersAtomicReference.set(invocationParameters);
+			_reasonAtomicReference.set(reason);
+			_transitionNameAtomicReference.set(transitionName);
 
-				ExecutionContext executionContext = invocationParameters.get(
-					"executionContext");
-
-				KaleoInstanceToken kaleoInstanceToken =
-					executionContext.getKaleoInstanceToken();
-
-				Map<String, Serializable> workflowContext =
-					executionContext.getWorkflowContext();
-
-				workflowContext.put("reason", reason);
-
-				_workflowNodeManager.completeWorkflowNode(
-					kaleoInstanceToken.getCompanyId(),
-					kaleoInstanceToken.getUserId(),
-					kaleoInstanceToken.getKaleoInstanceTokenId(),
-					transitionName, workflowContext, false);
+			try {
+				_completeWorkflowNodeCallable.call();
+			}
+			catch (Exception exception) {
+				ReflectionUtil.throwException(exception);
 			}
 		}
+
+		private final Callable<Void> _completeWorkflowNodeCallable;
+		private final AtomicReference<InvocationParameters>
+			_invocationParametersAtomicReference = new AtomicReference<>();
+		private final AtomicReference<String> _reasonAtomicReference =
+			new AtomicReference<>();
+		private final AtomicReference<String> _transitionNameAtomicReference =
+			new AtomicReference<>();
 
 	}
 
@@ -164,9 +193,7 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 			AssistantHandlerContext.builder(
 			).invocationParameters(
 				InvocationParameters.from(
-					Map.of(
-						"companyId", CompanyThreadLocal.getCompanyId(),
-						"executionContext", executionContext))
+					Map.of("executionContext", executionContext))
 			).memoryId(
 				GetterUtil.getString(workflowContext.get("memoryId"))
 			).onCompleteResponseConsumer(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor.java
@@ -53,7 +53,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -75,11 +74,8 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 			_completeWorkflowNodeCallable =
 				new CompanyInheritableThreadLocalCallable<>(
 					() -> {
-						InvocationParameters invocationParameters =
-							_invocationParametersAtomicReference.get();
-
 						ExecutionContext executionContext =
-							invocationParameters.get("executionContext");
+							_invocationParameters.get("executionContext");
 
 						KaleoInstanceToken kaleoInstanceToken =
 							executionContext.getKaleoInstanceToken();
@@ -87,15 +83,13 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 						Map<String, Serializable> workflowContext =
 							executionContext.getWorkflowContext();
 
-						workflowContext.put(
-							"reason", _reasonAtomicReference.get());
+						workflowContext.put("reason", _reason);
 
 						_workflowNodeManager.completeWorkflowNode(
 							kaleoInstanceToken.getCompanyId(),
 							kaleoInstanceToken.getUserId(),
 							kaleoInstanceToken.getKaleoInstanceTokenId(),
-							_transitionNameAtomicReference.get(),
-							workflowContext, false);
+							_transitionName, workflowContext, false);
 
 						return null;
 					});
@@ -113,9 +107,9 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 				@P("Transition name") String transitionName)
 			throws PortalException {
 
-			_invocationParametersAtomicReference.set(invocationParameters);
-			_reasonAtomicReference.set(reason);
-			_transitionNameAtomicReference.set(transitionName);
+			_invocationParameters = invocationParameters;
+			_reason = reason;
+			_transitionName = transitionName;
 
 			try {
 				_completeWorkflowNodeCallable.call();
@@ -126,12 +120,9 @@ public class AIDecisionNodeExecutor extends BaseNodeExecutor {
 		}
 
 		private final Callable<Void> _completeWorkflowNodeCallable;
-		private final AtomicReference<InvocationParameters>
-			_invocationParametersAtomicReference = new AtomicReference<>();
-		private final AtomicReference<String> _reasonAtomicReference =
-			new AtomicReference<>();
-		private final AtomicReference<String> _transitionNameAtomicReference =
-			new AtomicReference<>();
+		private InvocationParameters _invocationParameters;
+		private String _reason;
+		private String _transitionName;
 
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/RetrievalAugmentorUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/util/RetrievalAugmentorUtil.java
@@ -189,7 +189,6 @@ public class RetrievalAugmentorUtil {
 					new LiferayWebSearchEngine(
 						contentRetrieverJSONObject.getString(
 							"blueprintExternalReferenceCode"),
-						companyId,
 						GetterUtil.getLong(
 							workflowContext.get("oAuth2ApplicationId")),
 						EncryptorUtil.decrypt(

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngineTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngineTest.java
@@ -63,7 +63,7 @@ public class LiferayWebSearchEngineTest {
 			LiferayWebSearchEngine liferayWebSearchEngine =
 				new LiferayWebSearchEngine(
 					RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-					RandomTestUtil.randomLong(), RandomTestUtil.randomString());
+					RandomTestUtil.randomString());
 
 			SecurityException securityException = Assert.assertThrows(
 				SecurityException.class,

--- a/modules/dxp/apps/ai-hub/source-formatter-suppressions.xml
+++ b/modules/dxp/apps/ai-hub/source-formatter-suppressions.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-
-<suppressions>
-	<source-check>
-		<suppress checks="JavaCompanyThreadLocalCheck" files="ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngine\.java" />
-		<suppress checks="JavaCompanyThreadLocalCheck" files="ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/workflow/kaleo/runtime/node/AIDecisionNodeExecutor\.java" />
-	</source-check>
-</suppressions>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86905

## What is being fixed

Two `ai-hub` classes (`LiferayWebSearchEngine` and the `Tools.completeWorkflowNode` inner class on `AIDecisionNodeExecutor`) manually call `CompanyThreadLocal.setCompanyIdWithSafeCloseable(...)` because they run on langchain4j worker threads that do not inherit portal `ThreadLocal` state. Both files are suppressed from `JavaCompanyThreadLocalCheck`. The suppressions were tagged as tech debt under LPD-81801.

## How it is being fixed

Apply the in-module pattern from `LLMNodeExecutor.java:128-137`: build a `CompanyInheritableThreadLocalCallable` in the surrounding class's constructor (which runs on the Kaleo workflow thread, where `CompanyThreadLocal.getCompanyId()` already equals the workflow's company), route per-call inputs through `AtomicReference` fields, and invoke `.call()` from the langchain4j-facing entry point. Rethrow via Liferay's `ReflectionUtil.throwException`, the idiom already used in `LiferayWebSearchEngine.search`. Drop the now-orphaned `_companyId` field and constructor parameter on `LiferayWebSearchEngine` (cascade: one argument removed in `RetrievalAugmentorUtil`), drop the now-orphaned `"companyId"` entry from the `InvocationParameters` map in `AIDecisionNodeExecutor.doExecute`, and delete the `source-formatter-suppressions.xml` file.

## Why are there no tests?

Behavior-preserving refactor. The existing `LiferayWebSearchEngineTest` was updated to match the new 3-arg constructor signature. The refactor introduces no new observable behavior under the current `AssistantHandlerUtil` / `RetrievalAugmentorUtil` configuration.