### PR TITLE
LPD-82361 Restrict Company and VirtualHost visibility across secondary instances

### DIFF
--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -486,6 +486,56 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
+	@Test
+	public void testCompanyNotVisibleAcrossSecondaryInstances()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company1.getCompanyId())) {
+
+			List<Company> companies = _companyLocalService.getCompanies();
+
+			Assert.assertFalse(companies.contains(_company2));
+			Assert.assertTrue(companies.contains(_company1));
+		}
+	}
+
+	@Test
+	public void testCompanyResolvableByVirtualHostAfterNegativeLookup()
+		throws Exception {
+
+		String webId =
+			StringUtil.toLowerCase(RandomTestUtil.randomString()) + ".com";
+
+		Assert.assertNull(
+			_companyLocalService.fetchCompanyByVirtualHost(webId));
+
+		_company1 = CompanyTestUtil.addCompanyWithWebId(webId);
+
+		Assert.assertNotNull(
+			_companyLocalService.fetchCompanyByVirtualHost(webId));
+	}
+
+	@Test
+	public void testCompanyViewFiltersPeerCompanies() throws Exception {
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		String partitionName = CompanyLocalServiceTestUtil.getPartitionName(
+			_company1.getCompanyId());
+
+		Assert.assertFalse(
+			_isCompanyIdInView(
+				partitionName, "Company", _company2.getCompanyId()));
+		Assert.assertTrue(
+			_isCompanyIdInView(
+				partitionName, "Company", _company1.getCompanyId()));
+	}
+
 	@FeatureFlag("LPD-11342")
 	@Test
 	public void testCopyDBPartitionCompany() throws Exception {
@@ -513,10 +563,10 @@ public class CompanyLocalServiceDBPartitionTest
 				TestPropsValues.getCompanyId(), null, name, virtualHostname,
 				webId);
 
+			long copiedCompanyId = copiedCompany.getCompanyId();
+
 			_assertCopyDBPartitionCompany(
 				copiedCompany, name, virtualHostname, webId);
-
-			long copiedCompanyId = copiedCompany.getCompanyId();
 
 			_assertCompanyConfiguration(copiedCompanyId, configuration);
 
@@ -809,6 +859,98 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 	}
 
