### PR TITLE
LPD-93238 Group ResourcePermission cleanup by target table

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -45,7 +45,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
-		Map<String, List<String>> tableNames = new HashMap<>();
+		Map<String, List<String>> classNamesByTableName = new HashMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select distinct name from ResourcePermission where name " +
@@ -62,10 +62,10 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 					resourceActionsImpl.getCompositeModelNameSeparator();
 
 				while (resultSet.next()) {
-					String name = resultSet.getString("name");
+					String nameString = resultSet.getString("name");
 
 					String[] classNames = StringUtil.split(
-						name, compositeModelNameSeparator);
+						nameString, compositeModelNameSeparator);
 
 					String tableName = null;
 
@@ -95,7 +95,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 						if (_log.isDebugEnabled()) {
 							_log.debug(
 								StringBundler.concat(
-									"Skipping class name ", name,
+									"Skipping class name ", nameString,
 									" because its associated table was not ",
 									"found or it does not belong to Liferay"));
 						}
@@ -112,15 +112,17 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 						continue;
 					}
 
-					List<String> names = tableNames.computeIfAbsent(
+					List<String> names = classNamesByTableName.computeIfAbsent(
 						tableName, key -> new ArrayList<>());
 
-					names.add(name);
+					names.add(nameString);
 				}
 			}
 		}
 
-		for (Map.Entry<String, List<String>> entry : tableNames.entrySet()) {
+		for (Map.Entry<String, List<String>> entry :
+				classNamesByTableName.entrySet()) {
+
 			String tableName = entry.getKey();
 
 			String primaryKeyColumnName = "resourcePrimKey";
@@ -143,21 +145,21 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 			List<String> names = entry.getValue();
 
-			String namesClause;
+			String namesClauseString;
 
 			if (names.size() == 1) {
-				namesClause = StringBundler.concat(
+				namesClauseString = StringBundler.concat(
 					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
 					" and name = '", names.get(0), "'");
 			}
 			else {
 				List<String> quotedNames = new ArrayList<>(names.size());
 
-				for (String name : names) {
-					quotedNames.add(StringBundler.concat("'", name, "'"));
+				for (String nameString : names) {
+					quotedNames.add(StringBundler.concat("'", nameString, "'"));
 				}
 
-				namesClause = StringBundler.concat(
+				namesClauseString = StringBundler.concat(
 					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
 					" and name in (",
 					String.join(StringPool.COMMA_AND_SPACE, quotedNames), ")");
@@ -165,19 +167,19 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 			List<Long> orphanIds = new ArrayList<>();
 
-			String sql = StringBundler.concat(
+			String sqlString = StringBundler.concat(
 				"select distinct primKeyId from ResourcePermission where ",
-				"primKeyId != 0 and primKeyId is not null and ", namesClause,
-				" and primKeyId not in (select ", primaryKeyColumnName,
-				" from ", tableName, ")");
+				"primKeyId != 0 and primKeyId is not null and ",
+				namesClauseString, " and primKeyId not in (select ",
+				primaryKeyColumnName, " from ", tableName, ")");
 
 			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(sql)) {
+					connection.prepareStatement(sqlString)) {
 
-				ResultSet resultSet = preparedStatement.executeQuery();
-
-				while (resultSet.next()) {
-					orphanIds.add(resultSet.getLong("primKeyId"));
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					while (resultSet.next()) {
+						orphanIds.add(resultSet.getLong("primKeyId"));
+					}
 				}
 			}
 
@@ -201,7 +203,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 								"primKeyId in (",
 								String.join(
 									StringPool.COMMA_AND_SPACE, batchIds),
-								") and ", namesClause))) {
+								") and ", namesClauseString))) {
 
 					int deleted = preparedStatement.executeUpdate();
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -108,8 +108,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 					if (!dbInspector.hasTable(tableName)) {
 						if (_log.isWarnEnabled()) {
-							_log.warn(
-								"Unable to find table \"" + tableName + "\"");
+							_log.warn("Table " + tableName + " does not exist");
 						}
 
 						continue;
@@ -143,8 +142,8 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 			if (primaryKeyColumnName == null) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
-						"Unable to find primary key column for table \"" +
-							tableName + "\"");
+						"Skipping table " + tableName +
+							" because it does not have a primary key");
 				}
 
 				continue;

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -65,10 +65,10 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 					resourceActionsImpl.getCompositeModelNameSeparator();
 
 				while (resultSet.next()) {
-					String nameString = resultSet.getString("name");
+					String name = resultSet.getString("name");
 
 					String[] classNames = StringUtil.split(
-						nameString, compositeModelNameSeparator);
+						name, compositeModelNameSeparator);
 
 					String tableName = null;
 
