### PR TITLE
LPD-93483 Propagate primary key recreation failures during preupgrade

### DIFF
--- a/modules/apps/portal/portal-db-index-test/src/testIntegration/java/com/liferay/portal/db/index/test/PrimaryKeyUpdaterUtilTest.java
+++ b/modules/apps/portal/portal-db-index-test/src/testIntegration/java/com/liferay/portal/db/index/test/PrimaryKeyUpdaterUtilTest.java
@@ -133,6 +133,49 @@ public class PrimaryKeyUpdaterUtilTest {
 		}
 	}
 
+	@Test
+	public void testUpdateAllPrimaryKeysWhenPrimaryKeyIsDuplicated()
+		throws Exception {
+
+		DB db = DBManagerUtil.getDB();
+
+		try (Connection connection = DataAccess.getConnection()) {
+			db.removePrimaryKey(connection, "Counter");
+
+			String name = StringUtil.randomId();
+
+			db.runSQL(
+				connection,
+				"insert into Counter (name, currentId) values ('" + name +
+					"', 0)");
+			db.runSQL(
+				connection,
+				"insert into Counter (name, currentId) values ('" + name +
+					"', 0)");
+
+			try {
+				PrimaryKeyUpdaterUtil.updateAllPrimaryKeys();
+
+				Assert.fail();
+			}
+			catch (Exception exception) {
+				Assert.assertTrue(
+					exception.getMessage(
+					).contains(
+						"Unable to update database primary key for Counter"
+					));
+			}
+			finally {
+				db.runSQL(
+					connection,
+					"delete from Counter where name = '" + name + "'");
+
+				db.updatePrimaryKey(
+					connection, "Counter", new String[] {"name"});
+			}
+		}
+	}
+
 	private void _testUpdateAllPrimaryKeys() throws Exception {
 		DB db = DBManagerUtil.getDB();
 

--- a/portal-impl/src/com/liferay/portal/db/index/PrimaryKeyUpdaterUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/index/PrimaryKeyUpdaterUtil.java
@@ -7,6 +7,7 @@ package com.liferay.portal.db.index;
 
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.lang.CentralizedThreadLocal;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
@@ -21,7 +22,6 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsValues;
-import com.liferay.portal.kernel.util.Validator;
 
 import java.sql.Connection;
 
@@ -163,22 +163,16 @@ public class PrimaryKeyUpdaterUtil {
 
 		CompanyLocalServiceUtil.forEachCompanyId(
 			companyId -> {
-				try {
-					try (Connection connection = DataAccess.getConnection()) {
-						db.updatePrimaryKey(
-							connection, tableName, primaryKeyColumnNames);
-					}
+				try (Connection connection = DataAccess.getConnection()) {
+					db.updatePrimaryKey(
+						connection, tableName, primaryKeyColumnNames);
 				}
 				catch (Exception exception) {
-					String message = new String(
-						"Unable to update database primary key for " +
-							tableName);
-
-					if (Validator.isNotNull(companyId)) {
-						message += " and company " + companyId;
-					}
-
-					_log.error(message + " due to " + exception.getMessage());
+					throw new Exception(
+						StringBundler.concat(
+							"Unable to update database primary key for ",
+							tableName, " and company ", companyId),
+						exception);
 				}
 			});
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93483

## What Is Being Fixed

During preupgrade data cleanup, `PrimaryKeyUpdaterUtil.updateAllPrimaryKeys()` attempts to recreate missing primary keys. When `ALTER TABLE ... ADD PRIMARY KEY` fails for any reason, the exception was caught inside the `forEachCompanyId` lambda and only logged. The cleanup reported success regardless and the upgrade continued with the primary key still missing, causing it to fail later without a clear indication of the root cause.

## How It Is Being Fixed

The catch block in `PrimaryKeyUpdaterUtil._updatePrimaryKey` now rethrows the exception with a descriptive message (table name and company ID) instead of logging it. This lets it propagate through the existing `ThrowableCollector` infrastructure in `_addUpdatePrimaryKeysFutures`, which was already in place to collect and surface failures from concurrent futures. The upgrade now aborts at the cleanup stage with the underlying database error as the cause, giving the operator the information they need immediately.

A new test in `PrimaryKeyUpdaterUtilTest` removes Counter's primary key, inserts a duplicate row to make the ALTER fail deterministically, and asserts that `updateAllPrimaryKeys()` throws with the expected message. Cleanup runs in a `finally` block to restore Counter's state.