### PR TITLE
LPD-93239 Compute counter max server-side and run cleanup concurrently

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
@@ -248,6 +248,50 @@ public class CounterDataCleanupPreupgradeProcessTest
 	}
 
 	@Test
+	public void testUpgradeDLFileEntrySpecificCounterFilters()
+		throws Exception {
+
+		long fileEntryId1 = CounterLocalServiceUtil.increment();
+		long fileEntryId2 = CounterLocalServiceUtil.increment();
+		long fileEntryId3 = CounterLocalServiceUtil.increment();
+		long name =
+			CounterLocalServiceUtil.getCurrentId(DLFileEntry.class.getName()) +
+				100;
+
+		_test(
+			(UnsafeRunnable<Exception>)() -> runSQL(
+				StringBundler.concat(
+					"delete from DLFileEntry where fileEntryId in (",
+					fileEntryId1, ", ", fileEntryId2, ", ", fileEntryId3, ")")),
+			(UnsafeRunnable<Exception>)() -> {
+				runSQL(
+					StringBundler.concat(
+						"insert into DLFileEntry (mvccVersion, ",
+						"ctCollectionId, fileEntryId, name) values (0, 0,",
+						fileEntryId1, ", '", name, "')"));
+				runSQL(
+					StringBundler.concat(
+						"insert into DLFileEntry (mvccVersion, ",
+						"ctCollectionId, fileEntryId, name) values (0, 0,",
+						fileEntryId2, ", 'non-numeric')"));
+				runSQL(
+					StringBundler.concat(
+						"insert into DLFileEntry (mvccVersion, ",
+						"ctCollectionId, fileEntryId, name) values (0, 0,",
+						fileEntryId3, ", '99999999999999999999')"));
+			},
+			(UnsafeConsumer<List<String>, Exception>)messages -> {
+				Assert.assertEquals(messages.toString(), 1, messages.size());
+				Assert.assertTrue(
+					messages.toString(),
+					messages.contains(
+						StringBundler.concat(
+							"Counter ", DLFileEntry.class.getName(),
+							" has been reset to value ", name)));
+			});
+	}
+
+	@Test
 	public void testUpgradeKernelCounter() throws Exception {
 		long roleId =
 			CounterLocalServiceUtil.getCurrentId(Counter.class.getName()) +

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -10,7 +10,10 @@ import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -25,7 +28,9 @@ import java.sql.ResultSet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -115,7 +120,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 				if (!dbInspector.hasTable(tableName)) {
 					if (_log.isWarnEnabled()) {
-						_log.warn("Table " + tableName + " does not exist");
+						_log.warn("Table \"" + tableName + "\" does not exist");
 					}
 
 					continue;
@@ -146,31 +151,45 @@ public class CounterDataCleanupPreupgradeProcess
 		tableNames.remove(dbInspector.normalizeName("Counter"));
 		tableNames.removeAll(excludedTableNames);
 
+		Map<String, Long> tableMaxValues = new ConcurrentHashMap<>();
+
+		processConcurrently(
+			tableNames.toArray(new String[0]),
+			tableName -> {
+				if (!dbInspector.isObjectTable(tableName) &&
+					!_liferayTableNames.contains(tableName)) {
+
+					return;
+				}
+
+				String columnName =
+					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
+						connection, dbInspector, tableName);
+
+				if ((columnName == null) ||
+					!dbInspector.isNumeric(tableName, columnName)) {
+
+					return;
+				}
+
+				long maxValue = _getMaxValue(
+					columnName, dbInspector, tableName);
+
+				if (maxValue > 0) {
+					tableMaxValues.put(tableName, maxValue);
+				}
+			},
+			null);
+
 		long latestCounterValue = 0L;
 		String maxValueTableName = null;
 
-		for (String tableName : tableNames) {
-			if (!dbInspector.isObjectTable(tableName) &&
-				!_liferayTableNames.contains(tableName)) {
+		for (Map.Entry<String, Long> entry : tableMaxValues.entrySet()) {
+			long value = entry.getValue();
 
-				continue;
-			}
-
-			String columnName =
-				DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
-					connection, dbInspector, tableName);
-
-			if ((columnName == null) ||
-				!dbInspector.isNumeric(tableName, columnName)) {
-
-				continue;
-			}
-
-			long maxValue = _getMaxValue(columnName, dbInspector, tableName);
-
-			if (maxValue > latestCounterValue) {
-				latestCounterValue = maxValue;
-				maxValueTableName = tableName;
+			if (value > latestCounterValue) {
+				latestCounterValue = value;
+				maxValueTableName = entry.getKey();
 			}
 		}
 
@@ -205,7 +224,7 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.hasTable("Layout")) {
-			_log.error("Table Layout does not exist");
+			_log.error("Table \"Layout\" does not exist");
 
 			return;
 		}
@@ -289,10 +308,10 @@ public class CounterDataCleanupPreupgradeProcess
 	}
 
 	private String _getLogMessage(
-		String counterName, long countervalue, String tableName) {
+		String counterName, long counterValue, String tableName) {
 
 		return StringBundler.concat(
-			"Counter ", counterName, " has been reset to value ", countervalue,
+			"Counter ", counterName, " has been reset to value ", counterValue,
 			(tableName != null) ? " due to table " + tableName : "");
 	}
 
