### PR TITLE
LPD-92809 Prevent data cleanup test from failing on orphaned permissions

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourcePermissionPostupgradeDataCleanupProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/ResourcePermissionPostupgradeDataCleanupProcessTest.java
@@ -7,8 +7,6 @@ package com.liferay.data.cleanup.internal.verify.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Portlet;
@@ -53,9 +51,8 @@ public class ResourcePermissionPostupgradeDataCleanupProcessTest
 
 		test(
 			logCapture -> {
-				List<String> messages = logCapture.getMessages();
-
-				Assert.assertTrue(messages.toString(), messages.isEmpty());
+				_assertResourcePermissionNotDeleted(
+					logCapture, portlet.getPortletName());
 
 				Assert.assertTrue(_hasResourcePermission(resourcePermissionId));
 			},
@@ -115,9 +112,7 @@ public class ResourcePermissionPostupgradeDataCleanupProcessTest
 
 		test(
 			logCapture -> {
-				List<String> messages = logCapture.getMessages();
-
-				Assert.assertTrue(messages.toString(), messages.isEmpty());
+				_assertResourcePermissionNotDeleted(logCapture, portletName);
 
 				Assert.assertTrue(_hasResourcePermission(resourcePermissionId));
 			},
@@ -210,28 +205,6 @@ public class ResourcePermissionPostupgradeDataCleanupProcessTest
 			"ResourcePermissionPostupgradeDataCleanupProcess";
 	}
 
-	@Override
-	protected void test(
-			UnsafeConsumer<LogCapture, Exception> assertUnsafeConsumer,
-			UnsafeRunnable<Exception> cleanUpDataUnsafeRunnable,
-			UnsafeRunnable<Exception> initializeDataUnsafeRunnable)
-		throws Exception {
-
-		long resourcePermissionCount =
-			_resourcePermissionLocalService.getResourcePermissionsCount();
-
-		try {
-			super.test(
-				assertUnsafeConsumer, cleanUpDataUnsafeRunnable,
-				initializeDataUnsafeRunnable);
-		}
-		finally {
-			Assert.assertEquals(
-				resourcePermissionCount,
-				_resourcePermissionLocalService.getResourcePermissionsCount());
-		}
-	}
-
 	private void _addResourcePermission(
 			String portletName, long primKeyId, long resourcePermissionId,
 			long roleId)
@@ -250,6 +223,15 @@ public class ResourcePermissionPostupgradeDataCleanupProcessTest
 			preparedStatement.setInt(5, ResourceConstants.SCOPE_INDIVIDUAL);
 
 			preparedStatement.executeUpdate();
+		}
+	}
+
+	private void _assertResourcePermissionNotDeleted(
+		LogCapture logCapture, String name) {
+
+		for (String message : logCapture.getMessages()) {
+			Assert.assertFalse(
+				message, message.contains("\"" + name + "\" was not found"));
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92809

## What Is Being Fixed

`testLiferayPortletFoundResourcePermissionIsNotDeleted` in `ResourcePermissionPostupgradeDataCleanupProcessTest` failed intermittently on the upgrade CI routine (about 1 of 8 upgrade-database scenarios, recurring since April 2026). The test asserted that the cleanup process logged nothing and left the total resource permission count unchanged. Both are global assumptions that only hold on a pristine database. `ResourcePermissionPostupgradeDataCleanupProcess` deletes orphaned `com_liferay_` resource permissions whose portlet is no longer registered and logs each deletion, so any upgraded database that still carries such orphans, exactly what this process exists to clean up, broke the assertions.

## How It Is Being Fixed

The log assertion is scoped to the test's own portlet, so unrelated orphan deletions are tolerated while still verifying the registered portlet's permission is never the subject of a delete. The global resource permission count invariant is removed because each test method already verifies the fate of its specific row through `_hasResourcePermission`, making the count check redundant and fragile on non-pristine databases.

## Why Are There No Tests?

This change is itself a correction to an existing integration test. It was verified locally by reproducing the original failure: injecting an orphaned `com_liferay_` resource permission into the partition schema, confirming the unmodified test fails with the exact assertion, then confirming the corrected test passes with the orphan still present.