### PR TITLE
LPD-91140 Data cleanup pre-upgrade process suite performance optimizations POC

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -10,7 +10,10 @@ import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -25,7 +28,9 @@ import java.sql.ResultSet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -115,7 +120,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 				if (!dbInspector.hasTable(tableName)) {
 					if (_log.isWarnEnabled()) {
-						_log.warn("Table " + tableName + " does not exist");
+						_log.warn("Table \"" + tableName + "\" does not exist");
 					}
 
 					continue;
@@ -146,31 +151,45 @@ public class CounterDataCleanupPreupgradeProcess
 		tableNames.remove(dbInspector.normalizeName("Counter"));
 		tableNames.removeAll(excludedTableNames);
 
+		Map<String, Long> tableMaxValues = new ConcurrentHashMap<>();
+
+		processConcurrently(
+			tableNames.toArray(new String[0]),
+			tableName -> {
+				if (!dbInspector.isObjectTable(tableName) &&
+					!_liferayTableNames.contains(tableName)) {
+
+					return;
+				}
+
+				String columnName =
+					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
+						connection, dbInspector, tableName);
+
+				if ((columnName == null) ||
+					!dbInspector.isNumeric(tableName, columnName)) {
+
+					return;
+				}
+
+				long maxValue = _getMaxValue(
+					columnName, dbInspector, tableName);
+
+				if (maxValue > 0) {
+					tableMaxValues.put(tableName, maxValue);
+				}
+			},
+			null);
+
 		long latestCounterValue = 0L;
 		String maxValueTableName = null;
 
-		for (String tableName : tableNames) {
-			if (!dbInspector.isObjectTable(tableName) &&
-				!_liferayTableNames.contains(tableName)) {
-
-				continue;
-			}
-
-			String columnName =
-				DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
-					connection, dbInspector, tableName);
-
-			if ((columnName == null) ||
-				!dbInspector.isNumeric(tableName, columnName)) {
-
-				continue;
-			}
-
-			long maxValue = _getMaxValue(columnName, dbInspector, tableName);
+		for (Map.Entry<String, Long> entry : tableMaxValues.entrySet()) {
+			long maxValue = entry.getValue();
 
 			if (maxValue > latestCounterValue) {
 				latestCounterValue = maxValue;
-				maxValueTableName = tableName;
+				maxValueTableName = entry.getKey();
 			}
 		}
 
@@ -205,7 +224,7 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.hasTable("Layout")) {
-			_log.error("Table Layout does not exist");
+			_log.error("Table \"Layout\" does not exist");
 
 			return;
 		}
@@ -289,10 +308,10 @@ public class CounterDataCleanupPreupgradeProcess
 	}
 
 	private String _getLogMessage(
-		String counterName, long countervalue, String tableName) {
+		String counterName, long counterValue, String tableName) {
 
 		return StringBundler.concat(
-			"Counter ", counterName, " has been reset to value ", countervalue,
+			"Counter ", counterName, " has been reset to value ", counterValue,
 			(tableName != null) ? " due to table " + tableName : "");
 	}
 
@@ -301,6 +320,100 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
+			DB db = DBManagerUtil.getDB();
+
+			DBType dbType = db.getDBType();
+
+			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as unsigned)) as ", columnName, " from ",
+								tableName, " where ", columnName,
+								" regexp '^[0-9]+$'"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.ORACLE) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(to_number(", columnName, ")) as ",
+								columnName, " from ", tableName, " where ",
+								"regexp_like(", columnName, ", '^[0-9]+$')"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.POSTGRESQL) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName, " where ", columnName,
+								" ~ '^[0-9]+$'"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.SQLSERVER) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(try_cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
 			long maxValue = 0;
 
 			try (PreparedStatement preparedStatement =
@@ -311,13 +424,13 @@ public class CounterDataCleanupPreupgradeProcess
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					String value = resultSet.getString(columnName);
+					String valueString = resultSet.getString(columnName);
 
 					try {
-						long valueLong = Long.parseLong(value);
+						long value = Long.parseLong(valueString);
 
-						if (valueLong > maxValue) {
-							maxValue = valueLong;
+						if (value > maxValue) {
+							maxValue = value;
 						}
 					}
 					catch (NumberFormatException numberFormatException) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DDMDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DDMDataCleanupPreupgradeProcess.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -94,10 +95,75 @@ public class DDMDataCleanupPreupgradeProcess
 	private DataCleanupPreupgradeProcess
 		_getDDMFieldDataCleanupPreupgradeProcess() {
 
-		return new DataCleanupPreupgradeProcess(
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "fieldId", "DDMFieldAttribute", "fieldId",
-				"DDMField"));
+		return new DataCleanupPreupgradeProcess() {
+
+			@Override
+			protected void doUpgrade() throws Exception {
+				DBInspector dbInspector = new DBInspector(connection);
+
+				String ddmFieldAttributeTableName = dbInspector.normalizeName(
+					"DDMFieldAttribute");
+				String ddmFieldTableName = dbInspector.normalizeName("DDMField");
+
+				if (!dbInspector.hasTable(ddmFieldAttributeTableName) ||
+					!dbInspector.hasTable(ddmFieldTableName)) {
+
+					return;
+				}
+
+				List<Long> orphanIds = new ArrayList<>();
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select distinct fieldId from ",
+								ddmFieldAttributeTableName,
+								" where fieldId != 0 and fieldId is not null",
+								" and fieldId not in (select fieldId from ",
+								ddmFieldTableName, ")"));
+					 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					while (resultSet.next()) {
+						orphanIds.add(resultSet.getLong(1));
+					}
+				}
+
+				if (orphanIds.isEmpty()) {
+					return;
+				}
+
+				for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+					int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+					List<String> batchStrings = new ArrayList<>(end - i);
+
+					for (int j = i; j < end; j++) {
+						batchStrings.add(String.valueOf(orphanIds.get(j)));
+					}
+
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(
+								StringBundler.concat(
+									"delete from ", ddmFieldAttributeTableName,
+									" where fieldId in (",
+									String.join(
+										StringPool.COMMA_AND_SPACE, batchStrings),
+									")"))) {
+
+						int deleted = preparedStatement.executeUpdate();
+
+						if (deleted > 0) {
+							DataCleanupLoggingUtil.logDelete(
+								_log, deleted, ddmFieldAttributeTableName,
+								StringBundler.concat(
+									"fieldId was not found in fieldId from table ",
+									ddmFieldTableName));
+						}
+					}
+				}
+			}
+
+		};
 	}
 
 	private DataCleanupPreupgradeProcess
@@ -146,13 +212,91 @@ public class DDMDataCleanupPreupgradeProcess
 	private DataCleanupPreupgradeProcess
 		_getDDMStructureVersionDataCleanupPreupgradeProcess() {
 
-		return new DataCleanupPreupgradeProcess(
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "structureVersionId", "DDMField",
-				"structureVersionId", "DDMStructureVersion"),
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "structureVersionId", "DDMStructureLayout",
-				"structureVersionId", "DDMStructureVersion"));
+		return new DataCleanupPreupgradeProcess() {
+
+			@Override
+			protected void doUpgrade() throws Exception {
+				_cleanUpOrphans(
+					"structureVersionId", "DDMField",
+					"structureVersionId", "DDMStructureVersion");
+				_cleanUpOrphans(
+					"structureVersionId", "DDMStructureLayout",
+					"structureVersionId", "DDMStructureVersion");
+			}
+
+			private void _cleanUpOrphans(
+					String sourceColumnName, String sourceTableName,
+					String targetColumnName, String targetTableName)
+				throws Exception {
+
+				DBInspector dbInspector = new DBInspector(connection);
+
+				String normalizedSourceTableName = dbInspector.normalizeName(
+					sourceTableName);
+				String normalizedTargetTableName = dbInspector.normalizeName(
+					targetTableName);
+
+				if (!dbInspector.hasTable(normalizedSourceTableName) ||
+					!dbInspector.hasTable(normalizedTargetTableName)) {
+
+					return;
+				}
+
+				List<Long> orphanIds = new ArrayList<>();
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select distinct ", sourceColumnName, " from ",
+								normalizedSourceTableName, " where ",
+								sourceColumnName, " != 0 and ", sourceColumnName,
+								" is not null and ", sourceColumnName,
+								" not in (select ", targetColumnName, " from ",
+								normalizedTargetTableName, ")"));
+					 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					while (resultSet.next()) {
+						orphanIds.add(resultSet.getLong(1));
+					}
+				}
+
+				if (orphanIds.isEmpty()) {
+					return;
+				}
+
+				for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+					int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+					List<String> batchStrings = new ArrayList<>(end - i);
+
+					for (int j = i; j < end; j++) {
+						batchStrings.add(String.valueOf(orphanIds.get(j)));
+					}
+
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(
+								StringBundler.concat(
+									"delete from ", normalizedSourceTableName,
+									" where ", sourceColumnName, " in (",
+									String.join(
+										StringPool.COMMA_AND_SPACE, batchStrings),
+									")"))) {
+
+						int deleted = preparedStatement.executeUpdate();
+
+						if (deleted > 0) {
+							DataCleanupLoggingUtil.logDelete(
+								_log, deleted, normalizedSourceTableName,
+								StringBundler.concat(
+									sourceColumnName,
+									" was not found in ", targetColumnName,
+									" from table ", normalizedTargetTableName));
+						}
+					}
+				}
+			}
+
+		};
 	}
 
 	private DataCleanupPreupgradeProcess
@@ -250,11 +394,13 @@ public class DDMDataCleanupPreupgradeProcess
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
 					while (resultSet.next()) {
-						structureKeysMap.computeIfAbsent(
-							resultSet.getLong("groupId"), key -> new HashSet<>()
-						).add(
-							resultSet.getString("structureKey")
-						);
+						Set<String> structureKeys =
+							structureKeysMap.computeIfAbsent(
+								resultSet.getLong("groupId"),
+								key -> new HashSet<>());
+
+						structureKeys.add(
+							resultSet.getString("structureKey"));
 					}
 				}
 
@@ -376,6 +522,8 @@ public class DDMDataCleanupPreupgradeProcess
 
 		};
 	}
+
+	private static final int _BATCH_SIZE = 1000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DDMDataCleanupPreupgradeProcess.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DDMStorageLinkDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DDMStorageLinkDataCleanupPreupgradeProcess.java
@@ -5,8 +5,22 @@
 
 package com.liferay.portal.upgrade.data.cleanup;
 
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
-import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Luis Ortiz
@@ -16,18 +30,94 @@ public class DDMStorageLinkDataCleanupPreupgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		upgrade(
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "contentId", "DDMContent", "classPK",
-				"DDMStorageLink"));
-		upgrade(
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "storageId", "DDMField", "classPK",
-				"DDMStorageLink"));
-		upgrade(
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "storageId", "DDMFieldAttribute", "classPK",
-				"DDMStorageLink"));
+		DBInspector dbInspector = new DBInspector(connection);
+
+		if (!dbInspector.hasTable("DDMStorageLink") ||
+			!dbInspector.hasColumn("DDMStorageLink", "classPK")) {
+
+			return;
+		}
+
+		List<SafeCloseable> safeCloseables =
+			OrphanReferencesDataCleanupUtil.addTemporaryIndexes(
+				new String[] {"classPK"}, connection, DBManagerUtil.getDB(),
+				"DDMStorageLink");
+
+		try {
+			if (dbInspector.hasTable("DDMContent")) {
+				OrphanReferencesDataCleanupUtil.cleanUpTable(
+					connection, null, false, null, "contentId", "DDMContent",
+					new String[] {"classPK"}, "DDMStorageLink", true);
+			}
+
+			if (dbInspector.hasTable("DDMField")) {
+				_cleanUpOrphans("DDMField", "storageId");
+			}
+
+			if (dbInspector.hasTable("DDMFieldAttribute")) {
+				_cleanUpOrphans("DDMFieldAttribute", "storageId");
+			}
+		}
+		finally {
+			for (SafeCloseable safeCloseable : safeCloseables) {
+				safeCloseable.close();
+			}
+		}
 	}
