### PR TITLE
LPD-92794 Expect formatted timestamp in rotated report filename

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.upgrade.data.cleanup.util.OrphanReferencesDataC
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeLogProgressTracker;
 import com.liferay.portal.kernel.upgrade.recorder.UpgradeSQLRecorder;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -75,11 +76,15 @@ import java.net.URI;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
+import java.text.DateFormat;
+
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -1203,8 +1208,12 @@ public abstract class BaseUpgradeLogAppenderTestCase {
 
 		_appender.stop();
 
-		reportFile = _getReportFile(
-			reportFileName + "." + reportFile1LastModified);
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMdd_HHmmss", LocaleUtil.US, TimeZone.getTimeZone("UTC"));
+
+		String timestamp = dateFormat.format(new Date(reportFile1LastModified));
+
+		reportFile = _getReportFile(reportFileName + "." + timestamp);
 
 		Assert.assertTrue(reportFile.exists());
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92794

## Failing Test

`com.liferay.portal.upgrade.test.UpgradeLogAppenderUpgradeClientTest`

`modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java`

```
java.lang.AssertionError
	at org.junit.Assert.fail(Assert.java:87)
	at org.junit.Assert.assertTrue(Assert.java:42)
	at org.junit.Assert.assertTrue(Assert.java:53)
	at com.liferay.portal.upgrade.test.BaseUpgradeLogAppenderTestCase._assertRenameUpgradeReport(BaseUpgradeLogAppenderTestCase.java:1209)
	at com.liferay.portal.upgrade.test.BaseUpgradeLogAppenderTestCase.testRenameUpgradeReport(BaseUpgradeLogAppenderTestCase.java:893)
```

## Root Cause

Commit `75abd6c` ("LPD-88096 Format rotated upgrade report filename with timestamp") changed how `UpgradeReport` names the rotated report file when one already exists: from a raw `lastModified()` millisecond suffix (e.g. `upgrade_report.txt.1716451956000`) to a formatted `yyyyMMdd_HHmmss` UTC timestamp (e.g. `upgrade_report.txt.20260523_041236`). The test helper `_assertRenameUpgradeReport` was not updated and still looked for the old millisecond-suffixed file, which never exists, so `Assert.assertTrue(reportFile.exists())` failed.

## Fix

Format the expected rotated filename suffix in the test exactly the way the production code does, using `DateFormatFactoryUtil.getSimpleDateFormat("yyyyMMdd_HHmmss", LocaleUtil.US, TimeZone.getTimeZone("UTC"))` applied to the original report's `lastModified()`. The test now matches the current production naming and passes.

- `modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/BaseUpgradeLogAppenderTestCase.java`