+	@Test
+	public void testGetCompanyIdsScopedToSecondaryInstance() throws Exception {
+		_company1 = CompanyTestUtil.addCompany();
+
+		long companyId = _company1.getCompanyId();
+
+		Assert.assertTrue(
+			ArrayUtil.contains(PortalInstancePool.getCompanyIds(), companyId));
+
+		Assert.assertTrue(
+			ArrayUtil.contains(
+				PortalInstancePool.getCompanyIds(), _defaultCompanyId));
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			Assert.assertArrayEquals(
+				new long[] {companyId}, PortalInstancePool.getCompanyIds());
+		}
+	}
+
+	@Test
+	public void testVirtualHostNotVisibleAcrossSecondaryInstances()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company1.getCompanyId())) {
+
+			List<VirtualHost> virtualHosts =
+				_virtualHostLocalService.getVirtualHosts(
+					_company2.getCompanyId());
+
+			Assert.assertTrue(virtualHosts.isEmpty());
+		}
+	}
+
+	@Test
+	public void testVirtualHostUpdateReflectedOnSecondaryInstance()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+
+		String hostname = _company1.getVirtualHostname();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company1.getCompanyId())) {
+
+			_virtualHostLocalService.getVirtualHost(hostname);
+		}
+
+		String languageId = RandomTestUtil.randomString();
+
+		VirtualHost virtualHost = _virtualHostLocalService.getVirtualHost(
+			hostname);
+
+		virtualHost.setLanguageId(languageId);
+
+		virtualHost = _virtualHostLocalService.updateVirtualHost(virtualHost);
+
+		Assert.assertEquals(languageId, virtualHost.getLanguageId());
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company1.getCompanyId())) {
+
+			virtualHost = _virtualHostLocalService.getVirtualHost(hostname);
+
+			Assert.assertEquals(languageId, virtualHost.getLanguageId());
+		}
+	}
+
+	@Test
+	public void testVirtualHostViewFiltersPeerCompanies() throws Exception {
+		_company1 = CompanyTestUtil.addCompany();
+		_company2 = CompanyTestUtil.addCompany();
+
+		String partitionName = CompanyLocalServiceTestUtil.getPartitionName(
+			_company1.getCompanyId());
+
+		Assert.assertFalse(
+			_isCompanyIdInView(
+				partitionName, "VirtualHost", _company2.getCompanyId()));
+		Assert.assertTrue(
+			_isCompanyIdInView(
+				partitionName, "VirtualHost", _company1.getCompanyId()));
+	}
+
 	private void _addCopyDBPartitionCompanyCache(long companyId) {
 		_className1 = _classNameLocalService.addClassName(_CLASS_NAME_1);
 		_className2 = _classNameLocalService.addClassName(_CLASS_NAME_2);
@@ -908,15 +1050,22 @@ public class CompanyLocalServiceDBPartitionTest
 			Company company, String name, String virtualHostname, String webId)
 		throws Exception {
 
-		Assert.assertTrue(
-			ArrayUtil.contains(
-				CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
-				company.getCompanyId()));
 		Assert.assertEquals(name, company.getName());
-		Assert.assertEquals(virtualHostname, company.getVirtualHostname());
 		Assert.assertEquals(webId, company.getWebId());
 
-		_virtualHostLocalService.getVirtualHost(virtualHostname);
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					company.getCompanyId())) {
+
+			Assert.assertEquals(virtualHostname, company.getVirtualHostname());
+
+			Assert.assertTrue(
+				ArrayUtil.contains(
+					CompanyLocalServiceTestUtil.getCompanyIdsBySQL(),
+					company.getCompanyId()));
+
+			_virtualHostLocalService.getVirtualHost(virtualHostname);
+		}
 	}
 
 	private void _assertCopyDBPartitionCompanyCache(long companyId) {
@@ -1176,6 +1325,23 @@ public class CompanyLocalServiceDBPartitionTest
 		}
 
 		return false;
+	}
+
+	private boolean _isCompanyIdInView(
+			String partitionName, String tableName, long companyId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select companyId from ", partitionName, StringPool.PERIOD,
+					tableName, " where companyId = ?"))) {
+
+			preparedStatement.setLong(1, companyId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
 	}
 
 	private static final String _CLASS_NAME_1 =

--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl.java
@@ -447,9 +447,26 @@ public class EntityCacheImpl
 		if (quiet) {
 			PortalCacheHelperUtil.putWithoutReplicator(
 				portalCache, primaryKey, result);
+
+			return;
 		}
-		else {
+
+		long[] companyIds = DBPartition.getSharedPartitionedModelCompanyIds(
+			baseModel);
+
+		if (companyIds == null) {
 			portalCache.put(primaryKey, result);
+
+			return;
+		}
+
+		for (long companyId : companyIds) {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
+
+				portalCache.put(primaryKey, result);
+			}
 		}
 	}
 
@@ -476,7 +493,23 @@ public class EntityCacheImpl
 		PortalCache<Serializable, Serializable> portalCache = getPortalCache(
 			clazz);
 