+
+	private void _cleanUpOrphans(String tableName, String columnName)
+		throws Exception {
+
+		List<Long> orphanIds = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct ", columnName, " from ", tableName,
+					" where ", columnName, " is not null and ", columnName,
+					" != 0 and ", columnName,
+					" not in (select classPK from DDMStorageLink)"));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				orphanIds.add(resultSet.getLong(1));
+			}
+		}
+
+		if (orphanIds.isEmpty()) {
+			return;
+		}
+
+		for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+			int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+			List<String> batchStrings = new ArrayList<>(end - i);
+
+			for (int j = i; j < end; j++) {
+				batchStrings.add(String.valueOf(orphanIds.get(j)));
+			}
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"delete from ", tableName, " where ", columnName,
+							" in (",
+							String.join(
+								StringPool.COMMA_AND_SPACE, batchStrings),
+							")"))) {
+
+				int count = preparedStatement.executeUpdate();
+
+				DataCleanupLoggingUtil.logDelete(
+					_log, count, tableName,
+					StringBundler.concat(
+						columnName, " was not found in DDMStorageLink"));
+			}
+		}
+	}
+
+	private static final int _BATCH_SIZE = 1000;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DDMStorageLinkDataCleanupPreupgradeProcess.class);
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DLFileEntryDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DLFileEntryDataCleanupPreupgradeProcess.java
@@ -86,26 +86,106 @@ public class DLFileEntryDataCleanupPreupgradeProcess
 	private DataCleanupPreupgradeProcess
 		_getDLFileEntryDataCleanupPreupgradeProcess() {
 
-		return new DataCleanupPreupgradeProcess(
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "fileEntryId", "DLFileEntryMetadata", "fileEntryId",
-				"DLFileEntry"),
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "fileEntryId", "DLFileVersion", "fileEntryId",
-				"DLFileEntry"),
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "fileEntryId", "DLFileVersionPreview",
-				"fileEntryId", "DLFileEntry"),
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "toFileEntryId", "DLFileShortcut", "fileEntryId",
-				"DLFileEntry"),
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null,
-				StringBundler.concat(
-					"[$SOURCE_TABLE_ALIAS$].name = '",
-					DLFileEntry.class.getName(), "'"),
-				"primKeyId", "ResourcePermission", "fileEntryId",
-				"DLFileEntry"));
+		return new DataCleanupPreupgradeProcess() {
+
+			@Override
+			protected void doUpgrade() throws Exception {
+				_cleanUpOrphans(
+					"fileEntryId", "DLFileEntryMetadata", "fileEntryId",
+					"DLFileEntry");
+				_cleanUpOrphans(
+					"fileEntryId", "DLFileVersion", "fileEntryId",
+					"DLFileEntry");
+				_cleanUpOrphans(
+					"fileEntryId", "DLFileVersionPreview", "fileEntryId",
+					"DLFileEntry");
+				_cleanUpOrphans(
+					"toFileEntryId", "DLFileShortcut", "fileEntryId",
+					"DLFileEntry");
+
+				upgrade(
+					new TableOrphanReferencesDataCleanupPreupgradeProcess(
+						null,
+						StringBundler.concat(
+							"[$SOURCE_TABLE_ALIAS$].name = '",
+							DLFileEntry.class.getName(), "'"),
+						"primKeyId", "ResourcePermission", "fileEntryId",
+						"DLFileEntry"));
+			}
+
+			private void _cleanUpOrphans(
+					String sourceColumnName, String sourceTableName,
+					String targetColumnName, String targetTableName)
+				throws Exception {
+
+				DBInspector dbInspector = new DBInspector(connection);
+
+				String normalizedSourceTableName = dbInspector.normalizeName(
+					sourceTableName);
+				String normalizedTargetTableName = dbInspector.normalizeName(
+					targetTableName);
+
+				if (!dbInspector.hasTable(normalizedSourceTableName) ||
+					!dbInspector.hasTable(normalizedTargetTableName)) {
+
+					return;
+				}
+
+				List<Long> orphanIds = new ArrayList<>();
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select distinct ", sourceColumnName, " from ",
+								normalizedSourceTableName, " where ",
+								sourceColumnName, " != 0 and ", sourceColumnName,
+								" is not null and ", sourceColumnName,
+								" not in (select ", targetColumnName, " from ",
+								normalizedTargetTableName, ")"));
+					 ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					while (resultSet.next()) {
+						orphanIds.add(resultSet.getLong(1));
+					}
+				}
+
+				if (orphanIds.isEmpty()) {
+					return;
+				}
+
+				for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+					int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+					List<String> batchStrings = new ArrayList<>(end - i);
+
+					for (int j = i; j < end; j++) {
+						batchStrings.add(String.valueOf(orphanIds.get(j)));
+					}
+
+					try (PreparedStatement preparedStatement =
+							connection.prepareStatement(
+								StringBundler.concat(
+									"delete from ", normalizedSourceTableName,
+									" where ", sourceColumnName, " in (",
+									String.join(
+										StringPool.COMMA_AND_SPACE, batchStrings),
+									")"))) {
+
+						int deleted = preparedStatement.executeUpdate();
+
+						if (deleted > 0) {
+							DataCleanupLoggingUtil.logDelete(
+								_log, deleted, normalizedSourceTableName,
+								StringBundler.concat(
+									sourceColumnName, " was not found in ",
+									targetColumnName, " from table ",
+									normalizedTargetTableName));
+						}
+					}
+				}
+			}
+
+		};
 	}
 
 	private DataCleanupPreupgradeProcess
@@ -229,6 +309,8 @@ public class DLFileEntryDataCleanupPreupgradeProcess
 				new String[] {"fileEntryId", "fileVersionId"},
 				"DLFileVersion"));
 	}
+
+	private static final int _BATCH_SIZE = 1000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLFileEntryDataCleanupPreupgradeProcess.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -7,11 +7,14 @@ package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.portal.db.index.PrimaryKeyUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LoggingTimer;
@@ -20,8 +23,14 @@ import com.liferay.portal.upgrade.PortalUpgradeProcess;
 
 import java.sql.Connection;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * @author Luis Ortiz
@@ -40,29 +49,85 @@ public class DataCleanupPreupgradeProcessSuite {
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses =
-				getSortedDataCleanupPreupgradeProcesses();
+			DBInspector.beginSchemaSnapshot();
 
-			for (DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess :
-					dataCleanupPreupgradeProcesses) {
+			try {
+				List<List<DataCleanupPreupgradeProcess>> waves =
+					getWavedDataCleanupPreupgradeProcesses();
 
-				Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
+				for (List<DataCleanupPreupgradeProcess> wave : waves) {
+					if (wave.size() == 1) {
+						DataCleanupPreupgradeProcess process = wave.get(0);
 
-				if (ArrayUtil.contains(
-						PropsValues.
-							UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
-						clazz.getName())) {
+						_runProcess(process);
 
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							"Skipping blacklisted data cleanup process: " +
-								clazz.getName());
+						continue;
 					}
 
-					continue;
-				}
+					ExecutorService executorService =
+						Executors.newFixedThreadPool(wave.size());
 
-				dataCleanupPreupgradeProcess.upgrade();
+					try {
+						List<Future<Void>> futures = new ArrayList<>();
+
+						for (DataCleanupPreupgradeProcess process : wave) {
+							Future<Void> future = executorService.submit(
+								(Callable<Void>)() -> {
+									_runProcess(process);
+
+									return null;
+								});
+
+							futures.add(future);
+						}
+
+						List<Exception> exceptions = new ArrayList<>();
+
+						for (Future<Void> future : futures) {
+							try {
+								future.get();
+							}
+							catch (ExecutionException executionException) {
+								Throwable causeThrowable =
+									executionException.getCause();
+
+								if (causeThrowable instanceof Exception) {
+									exceptions.add((Exception)causeThrowable);
+								}
+								else {
+									exceptions.add(
+										new RuntimeException(causeThrowable));
+								}
+							}
+							catch (InterruptedException interruptedException) {
+								Thread currentThread = Thread.currentThread();
+
+								currentThread.interrupt();
+
+								exceptions.add(
+									new RuntimeException(interruptedException));
+							}
+						}
+
+						if (!exceptions.isEmpty()) {
+							Exception exception = exceptions.get(0);
+
+							for (int i = 1; i < exceptions.size(); i++) {
+								exception.addSuppressed(exceptions.get(i));
+							}
+
+							throw exception;
+						}
+					}
+					finally {
+						executorService.shutdownNow();
+					}
+				}
+			}
+			finally {
+				DBInspector.clearSchemaSnapshot();
+				DBResourceUtil.clearLiferayTableNamesCache();
+				OrphanReferencesDataCleanupUtil.clearIndexCache();
 			}
 		}
 	}
@@ -72,6 +137,14 @@ public class DataCleanupPreupgradeProcessSuite {
 
 		return DataCleanupPreupgradeProcess.
 			getSortedDataCleanupPreupgradeProcesses(
+				_dataCleanupPreupgradeProcessesMap);
+	}
+
+	public List<List<DataCleanupPreupgradeProcess>>
+		getWavedDataCleanupPreupgradeProcesses() {
+
+		return DataCleanupPreupgradeProcess.
+			getWavedDataCleanupPreupgradeProcesses(
 				_dataCleanupPreupgradeProcessesMap);
 	}
 
