### PR TITLE
LPD-84022 Lower the upgrade log progress interval to one minute

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -230,7 +230,7 @@
     #
     # Env: LIFERAY_UPGRADE_PERIOD_LOG_PERIOD_PROGRESS_PERIOD_INTERVAL
     #
-    upgrade.log.progress.interval=300000
+    upgrade.log.progress.interval=60000
 
     #
     # Set to true to enable the background thread that monitors long running


### PR DESCRIPTION
## Summary

Lowers the default `upgrade.log.progress.interval` from `300000` ms (5 minutes) to `60000` ms (1 minute), so long-running upgrade query progress is logged more frequently.

## Context

Part of epic LPD-73419 (Upgrade progress visibility). The property was introduced by LPD-84021; this adjusts its default for the LPD-84022 work.