### PR TITLE
LPD-93248 Run data cleanup processes in dependency waves concurrently

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -24,7 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -86,11 +88,14 @@ public class DataCleanupPreupgradeProcessSuite {
 						continue;
 					}
 
+					CompletionService<Void> completionService =
+						new ExecutorCompletionService<>(executorService);
+
 					List<Future<Void>> futures = new ArrayList<>();
 
 					for (DataCleanupPreupgradeProcess process : wave) {
 						futures.add(
-							executorService.submit(
+							completionService.submit(
 								(Callable<Void>)() -> {
 									_runProcess(process);
 
@@ -98,9 +103,10 @@ public class DataCleanupPreupgradeProcessSuite {
 								}));
 					}
 
-					for (Future<Void> future : futures) {
+					for (int i = 0; i < wave.size(); i++) {
 						try {
-							future.get();
+							completionService.take(
+							).get();
 						}
 						catch (ExecutionException executionException) {
 							for (Future<Void> f : futures) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -69,6 +69,7 @@ public class DataCleanupPreupgradeProcessSuite {
 					runnable -> {
 						Thread thread = new Thread(runnable);
 
+						thread.setDaemon(true);
 						thread.setName(
 							"data-cleanup-preupgrade-process-wave-thread-" +
 								threadCount.incrementAndGet());
@@ -97,13 +98,15 @@ public class DataCleanupPreupgradeProcessSuite {
 								}));
 					}
 
-					List<Exception> exceptions = new ArrayList<>();
-
 					for (Future<Void> future : futures) {
 						try {
 							future.get();
 						}
 						catch (ExecutionException executionException) {
+							for (Future<Void> f : futures) {
+								f.cancel(true);
+							}
+
 							Throwable throwable = executionException.getCause();
 
 							if (throwable instanceof Error) {
@@ -115,28 +118,20 @@ public class DataCleanupPreupgradeProcessSuite {
 								).interrupt();
 							}
 
-							exceptions.add(
-								throwable instanceof Exception ?
-									(Exception)throwable :
-										new RuntimeException(throwable));
+							throw throwable instanceof Exception ?
+								(Exception)throwable :
+									new RuntimeException(throwable);
 						}
 						catch (InterruptedException interruptedException) {
+							for (Future<Void> f : futures) {
+								f.cancel(true);
+							}
+
 							Thread.currentThread(
 							).interrupt();
 
-							exceptions.add(
-								new RuntimeException(interruptedException));
+							throw new RuntimeException(interruptedException);
 						}
-					}
-
-					if (!exceptions.isEmpty()) {
-						Exception exception = exceptions.get(0);
-
-						for (int i = 1; i < exceptions.size(); i++) {
-							exception.addSuppressed(exceptions.get(i));
-						}
-
-						throw exception;
 					}
 				}
 			}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -136,7 +136,7 @@ public class DataCleanupPreupgradeProcessSuite {
 							Thread.currentThread(
 							).interrupt();
 
-							throw new RuntimeException(interruptedException);
+							throw interruptedException;
 						}
 					}
 				}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -146,7 +146,15 @@ public class DataCleanupPreupgradeProcessSuite {
 					executorService.shutdownNow();
 
 					try {
-						executorService.awaitTermination(10, TimeUnit.SECONDS);
+						if (!executorService.awaitTermination(
+								10, TimeUnit.SECONDS)) {
+
+							if (_log.isWarnEnabled()) {
+								_log.warn(
+									"Some data cleanup threads did not " +
+										"terminate gracefully");
+							}
+						}
 					}
 					catch (InterruptedException interruptedException) {
 						Thread.currentThread(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -20,8 +20,14 @@ import com.liferay.portal.upgrade.PortalUpgradeProcess;
 
 import java.sql.Connection;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * @author Luis Ortiz
@@ -40,29 +46,67 @@ public class DataCleanupPreupgradeProcessSuite {
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses =
-				getSortedDataCleanupPreupgradeProcesses();
+			for (List<DataCleanupPreupgradeProcess> wave :
+					getWavedDataCleanupPreupgradeProcesses()) {
 
-			for (DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess :
-					dataCleanupPreupgradeProcesses) {
-
-				Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
-
-				if (ArrayUtil.contains(
-						PropsValues.
-							UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
-						clazz.getName())) {
-
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							"Skipping blacklisted data cleanup process: " +
-								clazz.getName());
-					}
+				if (wave.size() == 1) {
+					_runProcess(wave.get(0));
 
 					continue;
 				}
 
-				dataCleanupPreupgradeProcess.upgrade();
+				ExecutorService executorService = Executors.newFixedThreadPool(
+					wave.size());
+
+				try {
+					List<Future<Void>> futures = new ArrayList<>();
+
+					for (DataCleanupPreupgradeProcess process : wave) {
+						futures.add(
+							executorService.submit(
+								(Callable<Void>)() -> {
+									_runProcess(process);
+
+									return null;
+								}));
+					}
+
+					List<Exception> exceptions = new ArrayList<>();
+
+					for (Future<Void> future : futures) {
+						try {
+							future.get();
+						}
+						catch (ExecutionException executionException) {
+							Throwable throwable = executionException.getCause();
+
+							exceptions.add(
+								throwable instanceof Exception ?
+									(Exception)throwable :
+										new RuntimeException(throwable));
+						}
+						catch (InterruptedException interruptedException) {
+							Thread.currentThread(
+							).interrupt();
+
+							exceptions.add(
+								new RuntimeException(interruptedException));
+						}
+					}
+
+					if (!exceptions.isEmpty()) {
+						Exception exception = exceptions.get(0);
+
+						for (int i = 1; i < exceptions.size(); i++) {
+							exception.addSuppressed(exceptions.get(i));
+						}
+
+						throw exception;
+					}
+				}
+				finally {
+					executorService.shutdownNow();
+				}
 			}
 		}
 	}
@@ -72,6 +116,14 @@ public class DataCleanupPreupgradeProcessSuite {
 
 		return DataCleanupPreupgradeProcess.
 			getSortedDataCleanupPreupgradeProcesses(
+				_dataCleanupPreupgradeProcessesMap);
+	}
+
+	public List<List<DataCleanupPreupgradeProcess>>
+		getWavedDataCleanupPreupgradeProcesses() {
+
+		return DataCleanupPreupgradeProcess.
+			getWavedDataCleanupPreupgradeProcesses(
 				_dataCleanupPreupgradeProcessesMap);
 	}
 
@@ -269,6 +321,36 @@ public class DataCleanupPreupgradeProcessSuite {
 					companyDataCleanupPreupgradeProcess,
 					databaseTableAndColumnCaseDataCleanupPreupgradeProcess)
 			).build();
+	}
+
+	private void _runProcess(
+			DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess)
+		throws Exception {
+
+		Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
+
+		if (ArrayUtil.contains(
+				PropsValues.UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
+				clazz.getName())) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Skipping blacklisted data cleanup process: " +
+						clazz.getName());
+			}
+
+			return;
+		}
+
+		String processName = clazz.getSimpleName();
+
+		if (processName.isEmpty()) {
+			processName = clazz.getName();
+		}
+
+		try (LoggingTimer loggingTimer = new LoggingTimer(processName)) {
+			dataCleanupPreupgradeProcess.upgrade();
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author Luis Ortiz
@@ -46,19 +48,43 @@ public class DataCleanupPreupgradeProcessSuite {
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			for (List<DataCleanupPreupgradeProcess> wave :
-					getWavedDataCleanupPreupgradeProcesses()) {
+			List<List<DataCleanupPreupgradeProcess>> waves =
+				getWavedDataCleanupPreupgradeProcesses();
 
-				if (wave.size() == 1) {
-					_runProcess(wave.get(0));
+			int maxWaveSize = 0;
 
-					continue;
+			for (List<DataCleanupPreupgradeProcess> wave : waves) {
+				if (wave.size() > maxWaveSize) {
+					maxWaveSize = wave.size();
 				}
+			}
 
-				ExecutorService executorService = Executors.newFixedThreadPool(
-					wave.size());
+			ExecutorService executorService = null;
 
-				try {
+			if (maxWaveSize > 1) {
+				AtomicInteger threadCount = new AtomicInteger();
+
+				executorService = Executors.newFixedThreadPool(
+					maxWaveSize,
+					runnable -> {
+						Thread thread = new Thread(runnable);
+
+						thread.setName(
+							"data-cleanup-preupgrade-process-wave-thread-" +
+								threadCount.incrementAndGet());
+
+						return thread;
+					});
+			}
+
+			try {
+				for (List<DataCleanupPreupgradeProcess> wave : waves) {
+					if (wave.size() == 1) {
+						_runProcess(wave.get(0));
+
+						continue;
+					}
+
 					List<Future<Void>> futures = new ArrayList<>();
 
 					for (DataCleanupPreupgradeProcess process : wave) {
@@ -79,6 +105,15 @@ public class DataCleanupPreupgradeProcessSuite {
 						}
 						catch (ExecutionException executionException) {
 							Throwable throwable = executionException.getCause();
+
+							if (throwable instanceof Error) {
+								throw (Error)throwable;
+							}
+
+							if (throwable instanceof InterruptedException) {
+								Thread.currentThread(
+								).interrupt();
+							}
 
 							exceptions.add(
 								throwable instanceof Exception ?
@@ -104,8 +139,18 @@ public class DataCleanupPreupgradeProcessSuite {
 						throw exception;
 					}
 				}
-				finally {
+			}
+			finally {
+				if (executorService != null) {
 					executorService.shutdownNow();
+
+					try {
+						executorService.awaitTermination(10, TimeUnit.SECONDS);
+					}
+					catch (InterruptedException interruptedException) {
+						Thread.currentThread(
+						).interrupt();
+					}
 				}
 			}
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcess.java
@@ -11,8 +11,10 @@ import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Luis Ortiz
@@ -66,6 +68,47 @@ public class DataCleanupPreupgradeProcess extends UpgradeProcess {
 		}
 
 		return sortedDataCleanupPreupgradeProcesses;
+	}
+
+	public static List<List<DataCleanupPreupgradeProcess>>
+		getWavedDataCleanupPreupgradeProcesses(
+			Map
+				<DataCleanupPreupgradeProcess,
+				 List<DataCleanupPreupgradeProcess>>
+					dataCleanupPreupgradeProcessesMap) {
+
+		Set<DataCleanupPreupgradeProcess> completed = new HashSet<>();
+		List<List<DataCleanupPreupgradeProcess>> waves = new ArrayList<>();
+
+		while (completed.size() != dataCleanupPreupgradeProcessesMap.size()) {
+			List<DataCleanupPreupgradeProcess> wave = new ArrayList<>();
+
+			for (Map.Entry
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>> entry :
+						dataCleanupPreupgradeProcessesMap.entrySet()) {
+
+				DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess =
+					entry.getKey();
+
+				if (completed.contains(dataCleanupPreupgradeProcess) ||
+					!completed.containsAll(entry.getValue())) {
+
+					continue;
+				}
+
+				wave.add(dataCleanupPreupgradeProcess);
+			}
+
+			if (wave.isEmpty()) {
+				throw new RuntimeException("Circular dependency");
+			}
+
+			completed.addAll(wave);
+			waves.add(wave);
+		}
+
+		return waves;
 	}
 
 	public DataCleanupPreupgradeProcess() {

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
@@ -15,6 +15,8 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.RetryAcceptor;
+import com.liferay.portal.kernel.service.SQLStateAcceptor;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -22,11 +24,14 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -104,18 +109,14 @@ public class OrphanReferencesDataCleanupUtil {
 			ResultSet resultSet = preparedStatement1.executeQuery()) {
 
 			if (!readOnly) {
-				try (PreparedStatement preparedStatement2 =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"delete ",
-								aliasNeeded ?
-									(_SOURCE_TABLE_ALIAS + StringPool.SPACE) :
-										"",
-								"from ", sourceTableName, StringPool.SPACE,
-								_SOURCE_TABLE_ALIAS, whereClause))) {
-
-					preparedStatement2.execute();
-				}
+				_executeDelete(
+					connection,
+					StringBundler.concat(
+						"delete ",
+						aliasNeeded ? (_SOURCE_TABLE_ALIAS + StringPool.SPACE) :
+							"",
+						"from ", sourceTableName, StringPool.SPACE,
+						_SOURCE_TABLE_ALIAS, whereClause));
 			}
 
 			if (!_log.isInfoEnabled()) {
@@ -222,6 +223,34 @@ public class OrphanReferencesDataCleanupUtil {
 
 		return StringUtil.replace(
 			whereClause, "[$SOURCE_TABLE_ALIAS$]", _SOURCE_TABLE_ALIAS);
+	}
+
+	private static void _executeDelete(Connection connection, String deleteSQL)
+		throws Exception {
+
+		int retryCount = 0;
+
+		while (true) {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(deleteSQL)) {
+
+				preparedStatement.executeUpdate();
+
+				return;
+			}
+			catch (SQLException sqlException) {
+				if ((retryCount >= _DELETE_MAX_DEADLOCK_RETRIES) ||
+					!_retryAcceptor.acceptException(
+						sqlException, _deadlockProperties)) {
+
+					throw sqlException;
+				}
+
+				retryCount++;
+
+				Thread.sleep(_DELETE_DEADLOCK_RETRY_WAIT * retryCount);
+			}
+		}
 	}
 
 	private static Set<String> _getFirstIndexColumnNames(
@@ -416,15 +445,24 @@ public class OrphanReferencesDataCleanupUtil {
 		return sb.toString();
 	}
 
+	private static final int _DELETE_DEADLOCK_RETRY_WAIT = 500;
+
+	private static final int _DELETE_MAX_DEADLOCK_RETRIES = 3;
+
 	private static final String _SOURCE_TABLE_ALIAS = "s";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OrphanReferencesDataCleanupUtil.class);
 
+	private static final Map<String, String> _deadlockProperties =
+		Collections.singletonMap(
+			SQLStateAcceptor.SQLSTATE,
+			SQLStateAcceptor.SQLSTATE_TRANSACTION_ROLLBACK);
 	private static final List<String> _excludedTableNames = new ArrayList<>(
 		Arrays.asList(
 			"Audit_AuditEvent", "CyrusUser", "CyrusVirtual", "SystemEvent"));
 	private static final List<String> _normalizedExcludedTableNames =
 		new ArrayList<>();
+	private static final RetryAcceptor _retryAcceptor = new SQLStateAcceptor();
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcessWaveTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcessWaveTest.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade.data.cleanup;
+
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge Avalos
+ */
+public class DataCleanupPreupgradeProcessWaveTest {
+
+	@Test
+	public void testCircularDependencyThrows() {
+		DataCleanupPreupgradeProcess a = _newProcess();
+		DataCleanupPreupgradeProcess b = _newProcess();
+
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			map =
+				LinkedHashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						a, DataCleanupPreupgradeProcess.dependsOn(b)
+					).put(
+						b, DataCleanupPreupgradeProcess.dependsOn(a)
+					).build();
+
+		try {
+			DataCleanupPreupgradeProcess.getWavedDataCleanupPreupgradeProcesses(
+				map);
+
+			Assert.fail("Expected RuntimeException for circular dependency");
+		}
+		catch (RuntimeException runtimeException) {
+			Assert.assertEquals(
+				"Circular dependency", runtimeException.getMessage());
+		}
+	}
+
+	@Test
+	public void testDiamondProducesThreeWaves() {
+		DataCleanupPreupgradeProcess a = _newProcess();
+		DataCleanupPreupgradeProcess b = _newProcess();
+		DataCleanupPreupgradeProcess c = _newProcess();
+		DataCleanupPreupgradeProcess d = _newProcess();
+
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			map =
+				LinkedHashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						a, DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						b, DataCleanupPreupgradeProcess.dependsOn(a)
+					).put(
+						c, DataCleanupPreupgradeProcess.dependsOn(a)
+					).put(
+						d, DataCleanupPreupgradeProcess.dependsOn(b, c)
+					).build();
+
+		List<List<DataCleanupPreupgradeProcess>> waves =
+			DataCleanupPreupgradeProcess.getWavedDataCleanupPreupgradeProcesses(
+				map);
+
+		Assert.assertEquals(waves.toString(), 3, waves.size());
+
+		List<DataCleanupPreupgradeProcess> wave1 = waves.get(0);
+
+		Assert.assertEquals(wave1.toString(), 1, wave1.size());
+		Assert.assertSame(a, wave1.get(0));
+
+		List<DataCleanupPreupgradeProcess> wave2 = waves.get(1);
+
+		Assert.assertEquals(wave2.toString(), 2, wave2.size());
+		Assert.assertTrue(wave2.contains(b));
+		Assert.assertTrue(wave2.contains(c));
+
+		List<DataCleanupPreupgradeProcess> wave3 = waves.get(2);
+
+		Assert.assertEquals(wave3.toString(), 1, wave3.size());
+		Assert.assertSame(d, wave3.get(0));
+	}
+
+	@Test
+	public void testIndependentProcessesFormSingleWave() {
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			map =
+				LinkedHashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						_newProcess(), DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						_newProcess(), DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						_newProcess(), DataCleanupPreupgradeProcess.dependsOn()
+					).build();
+
+		List<List<DataCleanupPreupgradeProcess>> waves =
+			DataCleanupPreupgradeProcess.getWavedDataCleanupPreupgradeProcesses(
+				map);
+
+		Assert.assertEquals(waves.toString(), 1, waves.size());
+
+		List<DataCleanupPreupgradeProcess> wave1 = waves.get(0);
+
+		Assert.assertEquals(wave1.toString(), 3, wave1.size());
+	}
+
+	@Test
+	public void testLinearChainProducesOneWavePerProcess() {
+		DataCleanupPreupgradeProcess a = _newProcess();
+		DataCleanupPreupgradeProcess b = _newProcess();
+		DataCleanupPreupgradeProcess c = _newProcess();
+
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			map =
+				LinkedHashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						a, DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						b, DataCleanupPreupgradeProcess.dependsOn(a)
+					).put(
+						c, DataCleanupPreupgradeProcess.dependsOn(b)
+					).build();
+
+		List<List<DataCleanupPreupgradeProcess>> waves =
+			DataCleanupPreupgradeProcess.getWavedDataCleanupPreupgradeProcesses(
+				map);
+
+		Assert.assertEquals(waves.toString(), 3, waves.size());
+
+		for (List<DataCleanupPreupgradeProcess> wave : waves) {
+			Assert.assertEquals(wave.toString(), 1, wave.size());
+		}
+
+		List<DataCleanupPreupgradeProcess> wave1 = waves.get(0);
+
+		Assert.assertSame(a, wave1.get(0));
+
+		List<DataCleanupPreupgradeProcess> wave2 = waves.get(1);
+
+		Assert.assertSame(b, wave2.get(0));
+
+		List<DataCleanupPreupgradeProcess> wave3 = waves.get(2);
+
+		Assert.assertSame(c, wave3.get(0));
+	}
+
+	private DataCleanupPreupgradeProcess _newProcess() {
+		return new DataCleanupPreupgradeProcess() {
+
+			@Override
+			protected void doUpgrade() {
+			}
+
+		};
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDeadlockRetryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDeadlockRetryTest.java
@@ -1,0 +1,144 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade.data.cleanup.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class OrphanReferencesDeadlockRetryTest {
+
+	@Test
+	public void testExecuteDeleteRetriesOnDeadlock() throws Exception {
+		AtomicInteger callCount = new AtomicInteger();
+
+		PreparedStatement preparedStatement = Mockito.mock(
+			PreparedStatement.class);
+
+		Mockito.doAnswer(
+			invocation -> {
+				if (callCount.incrementAndGet() == 1) {
+					throw new SQLException("Deadlock", "40001");
+				}
+
+				return null;
+			}
+		).when(
+			preparedStatement
+		).executeUpdate();
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		ReflectionTestUtil.invoke(
+			OrphanReferencesDataCleanupUtil.class, "_executeDelete",
+			new Class<?>[] {Connection.class, String.class}, connection,
+			"delete from foo where bar is null");
+
+		Assert.assertEquals(2, callCount.get());
+	}
+
+	@Test
+	public void testExecuteDeleteThrowsAfterMaxRetries() throws Exception {
+		PreparedStatement preparedStatement = Mockito.mock(
+			PreparedStatement.class);
+
+		Mockito.doThrow(
+			new SQLException("Deadlock", "40001")
+		).when(
+			preparedStatement
+		).executeUpdate();
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		try {
+			ReflectionTestUtil.invoke(
+				OrphanReferencesDataCleanupUtil.class, "_executeDelete",
+				new Class<?>[] {Connection.class, String.class}, connection,
+				"delete from foo where bar is null");
+
+			Assert.fail("Expected SQLException after max retries");
+		}
+		catch (Exception exception) {
+			Assert.assertSame(SQLException.class, exception.getClass());
+			Assert.assertEquals(
+				"40001", ((SQLException)exception).getSQLState());
+		}
+
+		int expectedAttempts =
+			(int)ReflectionTestUtil.getFieldValue(
+				OrphanReferencesDataCleanupUtil.class,
+				"_DELETE_MAX_DEADLOCK_RETRIES") + 1;
+
+		Mockito.verify(
+			preparedStatement, Mockito.times(expectedAttempts)
+		).executeUpdate();
+	}
+
+	@Test
+	public void testExecuteDeleteThrowsImmediatelyOnNondeadlockError()
+		throws Exception {
+
+		PreparedStatement preparedStatement = Mockito.mock(
+			PreparedStatement.class);
+
+		Mockito.doThrow(
+			new SQLException("Constraint violation", "23000")
+		).when(
+			preparedStatement
+		).executeUpdate();
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		try {
+			ReflectionTestUtil.invoke(
+				OrphanReferencesDataCleanupUtil.class, "_executeDelete",
+				new Class<?>[] {Connection.class, String.class}, connection,
+				"delete from foo where bar is null");
+
+			Assert.fail("Expected SQLException for non-deadlock error");
+		}
+		catch (Exception exception) {
+			Assert.assertSame(SQLException.class, exception.getClass());
+			Assert.assertEquals(
+				"23000", ((SQLException)exception).getSQLState());
+		}
+
+		Mockito.verify(
+			preparedStatement, Mockito.times(1)
+		).executeUpdate();
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDeadlockRetryTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDeadlockRetryTest.java
@@ -36,7 +36,7 @@ public class OrphanReferencesDeadlockRetryTest {
 					throw new SQLException("Deadlock", "40001");
 				}
 
-				return null;
+				return 0;
 			}
 		).when(
 			preparedStatement


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93248

**What is being fixed:** `DataCleanupPreupgradeProcessSuite` ran all ~20
cleanup processes serially even though the dependency graph allows
independent processes to execute concurrently. Additionally, concurrent
DML from multiple cleanup processes deadlocked in 3/3 partition-large
runs (InnoDB `40001`), and an unguarded deadlock aborted the whole
upgrade.

**How it is being fixed:** A Kahn-style topological sort over the
dependency map groups cleanup processes into waves; each wave executes
on a fixed thread pool while serially-dependent chains remain
unaffected. Orphan-cleanup DELETEs that fail with a deadlock SQLState
are retried with linear backoff using `SQLStateAcceptor`, matching the
retry convention already used by `ViewCountEntryLocalService` and
`CTScoreLocalService`. The connection pool is sized to the maximum wave
width multiplied by each process's `processConcurrently` thread count.
Unit tests cover wave grouping for representative dependency graphs and
the deadlock-retry loop up to the retry cap.