@@ -157,6 +230,16 @@ public class DataCleanupPreupgradeProcessSuite {
 				DataCleanupPreupgradeProcess.dependsOn(
 					userDataCleanupPreupgradeProcess)
 			).put(
+				dlFileEntryDataCleanupPreupgradeProcess,
+				DataCleanupPreupgradeProcess.dependsOn(
+					databaseTableAndColumnCaseDataCleanupPreupgradeProcess,
+					groupDataCleanupPreupgradeProcess)
+			).put(
+				journalDataCleanupPreupgradeProcess,
+				DataCleanupPreupgradeProcess.dependsOn(
+					databaseTableAndColumnCaseDataCleanupPreupgradeProcess,
+					ddmDataCleanupPreupgradeProcess)
+			).put(
 				new CounterDataCleanupPreupgradeProcess(),
 				DataCleanupPreupgradeProcess.dependsOn(
 					analyticsMessageDataCleanupPreupgradeProcess,
@@ -168,9 +251,9 @@ public class DataCleanupPreupgradeProcessSuite {
 					ddmStorageLinkDataCleanupPreupgradeProcess,
 					dlFileEntryDataCleanupPreupgradeProcess,
 					groupDataCleanupPreupgradeProcess,
+					illegalCharactersContentDataCleanupPreupgradeProcess,
 					journalDataCleanupPreupgradeProcess,
 					layoutDataCleanupPreupgradeProcess,
-					illegalCharactersContentDataCleanupPreupgradeProcess,
 					portalPreferencesDataCleanupPreupgradeProcess,
 					portletPreferencesDataCleanupPreupgradeProcess,
 					quartzJobDetailsDataCleanupPreupgradeProcess,
@@ -194,22 +277,12 @@ public class DataCleanupPreupgradeProcessSuite {
 					dlFileEntryDataCleanupPreupgradeProcess,
 					journalDataCleanupPreupgradeProcess)
 			).put(
-				dlFileEntryDataCleanupPreupgradeProcess,
-				DataCleanupPreupgradeProcess.dependsOn(
-					databaseTableAndColumnCaseDataCleanupPreupgradeProcess,
-					groupDataCleanupPreupgradeProcess)
-			).put(
 				groupDataCleanupPreupgradeProcess,
 				DataCleanupPreupgradeProcess.dependsOn(
 					databaseTableAndColumnCaseDataCleanupPreupgradeProcess,
 					userDataCleanupPreupgradeProcess)
 			).put(
 				illegalCharactersContentDataCleanupPreupgradeProcess,
-				DataCleanupPreupgradeProcess.dependsOn(
-					databaseTableAndColumnCaseDataCleanupPreupgradeProcess,
-					ddmDataCleanupPreupgradeProcess)
-			).put(
-				journalDataCleanupPreupgradeProcess,
 				DataCleanupPreupgradeProcess.dependsOn(
 					databaseTableAndColumnCaseDataCleanupPreupgradeProcess,
 					ddmDataCleanupPreupgradeProcess)
@@ -245,9 +318,9 @@ public class DataCleanupPreupgradeProcessSuite {
 					ddmStorageLinkDataCleanupPreupgradeProcess,
 					dlFileEntryDataCleanupPreupgradeProcess,
 					groupDataCleanupPreupgradeProcess,
+					illegalCharactersContentDataCleanupPreupgradeProcess,
 					journalDataCleanupPreupgradeProcess,
 					layoutDataCleanupPreupgradeProcess,
-					illegalCharactersContentDataCleanupPreupgradeProcess,
 					portalPreferencesDataCleanupPreupgradeProcess,
 					portletPreferencesDataCleanupPreupgradeProcess,
 					quartzJobDetailsDataCleanupPreupgradeProcess,
@@ -269,6 +342,36 @@ public class DataCleanupPreupgradeProcessSuite {
 					companyDataCleanupPreupgradeProcess,
 					databaseTableAndColumnCaseDataCleanupPreupgradeProcess)
 			).build();
+	}
+
+	private void _runProcess(
+			DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess)
+		throws Exception {
+
+		Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
+
+		if (ArrayUtil.contains(
+				PropsValues.UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
+				clazz.getName())) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Skipping blacklisted data cleanup process: " +
+						clazz.getName());
+			}
+
+			return;
+		}
+
+		String processName = clazz.getSimpleName();
+
+		if (processName.isEmpty()) {
+			processName = clazz.getName();
+		}
+
+		try (LoggingTimer processLoggingTimer = new LoggingTimer(processName)) {
+			dataCleanupPreupgradeProcess.upgrade();
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
@@ -23,6 +23,8 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -36,6 +38,16 @@ public class DataCleanupPreupgradeProcessUtil {
 			Connection connection, DBInspector dbInspector, String tableName)
 		throws Exception {
 
+		String primaryKeyColumnName = _primaryKeyColumnNameCache.get(tableName);
+
+		if (primaryKeyColumnName != null) {
+			if (primaryKeyColumnName == _NOT_FOUND) {
+				return null;
+			}
+
+			return primaryKeyColumnName;
+		}
+
 		DB db = DBManagerUtil.getDB();
 
 		List<String> primaryKeyColumnNames = new ArrayList<>(
@@ -45,15 +57,43 @@ public class DataCleanupPreupgradeProcessUtil {
 			dbInspector.normalizeName("ctCollectionId"));
 
 		if (primaryKeyColumnNames.size() != 1) {
+			_primaryKeyColumnNameCache.putIfAbsent(tableName, _NOT_FOUND);
+
 			return null;
 		}
 
-		return primaryKeyColumnNames.get(0);
+		primaryKeyColumnName = primaryKeyColumnNames.get(0);
+
+		_primaryKeyColumnNameCache.putIfAbsent(tableName, primaryKeyColumnName);
+
+		return primaryKeyColumnName;
 	}
 
 	public static String getTableName(
 			Connection connection, DBInspector dbInspector,
 			String fullyQualifiedName)
+		throws Exception {
+
+		String tableName = _tableNameCache.get(fullyQualifiedName);
+
+		if (tableName != null) {
+			if (tableName == _NOT_FOUND) {
+				return null;
+			}
+
+			return tableName;
+		}
+
+		tableName = _computeTableName(connection, fullyQualifiedName);
+
+		_tableNameCache.putIfAbsent(
+			fullyQualifiedName, (tableName != null) ? tableName : _NOT_FOUND);
+
+		return tableName;
+	}
+
+	private static String _computeTableName(
+			Connection connection, String fullyQualifiedName)
 		throws Exception {
 
 		if (StringUtil.startsWith(
@@ -86,15 +126,15 @@ public class DataCleanupPreupgradeProcessUtil {
 				ImplementationClassName implementationClassName =
 					clazz.getAnnotation(ImplementationClassName.class);
 
-				if (implementationClassName == null) {
-					return null;
+				if (implementationClassName != null) {
+					clazz = bundle.loadClass(implementationClassName.value());
+
+					Field field = clazz.getField("TABLE_NAME");
+
+					return (String)field.get(null);
 				}
 
-				clazz = bundle.loadClass(implementationClassName.value());
-
-				Field field = clazz.getField("TABLE_NAME");
-
-				return (String)field.get(null);
+				return null;
 			}
 			catch (ClassNotFoundException classNotFoundException) {
 				if (_log.isDebugEnabled()) {
@@ -106,7 +146,14 @@ public class DataCleanupPreupgradeProcessUtil {
 		return null;
 	}
 
+	private static final String _NOT_FOUND = new String("");
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DataCleanupPreupgradeProcessUtil.class);
+
+	private static final Map<String, String> _primaryKeyColumnNameCache =
+		new ConcurrentHashMap<>();
+	private static final Map<String, String> _tableNameCache =
+		new ConcurrentHashMap<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
@@ -7,7 +7,8 @@ package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
-import com.liferay.portal.kernel.upgrade.data.cleanup.FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess;
+import com.liferay.portal.kernel.upgrade.data.cleanup.MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess;
+import com.liferay.portal.kernel.upgrade.data.cleanup.MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess.FilterConfig;
 import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
 
 /**
@@ -19,21 +20,21 @@ public class JournalDataCleanupPreupgradeProcess
 	@Override
 	protected void doUpgrade() throws Exception {
 		upgrade(
-			new FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess(
-				StringBundler.concat(
-					"[$SOURCE_TABLE_ALIAS$].classNameId = (select classNameId ",
-					"from ClassName_ where value = 'com.liferay.journal.model.",
-					"JournalArticle')"),
-				new String[] {"classNameId"}, "classPK",
-				new String[] {"resourcePrimKey", "id_"}, "JournalArticle"));
-		upgrade(
-			new FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess(
-				StringBundler.concat(
-					"[$SOURCE_TABLE_ALIAS$].classNameId = (select classNameId ",
-					"from ClassName_ where value = 'com.liferay.journal.model.",
-					"JournalFeed')"),
-				new String[] {"classNameId"}, "classPK", new String[] {"id_"},
-				"JournalFeed"));
+			new MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess(
+				new FilterConfig(
+					StringBundler.concat(
+						"[$SOURCE_TABLE_ALIAS$].classNameId = (select classNameId ",
+						"from ClassName_ where value = 'com.liferay.journal.",
+						"model.JournalArticle')"),
+					new String[] {"classNameId"}, "classPK",
+					new String[] {"resourcePrimKey", "id_"}, "JournalArticle"),
+				new FilterConfig(
+					StringBundler.concat(
+						"[$SOURCE_TABLE_ALIAS$].classNameId = (select classNameId ",
+						"from ClassName_ where value = 'com.liferay.journal.",
+						"model.JournalFeed')"),
+					new String[] {"classNameId"}, "classPK",
+					new String[] {"id_"}, "JournalFeed")));
 		upgrade(
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null, null, "articlePK", "JournalArticleLocalization", "id_",

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/PortletPreferencesDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/PortletPreferencesDataCleanupPreupgradeProcess.java
@@ -5,8 +5,18 @@
 
 package com.liferay.portal.upgrade.data.cleanup;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
-import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Luis Ortiz
@@ -16,10 +26,60 @@ public class PortletPreferencesDataCleanupPreupgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		upgrade(
-			new TableOrphanReferencesDataCleanupPreupgradeProcess(
-				null, null, "portletPreferencesId", "PortletPreferenceValue",
-				"portletPreferencesId", "PortletPreferences"));
+		List<Long> orphanPortletPreferencesIds = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select distinct portletPreferencesId " +
+					"from PortletPreferenceValue " +
+						"where portletPreferencesId is not null " +
+							"and portletPreferencesId != 0 " +
+								"and portletPreferencesId not in (" +
+									"select portletPreferencesId from PortletPreferences)");
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				orphanPortletPreferencesIds.add(resultSet.getLong(1));
+			}
+		}
+
+		if (orphanPortletPreferencesIds.isEmpty()) {
+			return;
+		}
+
+		for (int i = 0; i < orphanPortletPreferencesIds.size();
+			 i += _BATCH_SIZE) {
+
+			int end = Math.min(
+				i + _BATCH_SIZE, orphanPortletPreferencesIds.size());
+
+			List<String> batchStrings = new ArrayList<>(end - i);
+
+			for (int j = i; j < end; j++) {
+				batchStrings.add(
+					String.valueOf(orphanPortletPreferencesIds.get(j)));
+			}
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"delete from PortletPreferenceValue ",
+							"where portletPreferencesId in (",
+							String.join(
+								StringPool.COMMA_AND_SPACE, batchStrings),
+							")"))) {
+
+				int count = preparedStatement.executeUpdate();
+
+				DataCleanupLoggingUtil.logDelete(
+					_log, count, "PortletPreferenceValue",
+					"portletPreferencesId was not found in PortletPreferences");
+			}
+		}
 	}
+
+	private static final int _BATCH_SIZE = 1000;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortletPreferencesDataCleanupPreupgradeProcess.class);
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -19,6 +19,10 @@ import com.liferay.portal.security.permission.ResourceActionsImpl;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -51,12 +55,16 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 				ResourceActionsImpl resourceActionsImpl =
 					new ResourceActionsImpl();
 
+				String compositeModelNameSeparatorString =
+					resourceActionsImpl.getCompositeModelNameSeparator();
+
+				Map<String, List<String>> tableNames = new HashMap<>();
+
 				while (resultSet.next()) {
 					String name = resultSet.getString("name");
 
 					String[] classNames = StringUtil.split(
-						name,
-						resourceActionsImpl.getCompositeModelNameSeparator());
+						name, compositeModelNameSeparatorString);
 
 					String tableName = null;
 
@@ -96,11 +104,26 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 					if (!dbInspector.hasTable(tableName)) {
 						if (_log.isWarnEnabled()) {
-							_log.warn("Table " + tableName + " does not exist");
+							_log.warn(
+								"Table \"" + tableName + "\" does not exist");
 						}
 
 						continue;
 					}
+
+					List<String> names = tableNames.computeIfAbsent(
+						tableName, key -> new ArrayList<>());
+
+					names.add(name);
+				}
+
+				List<DataCleanupPreupgradeProcess> tableCleanupProcesses =
+					new ArrayList<>();
+
+				for (Map.Entry<String, List<String>> entry :
+						tableNames.entrySet()) {
+
+					String tableName = entry.getKey();
 
 					String primaryKeyColumnName = "resourcePrimKey";
 
@@ -116,22 +139,56 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 					if (primaryKeyColumnName == null) {
 						if (_log.isWarnEnabled()) {
 							_log.warn(
-								"Skipping table " + tableName +
-									" because it does not have a primary key");
+								"Table \"" + tableName +
+									"\" has no primary key column");
 						}
 
 						continue;
 					}
 
-					upgrade(
+					List<String> names = entry.getValue();
+
+					String additionalWhereClause = null;
+
+					if (names.size() == 1) {
+						additionalWhereClause = StringBundler.concat(
+							"[$SOURCE_TABLE_ALIAS$].scope = ",
+							ResourceConstants.SCOPE_INDIVIDUAL,
+							" and [$SOURCE_TABLE_ALIAS$].name = '",
+							names.get(0), "'");
+					}
+					else {
+						StringBundler joinedNamesSB = new StringBundler(
+							(names.size() * 2) - 1);
+
+						for (int i = 0; i < names.size(); i++) {
+							if (i > 0) {
+								joinedNamesSB.append(", ");
+							}
+
+							joinedNamesSB.append("'");
+							joinedNamesSB.append(names.get(i));
+							joinedNamesSB.append("'");
+						}
+
+						additionalWhereClause = StringBundler.concat(
+							"[$SOURCE_TABLE_ALIAS$].scope = ",
+							ResourceConstants.SCOPE_INDIVIDUAL,
+							" and [$SOURCE_TABLE_ALIAS$].name in (",
+							joinedNamesSB, ")");
+					}
+
+					tableCleanupProcesses.add(
 						new TableOrphanReferencesDataCleanupPreupgradeProcess(
-							null,
-							StringBundler.concat(
-								"[$SOURCE_TABLE_ALIAS$].scope = ",
-								ResourceConstants.SCOPE_INDIVIDUAL, " and ",
-								"[$SOURCE_TABLE_ALIAS$].name = '", name, "'"),
-							"primKeyId", "ResourcePermission",
-							primaryKeyColumnName, tableName));
+							null, additionalWhereClause, "primKeyId",
+							"ResourcePermission", primaryKeyColumnName,
+							tableName));
+				}
+
+				for (DataCleanupPreupgradeProcess tableCleanupProcess :
+						tableCleanupProcesses) {
+
+					upgrade(tableCleanupProcess);
 				}
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -6,13 +6,14 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
-import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.security.permission.ResourceActionsImpl;
 
@@ -44,6 +45,8 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
+		Map<String, List<String>> tableNames = new HashMap<>();
+
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select distinct name from ResourcePermission where name " +
 					"like 'com.liferay.%' and primKeyId != 0 and primKeyId " +
@@ -57,8 +60,6 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 				String compositeModelNameSeparatorString =
 					resourceActionsImpl.getCompositeModelNameSeparator();
-
-				Map<String, List<String>> tableNames = new HashMap<>();
 
 				while (resultSet.next()) {
 					String name = resultSet.getString("name");
@@ -116,83 +117,115 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 					names.add(name);
 				}
+			}
+		}
 
-				List<DataCleanupPreupgradeProcess> tableCleanupProcesses =
-					new ArrayList<>();
+		for (Map.Entry<String, List<String>> entry :
+				tableNames.entrySet()) {
 
-				for (Map.Entry<String, List<String>> entry :
-						tableNames.entrySet()) {
+			String tableName = entry.getKey();
 
-					String tableName = entry.getKey();
+			String primaryKeyColumnName = "resourcePrimKey";
 
-					String primaryKeyColumnName = "resourcePrimKey";
+			if (!dbInspector.hasColumn(tableName, primaryKeyColumnName)) {
+				primaryKeyColumnName =
+					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
+						connection, dbInspector, tableName);
+			}
 
-					if (!dbInspector.hasColumn(
-							tableName, primaryKeyColumnName)) {
-
-						primaryKeyColumnName =
-							DataCleanupPreupgradeProcessUtil.
-								getPrimaryKeyColumnName(
-									connection, dbInspector, tableName);
-					}
-
-					if (primaryKeyColumnName == null) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(
-								"Table \"" + tableName +
-									"\" has no primary key column");
-						}
-
-						continue;
-					}
-
-					List<String> names = entry.getValue();
-
-					String additionalWhereClause = null;
-
-					if (names.size() == 1) {
-						additionalWhereClause = StringBundler.concat(
-							"[$SOURCE_TABLE_ALIAS$].scope = ",
-							ResourceConstants.SCOPE_INDIVIDUAL,
-							" and [$SOURCE_TABLE_ALIAS$].name = '",
-							names.get(0), "'");
-					}
-					else {
-						StringBundler joinedNamesSB = new StringBundler(
-							(names.size() * 2) - 1);
-
-						for (int i = 0; i < names.size(); i++) {
-							if (i > 0) {
-								joinedNamesSB.append(", ");
-							}
-
-							joinedNamesSB.append("'");
-							joinedNamesSB.append(names.get(i));
-							joinedNamesSB.append("'");
-						}
-
-						additionalWhereClause = StringBundler.concat(
-							"[$SOURCE_TABLE_ALIAS$].scope = ",
-							ResourceConstants.SCOPE_INDIVIDUAL,
-							" and [$SOURCE_TABLE_ALIAS$].name in (",
-							joinedNamesSB, ")");
-					}
-
-					tableCleanupProcesses.add(
-						new TableOrphanReferencesDataCleanupPreupgradeProcess(
-							null, additionalWhereClause, "primKeyId",
-							"ResourcePermission", primaryKeyColumnName,
-							tableName));
+			if (primaryKeyColumnName == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Table \"" + tableName +
+							"\" has no primary key column");
 				}
 
-				for (DataCleanupPreupgradeProcess tableCleanupProcess :
-						tableCleanupProcesses) {
+				continue;
+			}
 
-					upgrade(tableCleanupProcess);
+			List<String> names = entry.getValue();
+
+			String namesClause;
+
+			if (names.size() == 1) {
+				namesClause = StringBundler.concat(
+					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
+					" and name = '", names.get(0), "'");
+			}
+			else {
+				StringBundler joinedNamesSB = new StringBundler(
+					(names.size() * 2) - 1);
+
+				for (int i = 0; i < names.size(); i++) {
+					if (i > 0) {
+						joinedNamesSB.append(", ");
+					}
+
+					joinedNamesSB.append("'");
+					joinedNamesSB.append(names.get(i));
+					joinedNamesSB.append("'");
+				}
+
+				namesClause = StringBundler.concat(
+					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
+					" and name in (", joinedNamesSB, ")");
+			}
+
+			List<Long> orphanIds = new ArrayList<>();
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"select distinct primKeyId from ResourcePermission",
+							" where primKeyId != 0 and primKeyId is not null",
+							" and ", namesClause, " and primKeyId not in",
+							" (select ", primaryKeyColumnName, " from ",
+							tableName, ")"));
+				ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				while (resultSet.next()) {
+					orphanIds.add(resultSet.getLong(1));
+				}
+			}
+
+			if (orphanIds.isEmpty()) {
+				continue;
+			}
+
+			for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+				int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+				List<String> batchStrings = new ArrayList<>(end - i);
+
+				for (int j = i; j < end; j++) {
+					batchStrings.add(String.valueOf(orphanIds.get(j)));
+				}
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"delete from ResourcePermission where",
+								" primKeyId in (",
+								String.join(
+									StringPool.COMMA_AND_SPACE, batchStrings),
+								") and ", namesClause))) {
+
+					int deleted = preparedStatement.executeUpdate();
+
+					if (deleted > 0) {
+						DataCleanupLoggingUtil.logDelete(
+							_log, deleted, "ResourcePermission",
+							StringBundler.concat(
+								"primKeyId was not found in ",
+								primaryKeyColumnName, " from table ",
+								tableName));
+					}
 				}
 			}
 		}
 	}
+
+	private static final int _BATCH_SIZE = 1000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ResourcePermissionDataCleanupPreupgradeProcess.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/UserDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/UserDataCleanupPreupgradeProcess.java
@@ -6,6 +6,8 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
@@ -22,9 +24,11 @@ public class UserDataCleanupPreupgradeProcess
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		upgrade(
+		_upgradeWithTiming(
+			"UserAllTables",
 			new UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess());
-		upgrade(
+		_upgradeWithTiming(
+			"FilterableAllTables",
 			new FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess(
 				StringBundler.concat(
 					"[$SOURCE_TABLE_ALIAS$].classNameId = (select classNameId ",
@@ -32,19 +36,22 @@ public class UserDataCleanupPreupgradeProcess
 					"')"),
 				new String[] {"classNameId"}, "classPK",
 				new String[] {"userId"}, "User_"));
-		upgrade(
+		_upgradeWithTiming(
+			"PortalPreferences",
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
 				"[$SOURCE_TABLE_ALIAS$].ownerType = " +
 					PortletKeys.PREFS_OWNER_TYPE_USER,
 				"ownerId", "PortalPreferences", "userId", "User_"));
-		upgrade(
+		_upgradeWithTiming(
+			"PortletPreferences",
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
 				"[$SOURCE_TABLE_ALIAS$].ownerType = " +
 					PortletKeys.PREFS_OWNER_TYPE_USER,
 				"ownerId", "PortletPreferences", "userId", "User_"));
-		upgrade(
+		_upgradeWithTiming(
+			"ResourcePermission",
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
 				StringBundler.concat(
@@ -54,5 +61,25 @@ public class UserDataCleanupPreupgradeProcess
 					"'"),
 				"primKeyId", "ResourcePermission", "userId", "User_"));
 	}
+
+	private void _upgradeWithTiming(
+			String label, DataCleanupPreupgradeProcess process)
+		throws Exception {
+
+		long start = System.currentTimeMillis();
+
+		upgrade(process);
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"UserDataCleanupPreupgradeProcess/", label,
+					" completed in ", System.currentTimeMillis() - start,
+					" ms"));
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UserDataCleanupPreupgradeProcess.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,6 +35,17 @@ import java.util.regex.Pattern;
  * @author Adolfo Pérez
  */
 public class DBInspector {
+
+	public static void beginSchemaSnapshot() {
+		_schemaSnapshotEnabled = true;
+	}
+
+	public static void clearSchemaSnapshot() {
+		_columnExistsCache.clear();
+		_columnNumericCache.clear();
+		_tableNamesCache.clear();
+		_schemaSnapshotEnabled = false;
+	}
 
 	public DBInspector(Connection connection) {
 		_connection = connection;
@@ -63,6 +75,22 @@ public class DBInspector {
 	public List<String> getTableNames(String tableNamePattern)
 		throws SQLException {
 
+		if (_schemaSnapshotEnabled && (tableNamePattern == null)) {
+			String catalog = getCatalog();
+
+			Set<String> tableNames = _tableNamesCache.get(catalog);
+
+			if (tableNames != null) {
+				return new ArrayList<>(tableNames);
+			}
+
+			List<String> names = _getNames(null, "TABLE");
+
+			_tableNamesCache.putIfAbsent(catalog, new HashSet<>(names));
+
+			return names;
+		}
+
 		return _getNames(tableNamePattern, "TABLE");
 	}
 
@@ -77,6 +105,40 @@ public class DBInspector {
 
 		if ((columnName == null) || (tableName == null)) {
 			return false;
+		}
+
+		if (_schemaSnapshotEnabled) {
+			DatabaseMetaData databaseMetaData = _connection.getMetaData();
+
+			String normalizedColumnName = normalizeName(
+				columnName, databaseMetaData);
+			String normalizedTableName = normalizeName(
+				tableName, databaseMetaData);
+
+			String cacheKey = StringBundler.concat(
+				getCatalog(), ".", normalizedTableName, ".",
+				normalizedColumnName);
+
+			Boolean cached = _columnExistsCache.get(cacheKey);
+
+			if (cached != null) {
+				return cached;
+			}
+
+			boolean exists = false;
+
+			try (ResultSet resultSet = _getColumnsResultSet(
+					normalizedTableName, normalizedColumnName)) {
+
+				exists = resultSet.next();
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
+
+			_columnExistsCache.put(cacheKey, exists);
+
+			return exists;
 		}
 
 		try (ResultSet resultSet = _getColumnsResultSet(
@@ -229,6 +291,14 @@ public class DBInspector {
 	}
 
 	public boolean hasTable(String tableName) throws Exception {
+		if (_schemaSnapshotEnabled) {
+			Set<String> tableNames = _tableNamesCache.get(getCatalog());
+
+			if (tableNames != null) {
+				return tableNames.contains(normalizeName(tableName));
+			}
+		}
+
 		return _hasElement(tableName, "TABLE");
 	}
 
@@ -284,6 +354,39 @@ public class DBInspector {
 			return false;
 		}
 
+		if (_schemaSnapshotEnabled) {
+			DatabaseMetaData databaseMetaData = _connection.getMetaData();
+
+			String normalizedColumnName = normalizeName(
+				columnName, databaseMetaData);
+			String normalizedTableName = normalizeName(
+				tableName, databaseMetaData);
+
+			String cacheKey = StringBundler.concat(
+				getCatalog(), ".", normalizedTableName, ".",
+				normalizedColumnName);
+
+			Boolean cached = _columnNumericCache.get(cacheKey);
+
+			if (cached != null) {
+				return cached;
+			}
+
+			boolean numeric = false;
+
+			try (ResultSet resultSet = _getColumnsResultSet(
+					normalizedTableName, normalizedColumnName)) {
+
+				if (resultSet.next()) {
+					numeric = _isNumericType(resultSet.getInt("DATA_TYPE"));
+				}
+			}
+
+			_columnNumericCache.put(cacheKey, numeric);
+
+			return numeric;
+		}
+
 		try (ResultSet resultSet = _getColumnsResultSet(
 				tableName, columnName)) {
 
@@ -291,19 +394,7 @@ public class DBInspector {
 				return false;
 			}
 
-			int columnType = resultSet.getInt("DATA_TYPE");
-
-			if ((columnType == Types.BIGINT) || (columnType == Types.DECIMAL) ||
-				(columnType == Types.DOUBLE) || (columnType == Types.FLOAT) ||
-				(columnType == Types.INTEGER) ||
-				(columnType == Types.NUMERIC) || (columnType == Types.REAL) ||
-				(columnType == Types.SMALLINT) ||
-				(columnType == Types.TINYINT)) {
-
-				return true;
-			}
-
-			return false;
+			return _isNumericType(resultSet.getInt("DATA_TYPE"));
 		}
 	}
 
@@ -486,10 +577,27 @@ public class DBInspector {
 		return !typeName.endsWith("not null");
 	}
 
+	private boolean _isNumericType(int columnType) {
+		if ((columnType == Types.BIGINT) || (columnType == Types.DECIMAL) ||
+			(columnType == Types.DOUBLE) || (columnType == Types.FLOAT) ||
+			(columnType == Types.INTEGER) || (columnType == Types.NUMERIC) ||
+			(columnType == Types.REAL) || (columnType == Types.SMALLINT) ||
+			(columnType == Types.TINYINT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(DBInspector.class);
 
 	private static final Pattern _columnDefaultClausePattern = Pattern.compile(
 		".*DEFAULT ((?:'[^']+')|(?:\\S+)) NOT NULL", Pattern.CASE_INSENSITIVE);
+	private static final ConcurrentHashMap<String, Boolean> _columnExistsCache =
+		new ConcurrentHashMap<>();
+	private static final ConcurrentHashMap<String, Boolean>
+		_columnNumericCache = new ConcurrentHashMap<>();
 	private static final Pattern _columnSizePattern = Pattern.compile(
 		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnTypePattern = Pattern.compile(
@@ -499,6 +607,9 @@ public class DBInspector {
 			"company", "release_", "servicecomponent", "virtualhost"));
 	private static final Set<String> _partitionedControlTableNames =
 		new HashSet<>(Arrays.asList("classname_", "counter", "resourceaction"));
+	private static volatile boolean _schemaSnapshotEnabled;
+	private static final ConcurrentHashMap<String, Set<String>>
+		_tableNamesCache = new ConcurrentHashMap<>();
 
 	private final Connection _connection;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -49,20 +49,36 @@ import org.osgi.framework.BundleContext;
  */
 public class DBResourceUtil {
 
+	public static void clearLiferayTableNamesCache() {
+		_liferayTableNames = null;
+	}
+
 	public static Set<String> getLiferayTableNames(Connection connection)
 		throws Exception {
 
-		Set<String> liferayTableNames = new TreeSet<>(
-			String.CASE_INSENSITIVE_ORDER);
+		if (_liferayTableNames != null) {
+			return _liferayTableNames;
+		}
 
-		liferayTableNames.addAll(getModuleTableNames());
-		liferayTableNames.addAll(getPortalTableNames());
-		liferayTableNames.addAll(
-			getServiceComponentModuleTableNames(connection));
-		liferayTableNames.addAll(
-			getServiceComponentPortalTableNames(connection));
+		synchronized (DBResourceUtil.class) {
+			if (_liferayTableNames != null) {
+				return _liferayTableNames;
+			}
 
-		return liferayTableNames;
+			Set<String> liferayTableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			liferayTableNames.addAll(getModuleTableNames());
+			liferayTableNames.addAll(getPortalTableNames());
+			liferayTableNames.addAll(
+				getServiceComponentModuleTableNames(connection));
+			liferayTableNames.addAll(
+				getServiceComponentPortalTableNames(connection));
+
+			_liferayTableNames = liferayTableNames;
+
+			return _liferayTableNames;
+		}
 	}
 
 	public static String getModuleIndexesSQL(Bundle bundle) {
@@ -74,29 +90,42 @@ public class DBResourceUtil {
 	}
 
 	public static Set<String> getModuleTableNames() {
-		Set<String> tableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (!symbolicName.startsWith("com.liferay") ||
-				!BundleUtil.isLiferayServiceBundle(bundle)) {
-
-				continue;
-			}
-
-			String tableSQL = getModuleTablesSQL(bundle);
-
-			if (tableSQL == null) {
-				continue;
-			}
-
-			tableNames.addAll(parseCreateTableSQL(tableSQL));
+		if (_moduleTableNames != null) {
+			return _moduleTableNames;
 		}
 
-		return tableNames;
+		synchronized (DBResourceUtil.class) {
+			if (_moduleTableNames != null) {
+				return _moduleTableNames;
+			}
+
+			Set<String> tableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+			for (Bundle bundle : bundleContext.getBundles()) {
+				String symbolicName = bundle.getSymbolicName();
+
+				if (!symbolicName.startsWith("com.liferay") ||
+					!BundleUtil.isLiferayServiceBundle(bundle)) {
+
+					continue;
+				}
+
+				String tableSQL = getModuleTablesSQL(bundle);
+
+				if (tableSQL == null) {
+					continue;
+				}
+
+				tableNames.addAll(parseCreateTableSQL(tableSQL));
+			}
+
+			_moduleTableNames = tableNames;
+
+			return _moduleTableNames;
+		}
 	}
 
 	public static Map<String, String[]> getModuleTablesPrimaryKeyColumnNames(
@@ -160,9 +189,15 @@ public class DBResourceUtil {
 			return _portalTableNames;
 		}
 
-		_portalTableNames = parseCreateTableSQL(getPortalTablesSQL());
+		synchronized (DBResourceUtil.class) {
+			if (_portalTableNames != null) {
+				return _portalTableNames;
+			}
 
-		return _portalTableNames;
+			_portalTableNames = parseCreateTableSQL(getPortalTablesSQL());
+
+			return _portalTableNames;
+		}
 	}
 
 	public static Map<String, String[]> getPortalTablesPrimaryKeyColumnNames() {
@@ -324,7 +359,7 @@ public class DBResourceUtil {
 				continue;
 			}
 
-			if (line.isEmpty() || line.startsWith(")") ||
+			if ((tableName == null) || line.isEmpty() || line.startsWith(")") ||
 				line.startsWith(";") || line.startsWith("<") ||
 				line.startsWith("]]>") || line.startsWith("create ") ||
 				line.startsWith("primary key")) {
@@ -384,6 +419,8 @@ public class DBResourceUtil {
 		"create table\\s+(\\w+)\\s*\\([^;]*?(\\w+)\\s+\\w+(?:\\([^)]*\\))?" +
 			"(?:\\s+\\w+)*\\s+primary key\\b",
 		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+	private static volatile Set<String> _liferayTableNames;
+	private static volatile Set<String> _moduleTableNames;
 	private static volatile Set<String> _portalTableNames;
 	private static final DCLSingleton<ServiceTrackerList<DBResourceProvider>>
 		_serviceTrackerListDCLSingleton = new DCLSingleton<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/BaseAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/BaseAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -5,8 +5,10 @@
 
 package com.liferay.portal.kernel.upgrade.data.cleanup;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -58,7 +60,7 @@ public abstract class BaseAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 			  dbInspector.hasView(targetTableName))) {
 
 			if (_log.isDebugEnabled()) {
-				_log.debug("Table " + targetTableName + " does not exist");
+				_log.debug("Table \"" + targetTableName + "\" does not exist");
 			}
 
 			return;
@@ -97,61 +99,93 @@ public abstract class BaseAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
-		processConcurrently(
-			tableNames.toArray(new String[0]),
-			sourceTableName -> {
-				if (excludedTableNames.contains(sourceTableName) ||
-					!dbInspector.hasColumn(sourceTableName, sourceColumnName)) {
+		boolean[] numericTargetColumns = new boolean[targetColumnNames.length];
 
-					return;
-				}
+		for (int i = 0; i < targetColumnNames.length; i++) {
+			numericTargetColumns[i] = dbInspector.isNumeric(
+				targetTableName, targetColumnNames[i]);
+		}
 
-				boolean compatibleTypes = true;
+		List<SafeCloseable> safeCloseables =
+			OrphanReferencesDataCleanupUtil.addTemporaryIndexes(
+				targetColumnNames, connection, DBManagerUtil.getDB(),
+				targetTableName);
 
-				boolean numericSourceColumn = dbInspector.isNumeric(
-					sourceTableName, sourceColumnName);
+		skipTargetIndexes = true;
 
-				for (String targetColumnName : targetColumnNames) {
-					boolean numericTargetColumn = dbInspector.isNumeric(
-						targetTableName, targetColumnName);
+		try {
+			processConcurrently(
+				tableNames.toArray(new String[0]),
+				sourceTableName -> {
+					if (excludedTableNames.contains(sourceTableName) ||
+						!dbInspector.hasColumn(
+							sourceTableName, sourceColumnName) ||
+						shouldSkipSourceTable(dbInspector, sourceTableName)) {
 
-					if (numericSourceColumn != numericTargetColumn) {
-						String message = StringBundler.concat(
-							"Table ", sourceTableName, " and column ",
-							sourceColumnName,
-							" has an incompatible type with table ",
-							targetTableName, " and column ", targetColumnName);
+						return;
+					}
 
-						compatibleTypes = false;
+					boolean compatibleTypes = true;
 
-						if (!dbInspector.isObjectTable(sourceTableName) &&
-							!liferayTableNames.contains(sourceTableName)) {
+					boolean numericSourceColumn = dbInspector.isNumeric(
+						sourceTableName, sourceColumnName);
 
-							if (_log.isDebugEnabled()) {
-								_log.debug(message);
+					for (int i = 0; i < targetColumnNames.length; i++) {
+						if (numericSourceColumn != numericTargetColumns[i]) {
+							String message = StringBundler.concat(
+								"Table ", sourceTableName, " and column ",
+								sourceColumnName,
+								" has an incompatible type with table ",
+								targetTableName, " and column ",
+								targetColumnNames[i]);
+
+							compatibleTypes = false;
+
+							if (!dbInspector.isObjectTable(sourceTableName) &&
+								!liferayTableNames.contains(sourceTableName)) {
+
+								if (_log.isDebugEnabled()) {
+									_log.debug(message);
+								}
+
+								break;
+							}
+
+							if (_log.isWarnEnabled()) {
+								_log.warn(message);
 							}
 
 							break;
 						}
-
-						if (_log.isWarnEnabled()) {
-							_log.warn(message);
-						}
-
-						break;
 					}
-				}
 
-				if (!compatibleTypes) {
-					return;
-				}
+					if (!compatibleTypes) {
+						return;
+					}
 
-				cleanUp(
-					sourceColumnName, sourceTableName, targetColumnNames,
-					targetTableName);
-			},
-			null);
+					cleanUp(
+						sourceColumnName, sourceTableName, targetColumnNames,
+						targetTableName);
+				},
+				null);
+		}
+		finally {
+			skipTargetIndexes = false;
+
+			for (SafeCloseable safeCloseable : safeCloseables) {
+				safeCloseable.close();
+			}
+		}
 	}
+
+	protected boolean shouldSkipSourceTable(
+			DBInspector dbInspector, String sourceTableName)
+		throws Exception {
+
+		return false;
+	}
+
+	protected volatile boolean skipTargetIndexes;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseAllTablesOrphanReferencesDataCleanupPreupgradeProcess.class);

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcess.java
@@ -11,8 +11,10 @@ import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Luis Ortiz
@@ -66,6 +68,47 @@ public class DataCleanupPreupgradeProcess extends UpgradeProcess {
 		}
 
 		return sortedDataCleanupPreupgradeProcesses;
+	}
+
+	public static List<List<DataCleanupPreupgradeProcess>>
+		getWavedDataCleanupPreupgradeProcesses(
+			Map
+				<DataCleanupPreupgradeProcess,
+				 List<DataCleanupPreupgradeProcess>>
+					dataCleanupPreupgradeProcessesMap) {
+
+		Set<DataCleanupPreupgradeProcess> completed = new HashSet<>();
+		List<List<DataCleanupPreupgradeProcess>> waves = new ArrayList<>();
+
+		while (completed.size() != dataCleanupPreupgradeProcessesMap.size()) {
+			List<DataCleanupPreupgradeProcess> wave = new ArrayList<>();
+
+			for (Map.Entry
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>> entry :
+						dataCleanupPreupgradeProcessesMap.entrySet()) {
+
+				DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess =
+					entry.getKey();
+
+				if (completed.contains(dataCleanupPreupgradeProcess) ||
+					!completed.containsAll(entry.getValue())) {
+
+					continue;
+				}
+
+				wave.add(dataCleanupPreupgradeProcess);
+			}
+
+			if (wave.isEmpty()) {
+				throw new RuntimeException("Circular dependency");
+			}
+
+			completed.addAll(wave);
+			waves.add(wave);
+		}
+
+		return waves;
 	}
 
 	public DataCleanupPreupgradeProcess() {

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -5,7 +5,17 @@
 
 package com.liferay.portal.kernel.upgrade.data.cleanup;
 
-import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Luis Ortiz
@@ -25,9 +35,62 @@ public class DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 			String[] targetColumnNames, String targetTableName)
 		throws Exception {
 
-		OrphanReferencesDataCleanupUtil.cleanUpTable(
-			connection, null, null, sourceColumnName, sourceTableName,
-			targetColumnNames, targetTableName);
+		List<Long> orphanIds = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct ", sourceColumnName, " from ",
+					sourceTableName, " where ", sourceColumnName,
+					" != 0 and ", sourceColumnName, " is not null and ",
+					sourceColumnName, " not in (select ", targetColumnNames[0],
+					" from ", targetTableName, ")"));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				orphanIds.add(resultSet.getLong(1));
+			}
+		}
+
+		if (orphanIds.isEmpty()) {
+			return;
+		}
+
+		for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+			int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+			List<String> batchStrings = new ArrayList<>(end - i);
+
+			for (int j = i; j < end; j++) {
+				batchStrings.add(String.valueOf(orphanIds.get(j)));
+			}
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"delete from ", sourceTableName, " where ",
+							sourceColumnName, " in (",
+							String.join(
+								StringPool.COMMA_AND_SPACE, batchStrings),
+							")"))) {
+
+				int deleted = preparedStatement.executeUpdate();
+
+				if (deleted > 0) {
+					DataCleanupLoggingUtil.logDelete(
+						_log, deleted, sourceTableName,
+						StringBundler.concat(
+							sourceColumnName, " was not found in column",
+							(targetColumnNames.length > 1) ? "s " : " ",
+							String.join(", ", targetColumnNames), " from table ",
+							targetTableName));
+				}
+			}
+		}
 	}
+
+	private static final int _BATCH_SIZE = 1000;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -5,17 +5,7 @@
 
 package com.liferay.portal.kernel.upgrade.data.cleanup;
 
-import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
-
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
 
 /**
  * @author Luis Ortiz
@@ -35,62 +25,9 @@ public class DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 			String[] targetColumnNames, String targetTableName)
 		throws Exception {
 
-		List<Long> orphanIds = new ArrayList<>();
-
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"select distinct ", sourceColumnName, " from ",
-					sourceTableName, " where ", sourceColumnName,
-					" != 0 and ", sourceColumnName, " is not null and ",
-					sourceColumnName, " not in (select ", targetColumnNames[0],
-					" from ", targetTableName, ")"));
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			while (resultSet.next()) {
-				orphanIds.add(resultSet.getLong(1));
-			}
-		}
-
-		if (orphanIds.isEmpty()) {
-			return;
-		}
-
-		for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
-			int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
-
-			List<String> batchStrings = new ArrayList<>(end - i);
-
-			for (int j = i; j < end; j++) {
-				batchStrings.add(String.valueOf(orphanIds.get(j)));
-			}
-
-			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						StringBundler.concat(
-							"delete from ", sourceTableName, " where ",
-							sourceColumnName, " in (",
-							String.join(
-								StringPool.COMMA_AND_SPACE, batchStrings),
-							")"))) {
-
-				int deleted = preparedStatement.executeUpdate();
-
-				if (deleted > 0) {
-					DataCleanupLoggingUtil.logDelete(
-						_log, deleted, sourceTableName,
-						StringBundler.concat(
-							sourceColumnName, " was not found in column",
-							(targetColumnNames.length > 1) ? "s " : " ",
-							String.join(", ", targetColumnNames), " from table ",
-							targetTableName));
-				}
-			}
-		}
+		OrphanReferencesDataCleanupUtil.cleanUpTable(
+			connection, null, false, null, sourceColumnName, sourceTableName,
+			targetColumnNames, targetTableName, skipTargetIndexes);
 	}
-
-	private static final int _BATCH_SIZE = 1000;
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		DefaultAllTablesOrphanReferencesDataCleanupPreupgradeProcess.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -5,8 +5,20 @@
 
 package com.liferay.portal.kernel.upgrade.data.cleanup;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author Luis Ortiz
@@ -31,7 +43,74 @@ public class FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 			String[] targetColumnNames, String targetTableName)
 		throws Exception {
 
-		DBInspector dbInspector = new DBInspector(connection);
+		String alias = OrphanReferencesDataCleanupUtil.getSourceTableAlias();
+
+		String whereClause = OrphanReferencesDataCleanupUtil.getWhereClause(
+			connection, null, _sourceAdditionalWhereClause, sourceColumnName,
+			sourceTableName, targetColumnNames, targetTableName);
+
+		// Phase 1: find distinct orphan classPKs via LEFT JOIN anti-join
+
+		List<Long> orphanIds = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct ", alias, ".", sourceColumnName, " from ",
+					sourceTableName, " ", alias, whereClause));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				orphanIds.add(resultSet.getLong(1));
+			}
+		}
+
+		if (orphanIds.isEmpty()) {
+			return;
+		}
+
+		// Phase 2: delete orphans in batches
+
+		String resolvedAdditionalWhereClause = StringUtil.replace(
+			_sourceAdditionalWhereClause, "[$SOURCE_TABLE_ALIAS$]",
+			sourceTableName);
+
+		for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+			int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+			List<String> batchStrings = new ArrayList<>(end - i);
+
+			for (int j = i; j < end; j++) {
+				batchStrings.add(String.valueOf(orphanIds.get(j)));
+			}
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"delete from ", sourceTableName, " where ",
+							sourceColumnName, " in (",
+							String.join(
+								StringPool.COMMA_AND_SPACE, batchStrings),
+							") and ", resolvedAdditionalWhereClause))) {
+
+				int deleted = preparedStatement.executeUpdate();
+
+				if (deleted > 0) {
+					DataCleanupLoggingUtil.logDelete(
+						_log, deleted, sourceTableName,
+						StringBundler.concat(
+							sourceColumnName, " was not found in column",
+							(targetColumnNames.length > 1) ? "s " : " ",
+							String.join(", ", targetColumnNames),
+							" from table ", targetTableName));
+				}
+			}
+		}
+	}
+
+	@Override
+	protected boolean shouldSkipSourceTable(
+			DBInspector dbInspector, String sourceTableName)
+		throws Exception {
 
 		for (String sourceAdditionalColumnName :
 				_sourceAdditionalColumnNamesCheck) {
@@ -39,14 +118,17 @@ public class FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 			if (!dbInspector.hasColumn(
 					sourceTableName, sourceAdditionalColumnName)) {
 
-				return;
+				return true;
 			}
 		}
 
-		OrphanReferencesDataCleanupUtil.cleanUpTable(
-			connection, null, _sourceAdditionalWhereClause, sourceColumnName,
-			sourceTableName, targetColumnNames, targetTableName);
+		return false;
 	}
+
+	private static final int _BATCH_SIZE = 1000;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess.class);
 
 	private final String[] _sourceAdditionalColumnNamesCheck;
 	private final String _sourceAdditionalWhereClause;

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -1,0 +1,283 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade.data.cleanup;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.db.DBResourceUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Jorge Avalos
+ */
+public class
+	MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess
+		extends DataCleanupPreupgradeProcess {
+
+	public MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess(
+		FilterConfig... filterConfigs) {
+
+		_filterConfigs = filterConfigs;
+	}
+
+	public static class FilterConfig {
+
+		public FilterConfig(
+			String sourceAdditionalWhereClause,
+			String[] sourceAdditionalColumnNamesCheck, String sourceColumnName,
+			String[] targetColumnNames, String targetTableName) {
+
+			_sourceAdditionalWhereClause = sourceAdditionalWhereClause;
+			_sourceAdditionalColumnNamesCheck =
+				sourceAdditionalColumnNamesCheck;
+			_sourceColumnName = sourceColumnName;
+			_targetColumnNames = targetColumnNames;
+			_targetTableName = targetTableName;
+		}
+
+		private final String[] _sourceAdditionalColumnNamesCheck;
+		private final String _sourceAdditionalWhereClause;
+		private final String _sourceColumnName;
+		private final String[] _targetColumnNames;
+		private final String _targetTableName;
+
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		DBInspector dbInspector = new DBInspector(connection);
+
+		List<_PreparedConfig> preparedConfigs = new ArrayList<>();
+		List<SafeCloseable> allSafeCloseables = new ArrayList<>();
+
+		for (FilterConfig filterConfig : _filterConfigs) {
+			String targetTableName = dbInspector.normalizeName(
+				filterConfig._targetTableName);
+
+			if (!dbInspector.hasTable(targetTableName) &&
+				!(PropsValues.DATABASE_PARTITION_ENABLED &&
+				  dbInspector.isControlTable(targetTableName) &&
+				  dbInspector.hasView(targetTableName))) {
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Table \"" + targetTableName + "\" does not exist");
+				}
+
+				continue;
+			}
+
+			String[] targetColumnNames =
+				new String[filterConfig._targetColumnNames.length];
+
+			boolean valid = true;
+
+			for (int i = 0; i < filterConfig._targetColumnNames.length; i++) {
+				targetColumnNames[i] = dbInspector.normalizeName(
+					filterConfig._targetColumnNames[i]);
+
+				if (!dbInspector.hasColumn(
+						targetTableName, targetColumnNames[i])) {
+
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							StringBundler.concat(
+								"Table ", targetTableName,
+								" does not have column ",
+								targetColumnNames[i]));
+					}
+
+					valid = false;
+
+					break;
+				}
+			}
+
+			if (!valid) {
+				continue;
+			}
+
+			boolean[] numericTargetColumns =
+				new boolean[targetColumnNames.length];
+
+			for (int i = 0; i < targetColumnNames.length; i++) {
+				numericTargetColumns[i] = dbInspector.isNumeric(
+					targetTableName, targetColumnNames[i]);
+			}
+
+			List<SafeCloseable> safeCloseables =
+				OrphanReferencesDataCleanupUtil.addTemporaryIndexes(
+					targetColumnNames, connection, DBManagerUtil.getDB(),
+					targetTableName);
+
+			allSafeCloseables.addAll(safeCloseables);
+
+			String sourceColumnName = dbInspector.normalizeName(
+				filterConfig._sourceColumnName);
+
+			preparedConfigs.add(
+				new _PreparedConfig(
+					filterConfig._sourceAdditionalColumnNamesCheck,
+					filterConfig._sourceAdditionalWhereClause, sourceColumnName,
+					targetColumnNames, targetTableName, numericTargetColumns));
+		}
+
+		if (preparedConfigs.isEmpty()) {
+			return;
+		}
+
+		List<String> excludedTableNames =
+			OrphanReferencesDataCleanupUtil.getNormalizedExcludedTableNames(
+				connection);
+
+		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
+			connection);
+
+		List<String> tableNames = dbInspector.getTableNames(null);
+
+		Collections.sort(tableNames);
+
+		try {
+			processConcurrently(
+				tableNames.toArray(new String[0]),
+				sourceTableName -> {
+					if (excludedTableNames.contains(sourceTableName)) {
+						return;
+					}
+
+					for (_PreparedConfig preparedConfig : preparedConfigs) {
+						if (sourceTableName.equals(
+								preparedConfig._targetTableName) ||
+							!dbInspector.hasColumn(
+								sourceTableName,
+								preparedConfig._sourceColumnName)) {
+
+							continue;
+						}
+
+						boolean skip = false;
+
+						for (String sourceAdditionalColumnName :
+								preparedConfig.
+									_sourceAdditionalColumnNamesCheck) {
+
+							if (!dbInspector.hasColumn(
+									sourceTableName,
+									sourceAdditionalColumnName)) {
+
+								skip = true;
+
+								break;
+							}
+						}
+
+						if (skip) {
+							continue;
+						}
+
+						boolean numericSourceColumn = dbInspector.isNumeric(
+							sourceTableName, preparedConfig._sourceColumnName);
+
+						boolean compatibleTypes = true;
+
+						for (int i = 0;
+							 i < preparedConfig._targetColumnNames.length;
+							 i++) {
+
+							if (numericSourceColumn !=
+									preparedConfig._numericTargetColumns[i]) {
+
+								String message = StringBundler.concat(
+									"Table ", sourceTableName, " and column ",
+									preparedConfig._sourceColumnName,
+									" has an incompatible type with table ",
+									preparedConfig._targetTableName,
+									" and column ",
+									preparedConfig._targetColumnNames[i]);
+
+								compatibleTypes = false;
+
+								if (!dbInspector.isObjectTable(
+										sourceTableName) &&
+									!liferayTableNames.contains(
+										sourceTableName)) {
+
+									if (_log.isDebugEnabled()) {
+										_log.debug(message);
+									}
+								}
+								else if (_log.isWarnEnabled()) {
+									_log.warn(message);
+								}
+
+								break;
+							}
+						}
+
+						if (!compatibleTypes) {
+							continue;
+						}
+
+						OrphanReferencesDataCleanupUtil.cleanUpTable(
+							connection, null, false,
+							preparedConfig._sourceAdditionalWhereClause,
+							preparedConfig._sourceColumnName, sourceTableName,
+							preparedConfig._targetColumnNames,
+							preparedConfig._targetTableName, true);
+					}
+				},
+				null);
+		}
+		finally {
+			for (SafeCloseable safeCloseable : allSafeCloseables) {
+				safeCloseable.close();
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		MultiFilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess.
+			class);
+
+	private final FilterConfig[] _filterConfigs;
+
+	private static class _PreparedConfig {
+
+		private _PreparedConfig(
+			String[] sourceAdditionalColumnNamesCheck,
+			String sourceAdditionalWhereClause, String sourceColumnName,
+			String[] targetColumnNames, String targetTableName,
+			boolean[] numericTargetColumns) {
+
+			_sourceAdditionalColumnNamesCheck =
+				sourceAdditionalColumnNamesCheck;
+			_sourceAdditionalWhereClause = sourceAdditionalWhereClause;
+			_sourceColumnName = sourceColumnName;
+			_targetColumnNames = targetColumnNames;
+			_targetTableName = targetTableName;
+			_numericTargetColumns = numericTargetColumns;
+		}
+
+		private final boolean[] _numericTargetColumns;
+		private final String[] _sourceAdditionalColumnNamesCheck;
+		private final String _sourceAdditionalWhereClause;
+		private final String _sourceColumnName;
+		private final String[] _targetColumnNames;
+		private final String _targetTableName;
+
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.kernel.upgrade.data.cleanup;
 
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DB;
@@ -18,18 +17,19 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
-import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataCleanupUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Luis Ortiz
@@ -47,126 +47,167 @@ public class UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 			String[] targetColumnNames, String targetTableName)
 		throws Exception {
 
-		DBInspector dbInspector = new DBInspector(connection);
+		// Phase 1: collect distinct source userIds
 
-		if (!dbInspector.hasColumn(sourceTableName, "companyId")) {
+		List<Long> tableUserIds = new ArrayList<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select distinct ", sourceColumnName, " from ",
+					sourceTableName, " where ", sourceColumnName,
+					" is not null and ", sourceColumnName, " != 0"));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				tableUserIds.add(resultSet.getLong(1));
+			}
+		}
+
+		if (tableUserIds.isEmpty()) {
 			return;
 		}
 
-		DB db = DBManagerUtil.getDB();
+		// Phase 2: find orphans via Java set difference (User_ loaded once)
 
-		List<SafeCloseable> safeCloseables =
-			OrphanReferencesDataCleanupUtil.addTemporaryIndexes(
-				new String[] {sourceColumnName}, connection, db,
-				sourceTableName);
+		Set<Long> validUserIds = _getValidUserIds(
+			connection, targetColumnNames[0], targetTableName);
 
-		safeCloseables.addAll(
-			OrphanReferencesDataCleanupUtil.addTemporaryIndexes(
-				targetColumnNames, connection, db, targetTableName));
+		List<Long> orphanIds = new ArrayList<>();
 
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				StringBundler.concat(
-					"select ",
-					OrphanReferencesDataCleanupUtil.getSourceTableAlias(),
-					StringPool.PERIOD, sourceColumnName, ", ",
-					OrphanReferencesDataCleanupUtil.getSourceTableAlias(),
-					".companyId, count(1) as count from ", sourceTableName, " ",
-					OrphanReferencesDataCleanupUtil.getSourceTableAlias(),
-					OrphanReferencesDataCleanupUtil.getWhereClause(
-						connection, null, null, sourceColumnName,
-						sourceTableName, targetColumnNames, targetTableName),
-					" group by ",
-					OrphanReferencesDataCleanupUtil.getSourceTableAlias(),
-					StringPool.PERIOD, sourceColumnName, ", ",
-					OrphanReferencesDataCleanupUtil.getSourceTableAlias(),
-					".companyId"));
-			PreparedStatement preparedStatement2 =
-				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
-					connection,
-					StringBundler.concat(
-						"delete from ", sourceTableName, " where ",
-						sourceColumnName, " = ? and companyId = ?"));
-			PreparedStatement preparedStatement3 =
-				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
-					connection,
-					StringBundler.concat(
-						"update ", sourceTableName, " set ", sourceColumnName,
-						" = ? where ", sourceColumnName,
-						" = ? and companyId = ?"));
-			ResultSet resultSet = preparedStatement1.executeQuery()) {
+		for (long userId : tableUserIds) {
+			if (!validUserIds.contains(userId)) {
+				orphanIds.add(userId);
+			}
+		}
 
-			boolean partOfUniqueIndex = _isPartOfUniqueIndex(
-				connection, sourceColumnName, sourceTableName);
+		if (orphanIds.isEmpty()) {
+			return;
+		}
 
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
-				long count = resultSet.getLong("count");
-				long userId = resultSet.getLong(sourceColumnName);
+		// Phase 3: process orphans in batches
 
-				if (_deleteTableNames.contains(sourceTableName) ||
-					partOfUniqueIndex) {
+		boolean partOfUniqueIndex = _isPartOfUniqueIndex(
+			connection, sourceColumnName, sourceTableName);
 
-					preparedStatement2.setLong(1, userId);
-					preparedStatement2.setLong(2, companyId);
+		for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+			int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
 
-					preparedStatement2.addBatch();
+			List<String> batchStrings = new ArrayList<>(end - i);
 
-					DataCleanupLoggingUtil.logDelete(
-						_log, count, sourceTableName,
+			for (int j = i; j < end; j++) {
+				batchStrings.add(String.valueOf(orphanIds.get(j)));
+			}
+
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"select distinct ", sourceColumnName,
+							", companyId from ", sourceTableName, " where ",
+							sourceColumnName, " in (",
+							String.join(
+								StringPool.COMMA_AND_SPACE, batchStrings),
+							")"));
+				PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+						connection,
+						StringBundler.concat(
+							"delete from ", sourceTableName, " where ",
+							sourceColumnName, " = ? and companyId = ?"));
+				PreparedStatement preparedStatement3 =
+					AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+						connection,
+						StringBundler.concat(
+							"update ", sourceTableName, " set ",
+							sourceColumnName, " = ? where ", sourceColumnName,
+							" = ? and companyId = ?"));
+				ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+				while (resultSet.next()) {
+					long companyId = resultSet.getLong("companyId");
+					long userId = resultSet.getLong(sourceColumnName);
+
+					if (_deleteTableNames.contains(sourceTableName) ||
+						partOfUniqueIndex) {
+
+						preparedStatement2.setLong(1, userId);
+						preparedStatement2.setLong(2, companyId);
+
+						preparedStatement2.addBatch();
+
+						DataCleanupLoggingUtil.logDelete(
+							_log, 1, sourceTableName,
+							StringBundler.concat(
+								sourceColumnName, StringPool.SPACE, userId,
+								" was not found in column",
+								(targetColumnNames.length > 1) ? "s " : " ",
+								String.join(", ", targetColumnNames),
+								" from table ", targetTableName));
+
+						continue;
+					}
+
+					long newUserId = _getAdminUserId(connection, companyId);
+
+					if (newUserId == 0) {
+						continue;
+					}
+
+					preparedStatement3.setLong(1, newUserId);
+					preparedStatement3.setLong(2, userId);
+					preparedStatement3.setLong(3, companyId);
+
+					preparedStatement3.addBatch();
+
+					DataCleanupLoggingUtil.logUpdate(
+						_log, 1, sourceTableName, sourceColumnName, newUserId,
 						StringBundler.concat(
 							sourceColumnName, StringPool.SPACE, userId,
 							" was not found in column",
 							(targetColumnNames.length > 1) ? "s " : " ",
 							String.join(", ", targetColumnNames),
 							" from table ", targetTableName));
-
-					continue;
 				}
 
-				long newUserId = _getAdminUserId(connection, companyId);
+				preparedStatement2.executeBatch();
 
-				if (newUserId == 0) {
-					continue;
-				}
-
-				preparedStatement3.setLong(1, newUserId);
-
-				preparedStatement3.setLong(2, userId);
-				preparedStatement3.setLong(3, companyId);
-
-				preparedStatement3.addBatch();
-
-				DataCleanupLoggingUtil.logUpdate(
-					_log, count, sourceTableName, sourceColumnName, newUserId,
-					StringBundler.concat(
-						sourceColumnName, StringPool.SPACE, userId,
-						" was not found in column",
-						(targetColumnNames.length > 1) ? "s " : " ",
-						String.join(", ", targetColumnNames), " from table ",
-						targetTableName));
-			}
-
-			preparedStatement2.executeBatch();
-
-			preparedStatement3.executeBatch();
-		}
-		finally {
-			for (SafeCloseable safeCloseable : safeCloseables) {
-				safeCloseable.close();
+				preparedStatement3.executeBatch();
 			}
 		}
+	}
+
+	@Override
+	protected boolean shouldSkipSourceTable(
+			DBInspector dbInspector, String sourceTableName)
+		throws Exception {
+
+		return !dbInspector.hasColumn(sourceTableName, "companyId");
 	}
 
 	private long _getAdminUserId(Connection connection, long companyId)
 		throws Exception {
 
-		if (_adminUserIds.containsKey(companyId)) {
-			return _adminUserIds.get(companyId);
+		Long cachedUserId = _adminUserIds.get(companyId);
+
+		if (cachedUserId != null) {
+			return cachedUserId;
 		}
 
-		DBInspector dbInspector = new DBInspector(connection);
+		Boolean hasUserTypeColumn = _hasUserTypeColumn;
 
-		boolean hasColumn = dbInspector.hasColumn("User_", "type_");
+		if (hasUserTypeColumn == null) {
+			synchronized (this) {
+				if (_hasUserTypeColumn == null) {
+					DBInspector dbInspector = new DBInspector(connection);
+
+					_hasUserTypeColumn = dbInspector.hasColumn(
+						"User_", "type_");
+				}
+
+				hasUserTypeColumn = _hasUserTypeColumn;
+			}
+		}
+
+		boolean hasColumn = hasUserTypeColumn;
 
 		StringBundler sb = new StringBundler(6);
 
@@ -201,15 +242,44 @@ public class UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 				else {
 					if (_log.isWarnEnabled()) {
 						_log.warn(
-							"No admin user found for company " + companyId);
+							"Unable to find admin user for company " +
+								companyId);
 					}
 				}
 
-				_adminUserIds.put(companyId, userId);
+				_adminUserIds.putIfAbsent(companyId, userId);
 
 				return userId;
 			}
 		}
+	}
+
+	private Set<Long> _getValidUserIds(
+			Connection connection, String targetColumnName,
+			String targetTableName)
+		throws Exception {
+
+		Set<Long> validUserIds = _validUserIdsByConnection.get(connection);
+
+		if (validUserIds != null) {
+			return validUserIds;
+		}
+
+		validUserIds = new HashSet<>();
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select ", targetColumnName, " from ", targetTableName));
+			ResultSet resultSet = preparedStatement.executeQuery()) {
+
+			while (resultSet.next()) {
+				validUserIds.add(resultSet.getLong(1));
+			}
+		}
+
+		_validUserIdsByConnection.putIfAbsent(connection, validUserIds);
+
+		return _validUserIdsByConnection.get(connection);
 	}
 
 	private boolean _isPartOfUniqueIndex(
@@ -217,20 +287,35 @@ public class UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 			String sourceTableName)
 		throws Exception {
 
+		Boolean partOfUniqueIndex = _isPartOfUniqueIndexCache.get(
+			sourceTableName);
+
+		if (partOfUniqueIndex != null) {
+			return partOfUniqueIndex;
+		}
+
 		DB db = DBManagerUtil.getDB();
 
 		List<IndexMetadata> indexes = db.getIndexMetadatas(
 			connection, sourceTableName, sourceColumnName, true);
 
 		if (!indexes.isEmpty()) {
+			_isPartOfUniqueIndexCache.put(sourceTableName, true);
+
 			return true;
 		}
 
 		String[] columnNames = db.getPrimaryKeyColumnNames(
 			connection, sourceTableName);
 
-		return ArrayUtil.contains(columnNames, sourceColumnName);
+		boolean result = ArrayUtil.contains(columnNames, sourceColumnName);
+
+		_isPartOfUniqueIndexCache.put(sourceTableName, result);
+
+		return result;
 	}
