### PR TITLE
LPD-82361 Restrict Company and VirtualHost on secondary instances

### DIFF
--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -486,6 +486,56 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
+	@Test
+	public void testCompanyNotVisibleAcrossSecondaryInstances()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company1.getCompanyId())) {
+
+			List<Company> companies = _companyLocalService.getCompanies();
+
+			Assert.assertFalse(companies.contains(_company2));
+			Assert.assertTrue(companies.contains(_company1));
+		}
+	}
+
+	@Test
+	public void testCompanyResolvableByVirtualHostAfterNegativeLookup()
+		throws Exception {
+
+		String webId =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) + ".com";
+
+		Assert.assertNull(
+			_companyLocalService.fetchCompanyByVirtualHost(webId));
+
+		_company1 = CompanyTestUtil.addCompanyWithWebId(webId);
+
+		Assert.assertNotNull(
+			_companyLocalService.fetchCompanyByVirtualHost(webId));
+	}
+
+	@Test
+	public void testCompanyViewFiltersPeerCompanies() throws Exception {
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		String partitionName = CompanyLocalServiceTestUtil.getPartitionName(
+			_company1.getCompanyId());
+
+		Assert.assertFalse(
+			_isCompanyIdInView(
+				partitionName, "Company", _company2.getCompanyId()));
+		Assert.assertTrue(
+			_isCompanyIdInView(
+				partitionName, "Company", _company1.getCompanyId()));
+	}
+
 	@FeatureFlag("LPD-11342")
 	@Test
 	public void testCopyDBPartitionCompany() throws Exception {
@@ -809,6 +859,62 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
+	@Test
+	public void testGetCompanyIdsScopedToSecondaryInstance() throws Exception {
+		_company1 = CompanyTestUtil.addCompany();
+
+		long companyId = _company1.getCompanyId();
+
+		Assert.assertTrue(
+			ArrayUtil.contains(PortalInstancePool.getCompanyIds(), companyId));
+
+		Assert.assertTrue(
+			ArrayUtil.contains(
+				PortalInstancePool.getCompanyIds(), _defaultCompanyId));
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			Assert.assertArrayEquals(
+				new long[] {companyId}, PortalInstancePool.getCompanyIds());
+		}
+	}
+
+	@Test
+	public void testVirtualHostNotVisibleAcrossSecondaryInstances()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company1.getCompanyId())) {
+
+			List<VirtualHost> virtualHosts =
+				_virtualHostLocalService.getVirtualHosts(
+					_company2.getCompanyId());
+
+			Assert.assertTrue(virtualHosts.isEmpty());
+		}
+	}
+
+	@Test
+	public void testVirtualHostViewFiltersPeerCompanies() throws Exception {
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		String partitionName = CompanyLocalServiceTestUtil.getPartitionName(
+			_company1.getCompanyId());
+
+		Assert.assertFalse(
+			_isCompanyIdInView(
+				partitionName, "VirtualHost", _company2.getCompanyId()));
+		Assert.assertTrue(
+			_isCompanyIdInView(
+				partitionName, "VirtualHost", _company1.getCompanyId()));
+	}
+
 	private void _addCopyDBPartitionCompanyCache(long companyId) {
 		_className1 = _classNameLocalService.addClassName(_CLASS_NAME_1);
 		_className2 = _classNameLocalService.addClassName(_CLASS_NAME_2);
@@ -908,15 +1014,21 @@ public class CompanyLocalServiceDBPartitionTest
 			Company company, String name, String virtualHostname, String webId)
 		throws Exception {
 
-		Assert.assertTrue(
-			ArrayUtil.contains(
-				CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
-				company.getCompanyId()));
 		Assert.assertEquals(name, company.getName());
 		Assert.assertEquals(virtualHostname, company.getVirtualHostname());
 		Assert.assertEquals(webId, company.getWebId());
 
-		_virtualHostLocalService.getVirtualHost(virtualHostname);
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					company.getCompanyId())) {
+
+			Assert.assertTrue(
+				ArrayUtil.contains(
+					CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
+					company.getCompanyId()));
+
+			_virtualHostLocalService.getVirtualHost(virtualHostname);
+		}
 	}
 
 	private void _assertCopyDBPartitionCompanyCache(long companyId) {
@@ -1176,6 +1288,23 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 
 		return false;
+	}
+
+	private boolean _isCompanyIdInView(
+			String partitionName, String tableName, long companyId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select companyId from ", partitionName, StringPool.PERIOD,
+					tableName, " where companyId = ?"))) {
+
+			preparedStatement.setLong(1, companyId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
 	}
 
 	private static final String _CLASS_NAME_1 =

--- a/portal-impl/src/com/liferay/portal/db/partition/db/DBPartitionDB.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/db/DBPartitionDB.java
@@ -75,10 +75,18 @@ public interface DBPartitionDB {
 	public default String getCreateViewSQL(
 		String fromPartitionName, String toPartitionName, String viewName) {
 
+		return getCreateViewSQL(
+			fromPartitionName, toPartitionName, viewName, StringPool.BLANK);
+	}
+
+	public default String getCreateViewSQL(
+		String fromPartitionName, String toPartitionName, String viewName,
+		String whereClause) {
+
 		return StringBundler.concat(
 			"create or replace view ", toPartitionName, StringPool.PERIOD,
 			viewName, " as select * from ", fromPartitionName,
-			StringPool.PERIOD, viewName);
+			StringPool.PERIOD, viewName, whereClause);
 	}
 
 	public String getDefaultPartitionName(Connection connection)

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -326,6 +326,19 @@ public class DBPartitionUtil {
 		return true;
 	}
 
+	public static boolean isCurrentCompanyRestricted() {
+		if (!PropsValues.DATABASE_PARTITION_ENABLED ||
+			CompanyThreadLocal.isInitializingPortalInstance() ||
+			CompanyThreadLocal.isUpgradingPortalInstance() ||
+			(CompanyThreadLocal.getNonsystemCompanyId() ==
+				PortalInstancePool.getDefaultCompanyId())) {
+
+			return false;
+		}
+
+		return true;
+	}
+
 	public static boolean removeDBPartition(long companyId)
 		throws PortalException {
 
@@ -466,8 +479,8 @@ public class DBPartitionUtil {
 					if (dbInspector.isControlTable(tableName)) {
 						statement.executeUpdate(
 							_dbPartitionDB.getCreateViewSQL(
-								_defaultPartitionName, partitionName,
-								tableName));
+								_defaultPartitionName, partitionName, tableName,
+								_getViewWhereClauseSQL(companyId, tableName)));
 					}
 					else {
 						statement.executeUpdate(
@@ -525,7 +538,9 @@ public class DBPartitionUtil {
 		String targetPartitionName = getPartitionName(toCompanyId);
 
 		try (AutoCloseable autoCloseable = _disableAutoCommit(connection)) {
-			_copySchema(connection, sourcePartitionName, targetPartitionName);
+			_copySchema(
+				toCompanyId, connection, sourcePartitionName,
+				targetPartitionName);
 
 			DatabaseMetaData databaseMetaData = connection.getMetaData();
 
@@ -705,7 +720,7 @@ public class DBPartitionUtil {
 	}
 
 	private static void _copySchema(
-			Connection connection, String sourcePartitionName,
+			long companyId, Connection connection, String sourcePartitionName,
 			String targetPartitionName)
 		throws SQLException {
 
@@ -732,7 +747,9 @@ public class DBPartitionUtil {
 						statement.executeUpdate(
 							_dbPartitionDB.getCreateViewSQL(
 								_defaultPartitionName, targetPartitionName,
-								fromTableName));
+								fromTableName,
+								_getViewWhereClauseSQL(
+									companyId, fromTableName)));
 
 						continue;
 					}
@@ -957,7 +974,8 @@ public class DBPartitionUtil {
 
 		try (AutoCloseable autoCloseable = _disableAutoCommit(connection)) {
 			_copySchema(
-				connection, getPartitionName(companyId), exportedPartitionName);
+				companyId, connection, getPartitionName(companyId),
+				exportedPartitionName);
 
 			DatabaseMetaData databaseMetaData = connection.getMetaData();
 
@@ -1305,6 +1323,18 @@ public class DBPartitionUtil {
 		return " where trigger_name like '%@" + companyId + "'";
 	}
 
+	private static String _getViewWhereClauseSQL(
+		long companyId, String tableName) {
+
+		if (StringUtil.equalsIgnoreCase(tableName, "Company") ||
+			StringUtil.equalsIgnoreCase(tableName, "VirtualHost")) {
+
+			return " where companyId = " + companyId;
+		}
+
+		return StringPool.BLANK;
+	}
+
 	private static void _importDBPartition(long companyId)
 		throws PortalException {
 
@@ -1397,7 +1427,8 @@ public class DBPartitionUtil {
 					statement.executeUpdate(
 						_dbPartitionDB.getCreateViewSQL(
 							_defaultPartitionName, targetPartitionName,
-							tableName));
+							tableName,
+							_getViewWhereClauseSQL(companyId, tableName)));
 				}
 
 				connection.commit();
@@ -1694,7 +1725,8 @@ public class DBPartitionUtil {
 						super.execute(
 							_dbPartitionDB.getCreateViewSQL(
 								_defaultPartitionName,
-								getPartitionName(companyId), tableName));
+								getPartitionName(companyId), tableName,
+								_getViewWhereClauseSQL(companyId, tableName)));
 					}
 
 					return returnValue;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -150,6 +150,7 @@ import java.net.UnknownHostException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -950,7 +951,18 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	 */
 	@Override
 	public List<Company> getCompanies() {
-		return companyPersistence.findAll();
+		if (!DBPartitionUtil.isCurrentCompanyRestricted()) {
+			return companyPersistence.findAll();
+		}
+
+		Company company = companyPersistence.fetchByPrimaryKey(
+			CompanyThreadLocal.getCompanyId());
+
+		if (company == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.singletonList(company);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.portal.service.impl;
 
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.AvailableLocaleException;
@@ -136,6 +137,12 @@ public class VirtualHostLocalServiceImpl
 
 	@Override
 	public List<VirtualHost> getVirtualHosts(long companyId) {
+		if (DBPartitionUtil.isCurrentCompanyRestricted() &&
+			(companyId != CompanyThreadLocal.getCompanyId())) {
+
+			return Collections.emptyList();
+		}
+
 		return virtualHostPersistence.findByCompanyId(companyId);
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -9,9 +9,11 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -63,11 +65,12 @@ public class PortalInstancePool {
 
 	public static long[] getCompanyIds() {
 		if (_cacheEnabled) {
-			return ArrayUtil.toLongArray(_portalInstances.keySet());
+			return _filterCompanyIds(
+				ArrayUtil.toLongArray(_portalInstances.keySet()));
 		}
 
 		try {
-			return _getCompanyIdsBySQL();
+			return _filterCompanyIds(_getCompanyIdsBySQL());
 		}
 		catch (SQLException sqlException) {
 			_log.error("Unable to get the company IDs by SQL", sqlException);
@@ -159,6 +162,19 @@ public class PortalInstancePool {
 
 	public static void remove(long companyId) {
 		_portalInstances.remove(companyId);
+	}
+
+	private static long[] _filterCompanyIds(long[] companyIds) {
+		if (!PropsValues.DATABASE_PARTITION_ENABLED ||
+			CompanyThreadLocal.isInitializingPortalInstance() ||
+			CompanyThreadLocal.isUpgradingPortalInstance() ||
+			(CompanyThreadLocal.getNonsystemCompanyId() ==
+				getDefaultCompanyId())) {
+
+			return companyIds;
+		}
+
+		return new long[] {CompanyThreadLocal.getNonsystemCompanyId()};
 	}
 
 	private static long _getCompanyIdBySQL(String webId) throws SQLException {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-82361

## What Is Being Fixed

With database partitioning enabled, the `Company` and `VirtualHost` tables live once in the default partition and are exposed to every secondary instance as unfiltered views, and `PortalInstancePool.getCompanyIds()` enumerates every company. A secondary instance can therefore read and enumerate the `Company` and `VirtualHost` records of other instances, which is a cross-partition data leak.

## How It Is Being Fixed

The restriction is enforced at three layers, all gated on `DATABASE_PARTITION_ENABLED` and never applied to the default instance, an upgrade, or instance initialization, so a leak at one layer is caught by the next. At the database layer the per-partition `Company` and `VirtualHost` views are created with a `where companyId` filter, so a secondary instance's view exposes only its own row. At the enumeration layer `PortalInstancePool.getCompanyIds()` returns only the current company on a secondary instance, which also scopes `forEachCompany` and `forEachCompanyId`. At the service layer `CompanyLocalService.getCompanies()` and `VirtualHostLocalService.getVirtualHosts(companyId)` return only the current instance's records. The default company is treated like any other peer, visible only to its own instance.

The ticket also proposed sharding the `Company` and `VirtualHost` caches by adding them to `DBPartition.isPartitionedModel`. I did not take that route, because it structurally breaks company resolution by web ID and by virtual host: the unique-finder caches store negative results per shard, and resolution runs before any company context exists, so the shard key is the very companyId the lookup is trying to discover. The reasoning is recorded in detail on the ticket.

Coverage lives in `CompanyLocalServiceDBPartitionTest`, which exercises the filtered views read directly from a secondary instance's partition, the `getCompanyIds` scoping, the service-layer filtering, and a guard that a company stays resolvable by its virtual host after a negative lookup.