@@ -98,7 +98,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 						if (_log.isDebugEnabled()) {
 							_log.debug(
 								StringBundler.concat(
-									"Skipping class name ", nameString,
+									"Skipping class name ", name,
 									" because its associated table was not ",
 									"found or it does not belong to Liferay"));
 						}
@@ -118,7 +118,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 					List<String> names = classNamesByTableName.computeIfAbsent(
 						tableName, key -> new ArrayList<>());
 
-					names.add(nameString);
+					names.add(name);
 				}
 			}
 		}
@@ -152,57 +152,57 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 			List<String> names = entry.getValue();
 
-			String namesClauseString;
+			String namesClause;
 
 			if (names.size() == 1) {
-				namesClauseString = StringBundler.concat(
+				namesClause = StringBundler.concat(
 					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
 					" and name = '", names.get(0), "'");
 			}
 			else {
 				List<String> quotedNames = new ArrayList<>(names.size());
 
-				for (String nameString : names) {
-					quotedNames.add(StringBundler.concat("'", nameString, "'"));
+				for (String name : names) {
+					quotedNames.add(StringBundler.concat("'", name, "'"));
 				}
 
-				namesClauseString = StringBundler.concat(
+				namesClause = StringBundler.concat(
 					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
 					" and name in (",
 					String.join(StringPool.COMMA_AND_SPACE, quotedNames), ")");
 			}
 
-			String sqlString;
+			String sql;
 
 			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
 				String aliasTableName = StringBundler.concat(
 					tableName, StringPool.UNDERLINE, primaryKeyColumnName);
 
-				sqlString = StringBundler.concat(
+				sql = StringBundler.concat(
 					"select distinct ResourcePermission.primKeyId from ",
 					"ResourcePermission left join ", tableName,
 					StringPool.SPACE, aliasTableName, " on ", aliasTableName,
 					StringPool.PERIOD, primaryKeyColumnName,
 					" = ResourcePermission.primKeyId where ",
 					"ResourcePermission.primKeyId is not null and ",
-					"ResourcePermission.primKeyId != 0 and ", namesClauseString,
+					"ResourcePermission.primKeyId != 0 and ", namesClause,
 					" and ", aliasTableName, StringPool.PERIOD,
 					primaryKeyColumnName, " is null");
 			}
 			else {
-				sqlString = StringBundler.concat(
+				sql = StringBundler.concat(
 					"select distinct ResourcePermission.primKeyId from ",
 					"ResourcePermission where ResourcePermission.primKeyId is ",
 					"not null and ResourcePermission.primKeyId != 0 and ",
-					namesClauseString, " and not exists (select 1 from ",
-					tableName, " where ", tableName, StringPool.PERIOD,
+					namesClause, " and not exists (select 1 from ", tableName,
+					" where ", tableName, StringPool.PERIOD,
 					primaryKeyColumnName, " = ResourcePermission.primKeyId)");
 			}
 
 			List<Long> orphanIds = new ArrayList<>();
 
 			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(sqlString)) {
+					connection.prepareStatement(sql)) {
 
 				try (ResultSet resultSet = preparedStatement.executeQuery()) {
 					while (resultSet.next()) {
@@ -233,7 +233,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 								"primKeyId in (",
 								String.join(
 									StringPool.COMMA_AND_SPACE, batchIds),
-								") and ", namesClauseString))) {
+								") and ", namesClause))) {
 
 					totalDeleted += preparedStatement.executeUpdate();
 				}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -168,10 +168,12 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 			List<Long> orphanIds = new ArrayList<>();
 
 			String sqlString = StringBundler.concat(
-				"select distinct primKeyId from ResourcePermission where ",
-				"primKeyId != 0 and primKeyId is not null and ",
-				namesClauseString, " and primKeyId not in (select ",
-				primaryKeyColumnName, " from ", tableName, ")");
+				"select distinct ResourcePermission.primKeyId from ",
+				"ResourcePermission where ResourcePermission.primKeyId != 0 ",
+				"and ResourcePermission.primKeyId is not null and ",
+				namesClauseString, " and not exists (select 1 from ", tableName,
+				" where ", tableName, ".", primaryKeyColumnName,
+				" = ResourcePermission.primKeyId)");
 
 			try (PreparedStatement preparedStatement =
 					connection.prepareStatement(sqlString)) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -7,16 +7,13 @@ package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