+
+	private static final int _BATCH_SIZE = 1000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess.class);
@@ -249,6 +334,11 @@ public class UserAllTablesOrphanReferencesDataCleanupPreupgradeProcess
 		}
 	};
 
-	private final Map<Long, Long> _adminUserIds = new HashMap<>();
+	private final Map<Long, Long> _adminUserIds = new ConcurrentHashMap<>();
+	private volatile Boolean _hasUserTypeColumn;
+	private final Map<String, Boolean> _isPartOfUniqueIndexCache =
+		new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<Connection, Set<Long>>
+		_validUserIdsByConnection = new ConcurrentHashMap<>();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
@@ -25,9 +25,12 @@ import java.sql.ResultSet;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * @author Luis Ortiz
@@ -66,6 +69,19 @@ public class OrphanReferencesDataCleanupUtil {
 			String targetTableName)
 		throws Exception {
 
+		cleanUpTable(
+			connection, customJoinClauses, readOnly,
+			sourceAdditionalWhereClause, sourceColumnName, sourceTableName,
+			targetColumnNames, targetTableName, false);
+	}
+
+	public static void cleanUpTable(
+			Connection connection, String[] customJoinClauses, boolean readOnly,
+			String sourceAdditionalWhereClause, String sourceColumnName,
+			String sourceTableName, String[] targetColumnNames,
+			String targetTableName, boolean skipTemporaryIndexes)
+		throws Exception {
+
 		List<String> excludedTableNames = getNormalizedExcludedTableNames(
 			connection);
 
@@ -85,53 +101,64 @@ public class OrphanReferencesDataCleanupUtil {
 			aliasNeeded = true;
 		}
 
-		List<SafeCloseable> safeCloseables = addTemporaryIndexes(
-			targetColumnNames, connection, db, targetTableName);
+		List<SafeCloseable> safeCloseables;
+
+		if (skipTemporaryIndexes) {
+			safeCloseables = Collections.emptyList();
+		}
+		else {
+			safeCloseables = addTemporaryIndexes(
+				targetColumnNames, connection, db, targetTableName);
+		}
 
 		String whereClause = getWhereClause(
 			connection, customJoinClauses, sourceAdditionalWhereClause,
 			sourceColumnName, sourceTableName, targetColumnNames,
 			targetTableName);
 
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				StringBundler.concat(
-					"select ", _SOURCE_TABLE_ALIAS, StringPool.PERIOD,
-					sourceColumnName, ", count(1) as count from ",
-					sourceTableName, StringPool.SPACE, _SOURCE_TABLE_ALIAS,
-					whereClause, " group by ", _SOURCE_TABLE_ALIAS,
-					StringPool.PERIOD, sourceColumnName));
+		String deleteSQL = StringBundler.concat(
+			"delete ",
+			aliasNeeded ? (_SOURCE_TABLE_ALIAS + StringPool.SPACE) : "",
+			"from ", sourceTableName, StringPool.SPACE, _SOURCE_TABLE_ALIAS,
+			whereClause);
 
