### PR TITLE
LPD-91049 Improve throughput of BaseJakartaUpgradeProcess and JakartaUpgradeProcessUtil

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseJakartaUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseJakartaUpgradeProcess.java
@@ -157,7 +157,7 @@ public abstract class BaseJakartaUpgradeProcess extends UpgradeProcess {
 		String columnName, String[] primaryKeyColumnNames, String tableName) {
 
 		StringBundler sb = new StringBundler(
-			(primaryKeyColumnNames.length * 2) + 7);
+			(primaryKeyColumnNames.length * 2) + 9);
 
 		sb.append("select ");
 
@@ -171,7 +171,9 @@ public abstract class BaseJakartaUpgradeProcess extends UpgradeProcess {
 		sb.append(tableName);
 		sb.append(" where ");
 		sb.append(columnName);
-		sb.append(" is not null");
+		sb.append(" like '%javax%' or ");
+		sb.append(columnName);
+		sb.append(" like '%JAVAX%'");
 
 		return sb.toString();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/JakartaUpgradeProcessUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/util/JakartaUpgradeProcessUtil.java
@@ -10,7 +10,9 @@ import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Luis Ortiz
@@ -72,13 +74,19 @@ public class JakartaUpgradeProcessUtil {
 
 		value = StringUtil.replace(value, sourcePackage, targetPackage);
 
+		String escapedSourcePackage = _escapedCache.computeIfAbsent(
+			sourcePackage, HtmlUtil::escapeJS);
+		String escapedTargetPackage = _escapedCache.computeIfAbsent(
+			targetPackage, HtmlUtil::escapeJS);
+
 		return StringUtil.replace(
-			value, HtmlUtil.escapeJS(sourcePackage),
-			HtmlUtil.escapeJS(targetPackage));
+			value, escapedSourcePackage, escapedTargetPackage);
 	}
 
 	private static final char[] _SEPARATORS = {'-', '/'};
 
+	private static final Map<String, String> _escapedCache =
+		new ConcurrentHashMap<>();
 	private static final Set<String> _preservedSubpackageNames = new HashSet<>(
 		Arrays.asList("annotation.processing", "transaction.xa"));
 	private static final Set<String> _subpackageNames = new HashSet<>(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91049

**What is being fixed:** The Jakarta upgrade process was fetching every
non-null column row from the database and recomputing HtmlUtil.escapeJS
on the same package strings repeatedly, making the upgrade run slow on
large datasets.

**How it is being fixed:** The SELECT query in _getSelectSQL now filters
server-side with `LIKE '%javax%' OR LIKE '%JAVAX%'` so only rows that
actually contain javax references are transferred and processed.
JakartaUpgradeProcessUtil caches HtmlUtil.escapeJS results in a static
ConcurrentHashMap so each of the roughly 250 distinct package strings is
escaped only once across the entire upgrade run.