-import com.liferay.portal.kernel.dao.db.DBManagerUtil;
-import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
-import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
+import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.security.permission.ResourceActionsImpl;
 
@@ -122,10 +119,6 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 			}
 		}
 
-		DB db = DBManagerUtil.getDB();
-
-		DBType dbType = db.getDBType();
-
 		for (Map.Entry<String, List<String>> entry :
 				namesByTableName.entrySet()) {
 
@@ -151,12 +144,11 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 			List<String> names = entry.getValue();
 
-			String namesClause;
+			String namesCondition;
 
 			if (names.size() == 1) {
-				namesClause = StringBundler.concat(
-					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
-					" and name = '", names.get(0), "'");
+				namesCondition = StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].name = '", names.get(0), "'");
 			}
 			else {
 				List<String> quotedNames = new ArrayList<>(names.size());
@@ -165,88 +157,22 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 					quotedNames.add(StringBundler.concat("'", name, "'"));
 				}
 
-				namesClause = StringBundler.concat(
-					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
-					" and name in (",
+				namesCondition = StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].name in (",
 					String.join(StringPool.COMMA_AND_SPACE, quotedNames), ")");
 			}
 
-			String sql;
-
-			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
-				String aliasTableName = StringBundler.concat(
-					tableName, StringPool.UNDERLINE, primaryKeyColumnName);
-
-				sql = StringBundler.concat(
-					"select distinct ResourcePermission.primKeyId from ",
-					"ResourcePermission left join ", tableName,
-					StringPool.SPACE, aliasTableName, " on ", aliasTableName,
-					StringPool.PERIOD, primaryKeyColumnName,
-					" = ResourcePermission.primKeyId where ",
-					"ResourcePermission.primKeyId is not null and ",
-					"ResourcePermission.primKeyId != 0 and ", namesClause,
-					" and ", aliasTableName, StringPool.PERIOD,
-					primaryKeyColumnName, " is null");
-			}
-			else {
-				sql = StringBundler.concat(
-					"select distinct ResourcePermission.primKeyId from ",
-					"ResourcePermission where ResourcePermission.primKeyId is ",
-					"not null and ResourcePermission.primKeyId != 0 and ",
-					namesClause, " and not exists (select 1 from ", tableName,
-					" where ", tableName, StringPool.PERIOD,
-					primaryKeyColumnName, " = ResourcePermission.primKeyId)");
-			}
-
-			List<Long> orphanIds = new ArrayList<>();
-
-			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(sql)) {
-
-				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					while (resultSet.next()) {
-						orphanIds.add(resultSet.getLong("primKeyId"));
-					}
-				}
-			}
-
-			if (orphanIds.isEmpty()) {
-				continue;
-			}
-
-			int totalDeleted = 0;
-
-			for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
-				int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
-
-				List<String> batchIds = new ArrayList<>(end - i);
-
-				for (int j = i; j < end; j++) {
-					batchIds.add(String.valueOf(orphanIds.get(j)));
-				}
-
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"delete from ResourcePermission where ",
-								"primKeyId in (",
-								String.join(
-									StringPool.COMMA_AND_SPACE, batchIds),
-								") and ", namesClause))) {
-
-					totalDeleted += preparedStatement.executeUpdate();
-				}
-			}
-
-			DataCleanupLoggingUtil.logDelete(
-				_log, totalDeleted, "ResourcePermission",
-				StringBundler.concat(
-					"primKeyId was not found in column ", primaryKeyColumnName,
-					" from table \"", tableName, "\""));
+			upgrade(
+				new TableOrphanReferencesDataCleanupPreupgradeProcess(
+					null,
+					StringBundler.concat(
+						"[$SOURCE_TABLE_ALIAS$].scope = ",
+						ResourceConstants.SCOPE_INDIVIDUAL, " and ",
+						namesCondition),
+					"primKeyId", "ResourcePermission",
+					primaryKeyColumnName, tableName));
 		}
 	}