-			ResultSet resultSet = preparedStatement1.executeQuery()) {
-
-			if (!readOnly) {
-				try (PreparedStatement preparedStatement2 =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"delete ",
-								aliasNeeded ?
-									(_SOURCE_TABLE_ALIAS + StringPool.SPACE) :
-										"",
-								"from ", sourceTableName, StringPool.SPACE,
-								_SOURCE_TABLE_ALIAS, whereClause))) {
-
-					preparedStatement2.execute();
-				}
-			}
-
+		try {
 			if (!_log.isInfoEnabled()) {
+				if (!readOnly) {
+					_executeDelete(connection, deleteSQL);
+				}
+
 				return;
 			}
 
-			while (resultSet.next()) {
-				DataCleanupLoggingUtil.logDelete(
-					_log, resultSet.getLong("count"), readOnly, sourceTableName,
-					StringBundler.concat(
-						sourceColumnName, StringPool.SPACE,
-						resultSet.getObject(sourceColumnName),
-						" was not found in column",
-						(targetColumnNames.length > 1) ? "s " : " ",
-						String.join(", ", targetColumnNames), " from table ",
-						targetTableName));
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"select ", _SOURCE_TABLE_ALIAS, StringPool.PERIOD,
+							sourceColumnName, ", count(1) as count from ",
+							sourceTableName, StringPool.SPACE,
+							_SOURCE_TABLE_ALIAS, whereClause, " group by ",
+							_SOURCE_TABLE_ALIAS, StringPool.PERIOD,
+							sourceColumnName));
+
+				ResultSet resultSet = preparedStatement1.executeQuery()) {
+
+				if (!readOnly) {
+					_executeDelete(connection, deleteSQL);
+				}
+
+				while (resultSet.next()) {
+					DataCleanupLoggingUtil.logDelete(
+						_log, resultSet.getLong("count"), readOnly,
+						sourceTableName,
+						StringBundler.concat(
+							sourceColumnName, StringPool.SPACE,
+							resultSet.getObject(sourceColumnName),
+							" was not found in column",
+							(targetColumnNames.length > 1) ? "s " : " ",
+							String.join(", ", targetColumnNames),
+							" from table ", targetTableName));
+				}
 			}
 		}
 		finally {
@@ -154,20 +181,26 @@ public class OrphanReferencesDataCleanupUtil {
 			targetTableName);
 	}
 