@@ -301,6 +320,123 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
+			DB db = DBManagerUtil.getDB();
+
+			DBType dbType = db.getDBType();
+
+			if (dbType == DBType.DB2) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName, " where regexp_like(", columnName,
+								", '^[0-9]+$')"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as unsigned)) as ", columnName, " from ",
+								tableName, " where ", columnName,
+								" regexp '^[0-9]+$'"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.ORACLE) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(to_number(", columnName, ")) as ",
+								columnName, " from ", tableName, " where ",
+								"regexp_like(", columnName, ", '^[0-9]+$')"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.POSTGRESQL) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName, " where ", columnName,
+								" ~ '^[0-9]+$'"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.SQLSERVER) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(try_cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
 			long maxValue = 0;
 
 			try (PreparedStatement preparedStatement =
@@ -311,13 +447,13 @@ public class CounterDataCleanupPreupgradeProcess
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					String value = resultSet.getString(columnName);
+					String valueString = resultSet.getString(columnName);
 
 					try {
-						long valueLong = Long.parseLong(value);
+						long value = Long.parseLong(valueString);
 
-						if (valueLong > maxValue) {
-							maxValue = valueLong;
+						if (value > maxValue) {
+							maxValue = value;
 						}
 					}
 					catch (NumberFormatException numberFormatException) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -120,7 +120,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 				if (!dbInspector.hasTable(tableName)) {
 					if (_log.isWarnEnabled()) {
-						_log.warn("Table \"" + tableName + "\" does not exist");
+						_log.warn("Table " + tableName + " does not exist");
 					}
 
 					continue;
@@ -308,10 +308,10 @@ public class CounterDataCleanupPreupgradeProcess
 	}
 
 	private String _getLogMessage(
-		String counterName, long counterValue, String tableName) {
+		String counterName, long countervalue, String tableName) {
 
 		return StringBundler.concat(
-			"Counter ", counterName, " has been reset to value ", counterValue,
+			"Counter ", counterName, " has been reset to value ", countervalue,
 			(tableName != null) ? " due to table " + tableName : "");
 	}
 
@@ -324,105 +324,11 @@ public class CounterDataCleanupPreupgradeProcess
 
 			DBType dbType = db.getDBType();
 
-			if (dbType == DBType.DB2) {
+			String sql = _getMaxValueSQL(columnName, dbType, tableName);
+
+			if (sql != null) {
 				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(cast(", columnName,
-								" as bigint)) as ", columnName, " from ",
-								tableName, " where regexp_like(", columnName,
-								", '^[0-9]{1,18}$')"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(cast(", columnName,
-								" as unsigned)) as ", columnName, " from ",
-								tableName, " where ", columnName,
-								" regexp '^[0-9]{1,18}$'"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if (dbType == DBType.ORACLE) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(to_number(", columnName, ")) as ",
-								columnName, " from ", tableName, " where ",
-								"regexp_like(", columnName,
-								", '^[0-9]{1,18}$')"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if (dbType == DBType.POSTGRESQL) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(cast(", columnName,
-								" as bigint)) as ", columnName, " from ",
-								tableName, " where ", columnName,
-								" ~ '^[0-9]{1,18}$'"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if (dbType == DBType.SQLSERVER) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(try_cast(", columnName,
-								" as bigint)) as ", columnName, " from ",
-								tableName));
+						connection.prepareStatement(sql);
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -448,13 +354,13 @@ public class CounterDataCleanupPreupgradeProcess
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					String valueString = resultSet.getString(columnName);
+					String value = resultSet.getString(columnName);
 
 					try {
-						long value = Long.parseLong(valueString);
+						long valueLong = Long.parseLong(value);
 
-						if (value > maxValue) {
-							maxValue = value;
+						if (valueLong > maxValue) {
+							maxValue = valueLong;
 						}
 					}
 					catch (NumberFormatException numberFormatException) {
@@ -481,6 +387,46 @@ public class CounterDataCleanupPreupgradeProcess
 		}
 
 		return 0L;
+	}
+
+	private String _getMaxValueSQL(
+		String columnName, DBType dbType, String tableName) {
+
+		if (dbType == DBType.DB2) {
+			return StringBundler.concat(
+				"select max(cast(", columnName, " as bigint)) as ", columnName,
+				" from ", tableName, " where regexp_like(", columnName,
+				", '^[0-9]{1,18}$')");
+		}
+
+		if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+			return StringBundler.concat(
+				"select max(cast(", columnName, " as unsigned)) as ", columnName,
+				" from ", tableName, " where ", columnName,
+				" regexp '^[0-9]{1,18}$'");
+		}
+
+		if (dbType == DBType.ORACLE) {
+			return StringBundler.concat(
+				"select max(to_number(", columnName, ")) as ", columnName,
+				" from ", tableName, " where regexp_like(", columnName,
+				", '^[0-9]{1,18}$')");
+		}
+
+		if (dbType == DBType.POSTGRESQL) {
+			return StringBundler.concat(
+				"select max(cast(", columnName, " as bigint)) as ", columnName,
+				" from ", tableName, " where ", columnName,
+				" ~ '^[0-9]{1,18}$'");
+		}
+
+		if (dbType == DBType.SQLSERVER) {
+			return StringBundler.concat(
+				"select max(try_cast(", columnName, " as bigint)) as ",
+				columnName, " from ", tableName);
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -321,7 +321,6 @@ public class CounterDataCleanupPreupgradeProcess
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
 			DB db = DBManagerUtil.getDB();
-
 			DBType dbType = db.getDBType();
 
 			if (dbType == DBType.DB2) {
@@ -331,7 +330,7 @@ public class CounterDataCleanupPreupgradeProcess
 								"select max(cast(", columnName,
 								" as bigint)) as ", columnName, " from ",
 								tableName, " where regexp_like(", columnName,
-								", '^[0-9]+$')"));
+								", '^[0-9]{1,18}$')"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -354,7 +353,7 @@ public class CounterDataCleanupPreupgradeProcess
 								"select max(cast(", columnName,
 								" as unsigned)) as ", columnName, " from ",
 								tableName, " where ", columnName,
-								" regexp '^[0-9]+$'"));
+								" regexp '^[0-9]{1,18}$'"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -376,7 +375,8 @@ public class CounterDataCleanupPreupgradeProcess
 							StringBundler.concat(
 								"select max(to_number(", columnName, ")) as ",
 								columnName, " from ", tableName, " where ",
-								"regexp_like(", columnName, ", '^[0-9]+$')"));
+								"regexp_like(", columnName,
+								", '^[0-9]{1,18}$')"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -399,7 +399,7 @@ public class CounterDataCleanupPreupgradeProcess
 								"select max(cast(", columnName,
 								" as bigint)) as ", columnName, " from ",
 								tableName, " where ", columnName,
-								" ~ '^[0-9]+$'"));
+								" ~ '^[0-9]{1,18}$'"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -321,6 +321,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
 			DB db = DBManagerUtil.getDB();
+
 			DBType dbType = db.getDBType();
 
 			if (dbType == DBType.DB2) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -224,7 +224,7 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.hasTable("Layout")) {
-			_log.error("Table \"Layout\" does not exist");
+			_log.error("Table Layout does not exist");
 
 			return;
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93239

**What is being fixed:** The counter data cleanup pre-upgrade process was
computing the maximum counter value entirely in Java — fetching every row
of every table with a non-numeric primary key column and calling
Long.parseLong on each value. For large tables this wastes memory and is
slow. The sequential per-table loop also serialized work that is
independent across tables.

**How it is being fixed:** The table scan is rewritten to use
processConcurrently so all tables are queried in parallel, with results
collected into a ConcurrentHashMap. For non-numeric columns the code now
issues a DB-native query (DB2, MariaDB/MySQL, Oracle, PostgreSQL, SQL
Server each get a dialect-appropriate cast + regex filter) that returns
the max value directly, falling back to the original Java-side parse only
for unrecognized DB types. A new integration test covers the DLFileEntry
counter case including non-numeric and overflowing name values to confirm
they are filtered correctly.