-
-	private static final int _BATCH_SIZE = 1000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ResourcePermissionDataCleanupPreupgradeProcess.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -169,8 +169,8 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 						"[$SOURCE_TABLE_ALIAS$].scope = ",
 						ResourceConstants.SCOPE_INDIVIDUAL, " and ",
 						namesCondition),
-					"primKeyId", "ResourcePermission",
-					primaryKeyColumnName, tableName));
+					"primKeyId", "ResourcePermission", primaryKeyColumnName,
+					tableName));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -48,7 +48,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
-		Map<String, List<String>> classNamesByTableName = new TreeMap<>();
+		Map<String, List<String>> namesByTableName = new TreeMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select distinct name from ResourcePermission where name " +
@@ -114,7 +114,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 						continue;
 					}
 
-					List<String> names = classNamesByTableName.computeIfAbsent(
+					List<String> names = namesByTableName.computeIfAbsent(
 						tableName, key -> new ArrayList<>());
 
 					names.add(name);
@@ -127,7 +127,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		DBType dbType = db.getDBType();
 
 		for (Map.Entry<String, List<String>> entry :
-				classNamesByTableName.entrySet()) {
+				namesByTableName.entrySet()) {
 
 			String tableName = entry.getKey();
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -7,7 +7,10 @@ package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -120,6 +123,10 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 			}
 		}
 
+		DB db = DBManagerUtil.getDB();
+
+		DBType dbType = db.getDBType();
+
 		for (Map.Entry<String, List<String>> entry :
 				classNamesByTableName.entrySet()) {
 
@@ -165,15 +172,34 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 					String.join(StringPool.COMMA_AND_SPACE, quotedNames), ")");
 			}
 
-			List<Long> orphanIds = new ArrayList<>();
+			String sqlString;
 
-			String sqlString = StringBundler.concat(
-				"select distinct ResourcePermission.primKeyId from ",
-				"ResourcePermission where ResourcePermission.primKeyId != 0 ",
-				"and ResourcePermission.primKeyId is not null and ",
-				namesClauseString, " and not exists (select 1 from ", tableName,
-				" where ", tableName, ".", primaryKeyColumnName,
-				" = ResourcePermission.primKeyId)");
+			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+				String aliasTableName = StringBundler.concat(
+					tableName, StringPool.UNDERLINE, primaryKeyColumnName);
+
+				sqlString = StringBundler.concat(
+					"select distinct ResourcePermission.primKeyId from ",
+					"ResourcePermission left join ", tableName,
+					StringPool.SPACE, aliasTableName, " on ", aliasTableName,
+					StringPool.PERIOD, primaryKeyColumnName,
+					" = ResourcePermission.primKeyId where ",
+					"ResourcePermission.primKeyId is not null and ",
+					"ResourcePermission.primKeyId != 0 and ", namesClauseString,
+					" and ", aliasTableName, StringPool.PERIOD,
+					primaryKeyColumnName, " is null");
+			}
+			else {
+				sqlString = StringBundler.concat(
+					"select distinct ResourcePermission.primKeyId from ",
+					"ResourcePermission where ResourcePermission.primKeyId is ",
+					"not null and ResourcePermission.primKeyId != 0 and ",
+					namesClauseString, " and not exists (select 1 from ",
+					tableName, " where ", tableName, StringPool.PERIOD,
+					primaryKeyColumnName, " = ResourcePermission.primKeyId)");
+			}
+
+			List<Long> orphanIds = new ArrayList<>();
 
 			try (PreparedStatement preparedStatement =
 					connection.prepareStatement(sqlString)) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -6,19 +6,24 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