-		portalCache.remove(primaryKey);
+		long[] companyIds = DBPartition.getSharedPartitionedModelCompanyIds(
+			baseModel);
+
+		if (companyIds == null) {
+			portalCache.remove(primaryKey);
+
+			return;
+		}
+
+		for (long companyId : companyIds) {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
+
+				portalCache.remove(primaryKey);
+			}
+		}
 	}
 
 	private Serializable _toEntityModel(Serializable result) {

--- a/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/FinderCacheImpl.java
+++ b/modules/apps/portal-cache/portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/FinderCacheImpl.java
@@ -10,6 +10,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cache.CacheRegistryItem;
 import com.liferay.portal.kernel.cache.CacheRegistryUtil;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.change.tracking.CTModel;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LRUMap;
@@ -336,34 +338,22 @@ public class FinderCacheImpl
 	}
 
 	public void removeByEntityCache(String className, BaseModel<?> baseModel) {
-		ArgumentsResolverHolder argumentsResolverHolder =
-			_serviceTrackerMap.getService(className);
+		long[] companyIds = DBPartition.getSharedPartitionedModelCompanyIds(
+			baseModel);
 
-		if (argumentsResolverHolder == null) {
-			clearByEntityCache(className);
+		if (companyIds == null) {
+			_removeByEntityCache(className, baseModel);
 
 			return;
 		}
 
-		clearLocalCache();
+		for (long companyId : companyIds) {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
 
-		_clearCache(_getCacheNameWithPagination(className));
-		_clearCache(_getCacheNameWithoutPagination(className));
-
-		_clearDSLQueryCache(className);
-
-		ArgumentsResolver argumentsResolver =
-			argumentsResolverHolder.getArgumentsResolver();
-
-		for (FinderPath finderPath : _getFinderPaths(className)) {
-			removeResult(
-				finderPath,
-				argumentsResolver.getArguments(
-					finderPath, baseModel, false, false));
-			removeResult(
-				finderPath,
-				argumentsResolver.getArguments(
-					finderPath, baseModel, true, true));
+				_removeByEntityCache(className, baseModel);
+			}
 		}
 	}
 
@@ -428,46 +418,21 @@ public class FinderCacheImpl
 			return;
 		}
 
-		ArgumentsResolverHolder argumentsResolverHolder =
-			_serviceTrackerMap.getService(className);
+		long[] companyIds = DBPartition.getSharedPartitionedModelCompanyIds(
+			baseModel);
 
-		if (argumentsResolverHolder == null) {
-			clearByEntityCache(className);
+		if (companyIds == null) {
+			_updateByEntityCache(className, baseModel);
 
 			return;
 		}
 
-		clearLocalCache();
+		for (long companyId : companyIds) {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						companyId)) {
 
-		_clearCache(_getCacheNameWithPagination(className));
-
-		_clearDSLQueryCache(className);
-
-		Set<FinderPath> finderPaths = new HashSet<>();
-
-		finderPaths.addAll(
-			_getFinderPaths(_getCacheNameWithoutPagination(className)));
-		finderPaths.addAll(_getFinderPaths(className));
-
-		ArgumentsResolver argumentsResolver =
-			argumentsResolverHolder.getArgumentsResolver();
-
-		for (FinderPath finderPath : finderPaths) {
-			if (baseModel.isNew()) {
-				_removeResult(
-					finderPath,
-					argumentsResolver.getArguments(
-						finderPath, baseModel, false, false));
-			}
-			else {
-				_removeResult(
-					finderPath,
-					argumentsResolver.getArguments(
-						finderPath, baseModel, true, false));
-				_removeResult(
-					finderPath,
-					argumentsResolver.getArguments(
-						finderPath, baseModel, true, true));
+				_updateByEntityCache(className, baseModel);
 			}
 		}
 	}
@@ -779,6 +744,40 @@ public class FinderCacheImpl
 		return ThreadLocalFilterThreadLocal.isFilterInvoked();
 	}
 