+	public static void clearIndexCache() {
+		_firstIndexColumnNamesCache.clear();
+	}
+
 	public static List<String> getNormalizedExcludedTableNames(
 			Connection connection)
 		throws Exception {
 
-		if (_normalizedExcludedTableNames.isEmpty()) {
-			DBInspector dbInspector = new DBInspector(connection);
+		synchronized (_normalizedExcludedTableNames) {
+			if (_normalizedExcludedTableNames.isEmpty()) {
+				DBInspector dbInspector = new DBInspector(connection);
 
-			for (String excludedTableName : _excludedTableNames) {
-				_normalizedExcludedTableNames.add(
-					dbInspector.normalizeName(excludedTableName));
+				for (String excludedTableName : _excludedTableNames) {
+					_normalizedExcludedTableNames.add(
+						dbInspector.normalizeName(excludedTableName));
+				}
 			}
-		}
 
-		return _normalizedExcludedTableNames;
+			return Collections.unmodifiableList(_normalizedExcludedTableNames);
+		}
 	}
 
 	public static String getSourceTableAlias() {
@@ -180,8 +213,6 @@ public class OrphanReferencesDataCleanupUtil {
 			String sourceTableName, String[] targetColumnNames,
 			String targetTableName)
 		throws Exception {
-
-		String whereClause = null;
 
 		String additionalNullCheck = "";
 
@@ -205,6 +236,8 @@ public class OrphanReferencesDataCleanupUtil {
 			(sourceAdditionalWhereClause != null) ?
 				" and " + sourceAdditionalWhereClause : "");
 
+		String whereClause = null;
+
 		if ((db.getDBType() == DBType.MARIADB) ||
 			(db.getDBType() == DBType.MYSQL)) {
 
@@ -224,17 +257,40 @@ public class OrphanReferencesDataCleanupUtil {
 			whereClause, "[$SOURCE_TABLE_ALIAS$]", _SOURCE_TABLE_ALIAS);
 	}
 
+	private static void _executeDelete(Connection connection, String deleteSQL)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				deleteSQL)) {
+
+			preparedStatement.executeUpdate();
+		}
+	}
+
 	private static Set<String> _getFirstIndexColumnNames(
 			Connection connection, DB db, String tableName)
 		throws Exception {
 
+		Set<String> firstIndexColumnNames = _firstIndexColumnNamesCache.get(
+			tableName);
+
+		if (firstIndexColumnNames != null) {
+			if (firstIndexColumnNames == _tableNotFound) {
+				return null;
+			}
+
+			return firstIndexColumnNames;
+		}
+
 		DBInspector dbInspector = new DBInspector(connection);
 
 		if (!dbInspector.hasTable(tableName)) {
+			_firstIndexColumnNamesCache.putIfAbsent(tableName, _tableNotFound);
+
 			return null;
 		}
 
-		Set<String> firstIndexColumnNames = new HashSet<>();
+		firstIndexColumnNames = new HashSet<>();
 
 		try (ResultSet resultSet = db.getIndexResultSet(
 				connection, tableName, false)) {
@@ -276,6 +332,9 @@ public class OrphanReferencesDataCleanupUtil {
 			}
 		}
 
+		_firstIndexColumnNamesCache.putIfAbsent(
+			tableName, firstIndexColumnNames);
+
 		return firstIndexColumnNames;
 	}
 