-import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
+import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.security.permission.ResourceActionsImpl;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -40,6 +45,8 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
+		Map<String, List<String>> tableNames = new HashMap<>();
+
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select distinct name from ResourcePermission where name " +
 					"like 'com.liferay.%' and primKeyId != 0 and primKeyId " +
@@ -51,12 +58,14 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 				ResourceActionsImpl resourceActionsImpl =
 					new ResourceActionsImpl();
 
+				String compositeModelNameSeparator =
+					resourceActionsImpl.getCompositeModelNameSeparator();
+
 				while (resultSet.next()) {
 					String name = resultSet.getString("name");
 
 					String[] classNames = StringUtil.split(
-						name,
-						resourceActionsImpl.getCompositeModelNameSeparator());
+						name, compositeModelNameSeparator);
 
 					String tableName = null;
 
@@ -96,46 +105,118 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 
 					if (!dbInspector.hasTable(tableName)) {
 						if (_log.isWarnEnabled()) {
-							_log.warn("Table " + tableName + " does not exist");
-						}
-
-						continue;
-					}
-
-					String primaryKeyColumnName = "resourcePrimKey";
-
-					if (!dbInspector.hasColumn(
-							tableName, primaryKeyColumnName)) {
-
-						primaryKeyColumnName =
-							DataCleanupPreupgradeProcessUtil.
-								getPrimaryKeyColumnName(
-									connection, dbInspector, tableName);
-					}
-
-					if (primaryKeyColumnName == null) {
-						if (_log.isWarnEnabled()) {
 							_log.warn(
-								"Skipping table " + tableName +
-									" because it does not have a primary key");
+								"Unable to find table \"" + tableName + "\"");
 						}
 
 						continue;
 					}
 