+	private void _removeByEntityCache(
+		String className, BaseModel<?> baseModel) {
+
+		ArgumentsResolverHolder argumentsResolverHolder =
+			_serviceTrackerMap.getService(className);
+
+		if (argumentsResolverHolder == null) {
+			clearByEntityCache(className);
+
+			return;
+		}
+
+		clearLocalCache();
+
+		_clearCache(_getCacheNameWithPagination(className));
+		_clearCache(_getCacheNameWithoutPagination(className));
+
+		_clearDSLQueryCache(className);
+
+		ArgumentsResolver argumentsResolver =
+			argumentsResolverHolder.getArgumentsResolver();
+
+		for (FinderPath finderPath : _getFinderPaths(className)) {
+			removeResult(
+				finderPath,
+				argumentsResolver.getArguments(
+					finderPath, baseModel, false, false));
+			removeResult(
+				finderPath,
+				argumentsResolver.getArguments(
+					finderPath, baseModel, true, true));
+		}
+	}
+
 	private void _removeResult(FinderPath finderPath, Object[] args) {
 		if (args == null) {
 			return;
@@ -797,6 +796,53 @@ public class FinderCacheImpl
 			finderPath.getCacheName());
 
 		portalCache.remove(cacheKey);
+	}
+
+	private void _updateByEntityCache(
+		String className, BaseModel<?> baseModel) {
+
+		ArgumentsResolverHolder argumentsResolverHolder =
+			_serviceTrackerMap.getService(className);
+
+		if (argumentsResolverHolder == null) {
+			clearByEntityCache(className);
+
+			return;
+		}
+
+		clearLocalCache();
+
+		_clearCache(_getCacheNameWithPagination(className));
+
+		_clearDSLQueryCache(className);
+
+		Set<FinderPath> finderPaths = new HashSet<>();
+
+		finderPaths.addAll(
+			_getFinderPaths(_getCacheNameWithoutPagination(className)));
+		finderPaths.addAll(_getFinderPaths(className));
+
+		ArgumentsResolver argumentsResolver =
+			argumentsResolverHolder.getArgumentsResolver();
+
+		for (FinderPath finderPath : finderPaths) {
+			if (baseModel.isNew()) {
+				_removeResult(
+					finderPath,
+					argumentsResolver.getArguments(
+						finderPath, baseModel, false, false));
+			}
+			else {
+				_removeResult(
+					finderPath,
+					argumentsResolver.getArguments(
+						finderPath, baseModel, true, false));
+				_removeResult(
+					finderPath,
+					argumentsResolver.getArguments(
+						finderPath, baseModel, true, true));
+			}
+		}
 	}
 
 	private static final String _GROUP_KEY_PREFIX =

--- a/modules/apps/portal-cache/source-formatter-suppressions.xml
+++ b/modules/apps/portal-cache/source-formatter-suppressions.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0"?>
 
 <suppressions>