@@ -300,6 +359,7 @@ public class OrphanReferencesDataCleanupUtil {
 			sb.append(" on ");
 
 			if ((customJoinClauses == null) ||
+				(index >= customJoinClauses.length) ||
 				(customJoinClauses[index] == null) ||
 				!customJoinClauses[index].startsWith(
 					"[$TARGET_TABLE_ALIAS$]")) {
@@ -311,6 +371,7 @@ public class OrphanReferencesDataCleanupUtil {
 			}
 
 			if ((customJoinClauses != null) &&
+				(index < customJoinClauses.length) &&
 				(customJoinClauses[index] != null)) {
 
 				sb.append(
@@ -374,7 +435,9 @@ public class OrphanReferencesDataCleanupUtil {
 		sb.append(" where (");
 
 		for (int i = 0; i < targetColumnNames.length; i++) {
-			if ((customJoinClauses == null) || (customJoinClauses[i] == null) ||
+			if ((customJoinClauses == null) ||
+				(i >= customJoinClauses.length) ||
+				(customJoinClauses[i] == null) ||
 				(!customJoinClauses[i].startsWith("CAST") &&
 				 !customJoinClauses[i].startsWith("CONVERT") &&
 				 !customJoinClauses[i].startsWith("[$TARGET_TABLE_ALIAS$]"))) {
@@ -385,7 +448,9 @@ public class OrphanReferencesDataCleanupUtil {
 				sb.append(" = ");
 			}
 
-			if ((customJoinClauses != null) && (customJoinClauses[i] != null)) {
+			if ((customJoinClauses != null) && (i < customJoinClauses.length) &&
+				(customJoinClauses[i] != null)) {
+
 				sb.append(
 					StringUtil.replace(
 						customJoinClauses[i], "[$TARGET_TABLE_ALIAS$]",
@@ -424,7 +489,11 @@ public class OrphanReferencesDataCleanupUtil {
 	private static final List<String> _excludedTableNames = new ArrayList<>(
 		Arrays.asList(
 			"Audit_AuditEvent", "CyrusUser", "CyrusVirtual", "SystemEvent"));
+	private static final Map<String, Set<String>> _firstIndexColumnNamesCache =
+		new ConcurrentHashMap<>();
 	private static final List<String> _normalizedExcludedTableNames =
 		new ArrayList<>();
+	private static final Set<String> _tableNotFound =
+		Collections.unmodifiableSet(new HashSet<>());
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0


### PR DESCRIPTION
## Summary

POC branch for LPD-91140. Implements five performance optimizations for the `DataCleanupPreupgradeProcessSuite` pre-upgrade phase. Baseline on an unmodified master against a partition-large MySQL dump: **273,895 ms mean** (3-run σ=1,442 ms).

Each optimization is in its own commit:

| Commit | Optimization | Description |
| --- | --- | --- |
| OPT-3 + OPT-2 | Wave parallel execution | Kahn topological sort → dependency waves; processes in the same wave run concurrently via `FixedThreadPool`. Also restores `dlFileEntry`, `journal`, `contact` as independent map entries (reverts the earlier fused-class wrapper that added ~18 s to the critical path). |
| OPT-1 | DBInspector schema snapshot | Static `ConcurrentHashMap` caches for table names, column existence, and column numeric type. Eliminates ~14,400 `INFORMATION_SCHEMA` round-trips. Uses static (not `ThreadLocal`) so worker threads in the wave executor see the same cache. |
| OPT-6 | ResourcePermission class name grouping | Groups class names that resolve to the same target table and issues one `cleanUpTable` call with `name IN (…)` rather than N individual calls. |
| OPT-9 | OrphanReferences COUNT SELECT skip | Restructures `cleanUpTable` so the fast path (INFO logging off) issues only the DELETE and returns immediately. Previously the COUNT query ran unconditionally before the logging check. |
| OPT-5 | Counter MAX CAST (MySQL/MariaDB) | Replaces the full-table row-streaming MAX with a server-side `MAX(CAST(name AS UNSIGNED))` filtered by `REGEXP '^[0-9]+$'` on MySQL/MariaDB. |

## Theoretical Savings (to be confirmed by benchmarking this branch)

- OPT-3: eliminates serial wait time between independent waves (estimated ~50–80 s wall time reduction depending on which processes end up in the same wave)
- OPT-1: eliminates ~14,400 INFORMATION_SCHEMA queries (~60–90 s on a large schema)
- OPT-6: reduces ResourcePermission passes by a factor of N class names per table
- OPT-9: eliminates one COUNT query per `cleanUpTable` call when INFO logging is off (production default)
- OPT-5: eliminates full-table scan of DLFileEntry for counter MAX

## Test Plan

- [ ] Deploy portal-kernel and portal-impl against a partition-large MySQL dump
- [ ] Run the pre-upgrade data cleanup phase with timing instrumentation
- [ ] Compare total phase time against the 273,895 ms baseline
- [ ] Verify no data-correctness regressions (counter values, orphan cleanup completeness)