-					upgrade(
-						new TableOrphanReferencesDataCleanupPreupgradeProcess(
-							null,
+					List<String> names = tableNames.computeIfAbsent(
+						tableName, key -> new ArrayList<>());
+
+					names.add(name);
+				}
+			}
+		}
+
+		for (Map.Entry<String, List<String>> entry : tableNames.entrySet()) {
+			String tableName = entry.getKey();
+
+			String primaryKeyColumnName = "resourcePrimKey";
+
+			if (!dbInspector.hasColumn(tableName, primaryKeyColumnName)) {
+				primaryKeyColumnName =
+					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
+						connection, dbInspector, tableName);
+			}
+
+			if (primaryKeyColumnName == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to find primary key column for table \"" +
+							tableName + "\"");
+				}
+
+				continue;
+			}
+
+			List<String> names = entry.getValue();
+
+			String namesClause;
+
+			if (names.size() == 1) {
+				namesClause = StringBundler.concat(
+					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
+					" and name = '", names.get(0), "'");
+			}
+			else {
+				List<String> quotedNames = new ArrayList<>(names.size());
+
+				for (String name : names) {
+					quotedNames.add(StringBundler.concat("'", name, "'"));
+				}
+
+				namesClause = StringBundler.concat(
+					"scope = ", ResourceConstants.SCOPE_INDIVIDUAL,
+					" and name in (",
+					String.join(StringPool.COMMA_AND_SPACE, quotedNames), ")");
+			}
+
+			List<Long> orphanIds = new ArrayList<>();
+
+			String sql = StringBundler.concat(
+				"select distinct primKeyId from ResourcePermission where ",
+				"primKeyId != 0 and primKeyId is not null and ", namesClause,
+				" and primKeyId not in (select ", primaryKeyColumnName,
+				" from ", tableName, ")");
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(sql)) {
+
+				ResultSet resultSet = preparedStatement.executeQuery();
+
+				while (resultSet.next()) {
+					orphanIds.add(resultSet.getLong("primKeyId"));
+				}
+			}
+
+			if (orphanIds.isEmpty()) {
+				continue;
+			}
+
+			for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
+				int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
+
+				List<String> batchIds = new ArrayList<>(end - i);
+
+				for (int j = i; j < end; j++) {
+					batchIds.add(String.valueOf(orphanIds.get(j)));
+				}
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
 							StringBundler.concat(
-								"[$SOURCE_TABLE_ALIAS$].scope = ",
-								ResourceConstants.SCOPE_INDIVIDUAL, " and ",
-								"[$SOURCE_TABLE_ALIAS$].name = '", name, "'"),
-							"primKeyId", "ResourcePermission",
-							primaryKeyColumnName, tableName));
+								"delete from ResourcePermission where ",
+								"primKeyId in (",
+								String.join(
+									StringPool.COMMA_AND_SPACE, batchIds),
+								") and ", namesClause))) {
+
+					int deleted = preparedStatement.executeUpdate();
+
+					DataCleanupLoggingUtil.logDelete(
+						_log, deleted, "ResourcePermission",
+						StringBundler.concat(
+							"primKeyId was not found in column ",
+							primaryKeyColumnName, " from table \"", tableName,
+							"\""));
 				}
 			}
 		}
 	}
+
+	private static final int _BATCH_SIZE = 1000;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ResourcePermissionDataCleanupPreupgradeProcess.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -21,10 +21,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * @author Luis Ortiz
@@ -45,7 +45,7 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
-		Map<String, List<String>> classNamesByTableName = new HashMap<>();
+		Map<String, List<String>> classNamesByTableName = new TreeMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select distinct name from ResourcePermission where name " +
@@ -187,6 +187,8 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 				continue;
 			}
 
+			int totalDeleted = 0;
+
 			for (int i = 0; i < orphanIds.size(); i += _BATCH_SIZE) {
 				int end = Math.min(i + _BATCH_SIZE, orphanIds.size());
 
@@ -205,16 +207,15 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 									StringPool.COMMA_AND_SPACE, batchIds),
 								") and ", namesClauseString))) {
 
-					int deleted = preparedStatement.executeUpdate();
-
-					DataCleanupLoggingUtil.logDelete(
-						_log, deleted, "ResourcePermission",
-						StringBundler.concat(
-							"primKeyId was not found in column ",
-							primaryKeyColumnName, " from table \"", tableName,
-							"\""));
+					totalDeleted += preparedStatement.executeUpdate();
 				}
 			}
+
+			DataCleanupLoggingUtil.logDelete(
+				_log, totalDeleted, "ResourcePermission",
+				StringBundler.concat(
+					"primKeyId was not found in column ", primaryKeyColumnName,
+					" from table \"", tableName, "\""));
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93238

**What is being fixed:** `ResourcePermissionDataCleanupPreupgradeProcess` issued one cleanup pass per distinct resource name — roughly 32 passes in practice — causing class names that resolved to the same target table to rescan it repeatedly.

**How it is being fixed:** Class names are grouped into a `Map<String, List<String>>` keyed by the resolved target table. Each table then receives a single `upgrade()` call to `TableOrphanReferencesDataCleanupPreupgradeProcess` with a `name in (…)` source where clause, reducing cleanup from one pass per class name to one pass per target table while preserving the shared path's DB-specific query building, logging, temporary-index management, and deadlock retry.