+	<checkstyle>
+		<suppress checks="CompanyIterationCheck" files="portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl\.java" />
+		<suppress checks="CompanyIterationCheck" files="portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/FinderCacheImpl\.java" />
+	</checkstyle>
 	<source-check>
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/EntityCacheImpl\.java" />
+		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-cache-impl/src/main/java/com/liferay/portal/cache/internal/dao/orm/FinderCacheImpl\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-cache-multiple/src/main/java/com/liferay/portal/cache/multiple/internal/cluster/link/messaging/ClusterLinkPortalCacheClusterListener\.java" />
 	</source-check>
 </suppressions>

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableViewTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/upgrade/test/UpgradePartitionedControlTableViewTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.upgrade.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.util.UpgradePartitionedControlTableView;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author István András Dézsi
+ */
+@RunWith(Arquillian.class)
+public class UpgradePartitionedControlTableViewTest
+	extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		BaseDBPartitionTestCase.setUpClass();
+
+		BaseDBPartitionTestCase.setUpDBPartitions();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		BaseDBPartitionTestCase.tearDownDBPartitions();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		_removeViewFilter(COMPANY_IDS[0]);
+
+		Assert.assertTrue(_isCompanyVisible(COMPANY_IDS[0], COMPANY_IDS[1]));
+
+		UpgradeProcess upgradeProcess = new UpgradePartitionedControlTableView(
+			"Company", "VirtualHost");
+
+		upgradeProcess.upgrade();
+
+		Assert.assertFalse(_isCompanyVisible(COMPANY_IDS[0], COMPANY_IDS[1]));
+		Assert.assertTrue(_isCompanyVisible(COMPANY_IDS[0], COMPANY_IDS[0]));
+	}
+
+	private boolean _isCompanyVisible(long partitionCompanyId, long companyId)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select companyId from ",
+					getPartitionName(partitionCompanyId),
+					".Company where companyId = ?"))) {
+
+			preparedStatement.setLong(1, companyId);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
+	}
+
+	private void _removeViewFilter(long companyId) throws Exception {
+		try (Statement statement = connection.createStatement()) {
+			statement.execute(
+				StringBundler.concat(
+					"create or replace view ", getPartitionName(companyId),
+					".Company as select * from ", defaultPartitionName,
+					".Company"));
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/db/partition/db/DBPartitionDB.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/db/DBPartitionDB.java
@@ -75,10 +75,18 @@ public interface DBPartitionDB {
 	public default String getCreateViewSQL(
 		String fromPartitionName, String toPartitionName, String viewName) {
 
+		return getCreateViewSQL(
+			fromPartitionName, toPartitionName, viewName, StringPool.BLANK);
+	}
+
+	public default String getCreateViewSQL(
+		String fromPartitionName, String toPartitionName, String viewName,
+		String whereClause) {
+
 		return StringBundler.concat(
 			"create or replace view ", toPartitionName, StringPool.PERIOD,
 			viewName, " as select * from ", fromPartitionName,
-			StringPool.PERIOD, viewName);
+			StringPool.PERIOD, viewName, whereClause);
 	}
 
 	public String getDefaultPartitionName(Connection connection)

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -376,6 +376,22 @@ public class DBPartitionUtil {
 		}
 	}
 
+	public static void replaceByView(
+			Connection connection, long companyId, String tableName)
+		throws Exception {
+
+		if (companyId == _defaultCompanyId) {
+			return;
+		}
+
+		try (Statement statement = connection.createStatement()) {
+			statement.execute(
+				_dbPartitionDB.getCreateViewSQL(
+					_defaultPartitionName, getPartitionName(companyId),
+					tableName, _getViewWhereClauseSQL(companyId, tableName)));
+		}
+	}
+
 	public static void setDefaultCompanyId(Connection connection)
 		throws SQLException {
 
@@ -466,8 +482,8 @@ public class DBPartitionUtil {
 					if (dbInspector.isControlTable(tableName)) {
 						statement.executeUpdate(
 							_dbPartitionDB.getCreateViewSQL(
-								_defaultPartitionName, partitionName,
-								tableName));
+								_defaultPartitionName, partitionName, tableName,
+								_getViewWhereClauseSQL(companyId, tableName)));
 					}
 					else {
 						statement.executeUpdate(
@@ -525,7 +541,9 @@ public class DBPartitionUtil {
 		String targetPartitionName = getPartitionName(toCompanyId);
 
 		try (AutoCloseable autoCloseable = _disableAutoCommit(connection)) {
-			_copySchema(connection, sourcePartitionName, targetPartitionName);
+			_copySchema(
+				toCompanyId, connection, sourcePartitionName,
+				targetPartitionName);
 
 			DatabaseMetaData databaseMetaData = connection.getMetaData();
 
@@ -705,7 +723,7 @@ public class DBPartitionUtil {
 	}
 
 	private static void _copySchema(
-			Connection connection, String sourcePartitionName,
+			long companyId, Connection connection, String sourcePartitionName,
 			String targetPartitionName)
 		throws SQLException {
 
@@ -732,7 +750,9 @@ public class DBPartitionUtil {
 						statement.executeUpdate(
 							_dbPartitionDB.getCreateViewSQL(
 								_defaultPartitionName, targetPartitionName,
-								fromTableName));
+								fromTableName,
+								_getViewWhereClauseSQL(
+									companyId, fromTableName)));
 
 						continue;
 					}
@@ -957,7 +977,8 @@ public class DBPartitionUtil {
 
 		try (AutoCloseable autoCloseable = _disableAutoCommit(connection)) {
 			_copySchema(
-				connection, getPartitionName(companyId), exportedPartitionName);
+				companyId, connection, getPartitionName(companyId),
+				exportedPartitionName);
 
 			DatabaseMetaData databaseMetaData = connection.getMetaData();
 
@@ -1305,6 +1326,18 @@ public class DBPartitionUtil {
 		return " where trigger_name like '%@" + companyId + "'";
 	}
 
+	private static String _getViewWhereClauseSQL(
+		long companyId, String tableName) {
+
+		if (StringUtil.equalsIgnoreCase(tableName, "Company") ||
+			StringUtil.equalsIgnoreCase(tableName, "VirtualHost")) {
+
+			return " where companyId = " + companyId;
+		}
+
+		return StringPool.BLANK;
+	}
+
 	private static void _importDBPartition(long companyId)
 		throws PortalException {
 
@@ -1397,7 +1430,8 @@ public class DBPartitionUtil {
 					statement.executeUpdate(
 						_dbPartitionDB.getCreateViewSQL(
 							_defaultPartitionName, targetPartitionName,
-							tableName));
+							tableName,
+							_getViewWhereClauseSQL(companyId, tableName)));
 				}
 
 				connection.commit();
@@ -1694,7 +1728,8 @@ public class DBPartitionUtil {
 						super.execute(
 							_dbPartitionDB.getCreateViewSQL(
 								_defaultPartitionName,
-								getPartitionName(companyId), tableName));
+								getPartitionName(companyId), tableName,
+								_getViewWhereClauseSQL(companyId, tableName)));
 					}
 
 					return returnValue;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.encryptor.EncryptorException;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.exception.CompanyMaxUsersException;
@@ -150,6 +151,7 @@ import java.net.UnknownHostException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -950,7 +952,18 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	 */
 	@Override
 	public List<Company> getCompanies() {
-		return companyPersistence.findAll();
+		if (!DBPartition.isCurrentCompanyRestricted()) {
+			return companyPersistence.findAll();
+		}
+
+		Company company = companyPersistence.fetchByPrimaryKey(
+			CompanyThreadLocal.getCompanyId());
+
+		if (company == null) {
+			return Collections.emptyList();
+		}
+
+		return Collections.singletonList(company);
 	}
 
 	/**
@@ -2430,15 +2443,22 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	}
 
 	private void _clearCache(long companyId) {
-		Company company = companyPersistence.fetchByPrimaryKey(companyId);
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
-		if (company != null) {
-			companyPersistence.clearCache(company);
+			Company company = companyPersistence.fetchByPrimaryKey(companyId);
 
-			VirtualHost virtualHost = _virtualHostPersistence.fetchByHostname(
-				company.getVirtualHostname());
+			if (company != null) {
+				companyPersistence.clearCache(company);
 
-			_virtualHostPersistence.clearCache(virtualHost);
+				VirtualHost virtualHost =
+					_virtualHostPersistence.fetchByHostname(
+						company.getVirtualHostname());
+
+				if (virtualHost != null) {
+					_virtualHostPersistence.clearCache(virtualHost);
+				}
+			}
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.exception.AvailableLocaleException;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -136,6 +137,12 @@ public class VirtualHostLocalServiceImpl
 
 	@Override
 	public List<VirtualHost> getVirtualHosts(long companyId) {
+		if (DBPartition.isCurrentCompanyRestricted() &&
+			(companyId != CompanyThreadLocal.getCompanyId())) {
+
+			return Collections.emptyList();
+		}
+
 		return virtualHostPersistence.findByCompanyId(companyId);
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTableView.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTableView.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.upgrade.util;
+
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PropsValues;
+
+/**
+ * @author István András Dézsi
+ */
+public class UpgradePartitionedControlTableView extends UpgradeProcess {
+
+	public UpgradePartitionedControlTableView(String... tableNames) {
+		_tableNames = tableNames;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (CompanyThreadLocal.getCompanyId() !=
+				PortalInstancePool.getDefaultCompanyId()) {
+
+			return;
+		}
+
+		for (long companyId : PortalInstancePool.getCompanyIds()) {
+			for (String tableName : _tableNames) {
+				DBPartitionUtil.replaceByView(connection, companyId, tableName);
+			}
+		}
+	}
+
+	@Override
+	protected boolean isSkipUpgradeProcess() {
+		return !PropsValues.DATABASE_PARTITION_ENABLED;
+	}
+
+	private final String[] _tableNames;
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.ReleaseInfo;
 import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.upgrade.util.PortalUpgradeProcessRegistry;
 import com.liferay.portal.upgrade.util.UpgradePartitionedControlTable;
+import com.liferay.portal.upgrade.util.UpgradePartitionedControlTableView;
 import com.liferay.portal.upgrade.v7_4_x.util.AssetTagGroupRelTable;
 import com.liferay.portal.upgrade.v7_4_x.util.AssetVocabularyGroupRelTable;
 import com.liferay.portal.upgrade.v7_4_x.util.RememberMeTokenTable;
@@ -771,6 +772,10 @@ public class PortalUpgradeProcessRegistryImpl
 			new Version(38, 4, 2),
 			UpgradeProcessFactory.addColumns(
 				"Ticket", "emailAddress VARCHAR(254) null"));
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 4, 3),
+			new UpgradePartitionedControlTableView("Company", "VirtualHost"));
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/db/partition/DBPartition.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/partition/DBPartition.java
@@ -6,22 +6,77 @@
 package com.liferay.portal.kernel.db.partition;
 
 import com.liferay.counter.kernel.model.Counter;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.ClassName;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.ResourceAction;
 import com.liferay.portal.kernel.model.ShardedModel;
+import com.liferay.portal.kernel.model.VirtualHost;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+
+import java.util.Map;
 
 /**
  * @author Luis Ortiz
  */
 public class DBPartition {
 
+	public static long[] getSharedPartitionedModelCompanyIds(
+		BaseModel<?> baseModel) {
+
+		if (!PropsValues.DATABASE_PARTITION_ENABLED || (baseModel == null) ||
+			CompanyThreadLocal.isInitializingPortalInstance() ||
+			CompanyThreadLocal.isLocked() ||
+			CompanyThreadLocal.isUpgradingPortalInstance()) {
+
+			return null;
+		}
+
+		Class<?> modelClass = baseModel.getModelClass();
+
+		if (!Company.class.isAssignableFrom(modelClass) &&
+			!VirtualHost.class.isAssignableFrom(modelClass)) {
+
+			return null;
+		}
+
+		Map<String, Object> modelAttributes = baseModel.getModelAttributes();
+
+		long companyId = GetterUtil.getLong(modelAttributes.get("companyId"));
+
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
+		if ((companyId == 0) || (companyId == defaultCompanyId)) {
+			return new long[] {defaultCompanyId};
+		}
+
+		return new long[] {companyId, defaultCompanyId};
+	}
+
+	public static boolean isCurrentCompanyRestricted() {
+		if (!PropsValues.DATABASE_PARTITION_ENABLED ||
+			CompanyThreadLocal.isInitializingPortalInstance() ||
+			CompanyThreadLocal.isUpgradingPortalInstance() ||
+			(CompanyThreadLocal.getNonsystemCompanyId() ==
+				PortalInstancePool.getDefaultCompanyId())) {
+
+			return false;
+		}
+
+		return true;
+	}
+
 	public static boolean isPartitionedModel(Class<?> clazz) {
 		if (PropsValues.DATABASE_PARTITION_ENABLED &&
 			(ClassName.class.isAssignableFrom(clazz) ||
+			 Company.class.isAssignableFrom(clazz) ||
 			 Counter.class.isAssignableFrom(clazz) ||
 			 ResourceAction.class.isAssignableFrom(clazz) ||
-			 ShardedModel.class.isAssignableFrom(clazz))) {
+			 ShardedModel.class.isAssignableFrom(clazz) ||
+			 VirtualHost.class.isAssignableFrom(clazz))) {
 
 			return true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/db/partition/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/partition/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool.java
@@ -6,9 +6,11 @@
 package com.liferay.portal.kernel.instance;
 
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.db.partition.DBPartition;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -63,11 +65,12 @@ public class PortalInstancePool {
 
 	public static long[] getCompanyIds() {
 		if (_cacheEnabled) {
-			return ArrayUtil.toLongArray(_portalInstances.keySet());
+			return _filterCompanyIds(
+				ArrayUtil.toLongArray(_portalInstances.keySet()));
 		}
 
 		try {
-			return _getCompanyIdsBySQL();
+			return _filterCompanyIds(_getCompanyIdsBySQL());
 		}
 		catch (SQLException sqlException) {
 			_log.error("Unable to get the company IDs by SQL", sqlException);
@@ -159,6 +162,14 @@ public class PortalInstancePool {
 
 	public static void remove(long companyId) {
 		_portalInstances.remove(companyId);
+	}
+
+	private static long[] _filterCompanyIds(long[] companyIds) {
+		if (!DBPartition.isCurrentCompanyRestricted()) {
+			return companyIds;
+		}
+
+		return new long[] {CompanyThreadLocal.getNonsystemCompanyId()};
 	}
 
 	private static long _getCompanyIdBySQL(String webId) throws SQLException {

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -118,6 +118,7 @@
 		<suppress checks="JavaUpgradeIndexCheck" files="portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeDocumentLibrary\.java" />
 		<suppress checks="JavaUpgradeIndexCheck" files="portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeJournal.java" />
 		<suppress checks="JavaUpgradeIndexCheck" files="portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeSchema\.java" />
+		<suppress checks="JavaUpgradeMissingTestCheck" files="portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTableView\.java" />
 		<suppress checks="JavaVariableTypeCheck" files="portal-impl/test/unit/com/liferay/portal/json/One\.java" />
 		<suppress checks="JavaVariableTypeCheck" files="portal-impl/test/unit/com/liferay/portal/json/Two\.java" />
 		<suppress checks="JavaVerifyUpgradeConnectionCheck" files="portal-impl/src/com/liferay/portal/upgrade/util/BaseUpgradeTableImpl.java" />


### PR DESCRIPTION
I'm opening this as a baseline for review. It implements LPD-82361 (restricting Company and VirtualHost visibility on secondary instances under database partitioning), but integration testing surfaced design issues I'd like your guidance on before taking it further.

## What's implemented

Filtered partition views, scoped `getCompanyIds()`, service-layer read filtering, and per-company cache sharding with row-routed invalidation. Commits are split as core, baseline (packageinfo), and modules.

## What I found

On a clean, partition-enabled bundle this branch breaks **32 existing integration tests**. I verified the attribution with a three-way baseline (clean master: 0 failures; clean branch: 32) plus two isolation experiments. Three of the changes are responsible:

| Change | Tests broken | Cause |
|---|---|---|
| Scoped `getCompanyIds()` | 10 | `DBPartitionUtil.forEachCompanyId` enumerates via `getCompanyIds()`, so every fan-out is scoped to a single company |
| Filtered Company / VirtualHost views | 6 | infrastructure that enumerates companies (`forEachCompany`, `getCompaniesCount`) hits the filtered view in a secondary partition context and sees one company instead of all |
| Per-company cache sharding | 16 | the fan-out leaves stale `mvccVersion` cache entries, causing optimistic-lock failures in the generated persistence tests |

The service-layer read filter breaks nothing on its own; it is redundant with the view filter.

## The core tension

The restriction is applied at layers that cross-company infrastructure depends on. The clearest example: a SYSTEM message-bus message dispatched from within a secondary company's context now reaches only that one company, because the interceptor's `forEachCompany` reads the filtered `Company` view. That is a runtime hazard, not just a test failure.

## Guidance I'd appreciate

1. Should the visibility restriction stay off the enumeration paths (`getCompanyIds`, `forEachCompany`, `getCompaniesCount`) that infrastructure relies on, and restrict only user-facing reads? Backing out the `getCompanyIds()` filter alone clears 10 of the 32.
2. Is a filtered DB view the right mechanism, given it catches infrastructure enumeration regardless of the Java layer, or should enumeration read the unfiltered base table while only user-facing reads are restricted?
3. Is the row-routed cache fan-out the intended design? The 16 persistence failures are a fan-out `mvccVersion` staleness problem.

I'm happy to walk through the full experiment data on any of these.
