### PR TITLE
LPD-94069 Remove unpopulated-column guard from DuplicateUniqueFinderRowsCleaner

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DuplicateUniqueFinderRowsCleaner.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DuplicateUniqueFinderRowsCleaner.java
@@ -16,10 +16,8 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Types;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,10 +40,6 @@ public class DuplicateUniqueFinderRowsCleaner {
 	}
 
 	public boolean deleteDuplicates() throws Exception {
-		if (_hasUnpopulatedColumn()) {
-			return false;
-		}
-
 		boolean duplicatesDeleted = false;
 
 		List<String[]> duplicateColumnValuesList =
@@ -226,92 +220,6 @@ public class DuplicateUniqueFinderRowsCleaner {
 		}
 
 		return duplicateRows;
-	}
-
-	private boolean _hasUnpopulatedColumn() throws Exception {
-		Map<String, Integer> columnDataTypes = new HashMap<>();
-
-		DatabaseMetaData databaseMetaData = _connection.getMetaData();
-
-		DBInspector dbInspector = new DBInspector(_connection);
-
-		try (ResultSet resultSet = databaseMetaData.getColumns(
-				dbInspector.getCatalog(), dbInspector.getSchema(),
-				dbInspector.normalizeName(_tableName, databaseMetaData),
-				null)) {
-
-			while (resultSet.next()) {
-				columnDataTypes.put(
-					StringUtil.toLowerCase(resultSet.getString("COLUMN_NAME")),
-					resultSet.getInt("DATA_TYPE"));
-			}
-		}
-
-		StringBundler sb = new StringBundler();
-
-		sb.append("select count(*) as count");
-
-		for (String columnName : _columnNames) {
-			Integer dataType = columnDataTypes.get(
-				StringUtil.toLowerCase(columnName));
-
-			if ((dataType != null) && _isStringType(dataType)) {
-				sb.append(", count(nullif(");
-				sb.append(columnName);
-				sb.append(", '')) as count_");
-			}
-			else {
-				sb.append(", count(");
-				sb.append(columnName);
-				sb.append(") as count_");
-			}
-
-			sb.append(columnName);
-		}
-
-		sb.append(" from ");
-		sb.append(_tableName);
-
-		try (PreparedStatement preparedStatement = _connection.prepareStatement(
-				sb.toString());
-
-			ResultSet resultSet = preparedStatement.executeQuery()) {
-
-			if (!resultSet.next()) {
-				return false;
-			}
-
-			long totalCount = resultSet.getLong("count");
-
-			if (totalCount == 0) {
-				return false;
-			}
-
-			for (String columnName : _columnNames) {
-				if (resultSet.getLong("count_" + columnName) == 0) {
-					_log.error(
-						StringBundler.concat(
-							"Unable to delete duplicate records in table ",
-							_tableName, " because all values in column ",
-							columnName, " are null or empty"));
-
-					return true;
-				}
-			}
-		}
-
-		return false;
-	}
-
-	private boolean _isStringType(int dataType) {
-		if ((dataType == Types.CHAR) || (dataType == Types.LONGNVARCHAR) ||
-			(dataType == Types.LONGVARCHAR) || (dataType == Types.NCHAR) ||
-			(dataType == Types.NVARCHAR) || (dataType == Types.VARCHAR)) {
-
-			return true;
-		}
-
-		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DuplicateUniqueFinderRowsCleanerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DuplicateUniqueFinderRowsCleanerTest.java
@@ -1,0 +1,365 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.dao.db;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class DuplicateUniqueFinderRowsCleanerTest {
+
+	@Test
+	public void testDeleteDuplicates() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class)) {
+
+			DB db = Mockito.mock(DB.class);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			Mockito.when(
+				db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME)
+			).thenReturn(
+				new String[] {_PRIMARY_KEY_COLUMN}
+			);
+
+			PreparedStatement groupByPreparedStatement = Mockito.mock(
+				PreparedStatement.class);
+			ResultSet groupByResultSet = Mockito.mock(ResultSet.class);
+
+			Mockito.when(
+				groupByPreparedStatement.executeQuery()
+			).thenReturn(
+				groupByResultSet
+			);
+
+			Mockito.when(
+				groupByResultSet.next()
+			).thenReturn(
+				true, false
+			);
+
+			Mockito.when(
+				groupByResultSet.getString(1)
+			).thenReturn(
+				"value1"
+			);
+
+			PreparedStatement selectPreparedStatement = Mockito.mock(
+				PreparedStatement.class);
+			ResultSet selectResultSet = Mockito.mock(ResultSet.class);
+			ResultSetMetaData selectResultSetMetaData = Mockito.mock(
+				ResultSetMetaData.class);
+
+			Mockito.when(
+				selectPreparedStatement.executeQuery()
+			).thenReturn(
+				selectResultSet
+			);
+
+			Mockito.when(
+				selectResultSet.getMetaData()
+			).thenReturn(
+				selectResultSetMetaData
+			);
+
+			Mockito.when(
+				selectResultSetMetaData.getColumnCount()
+			).thenReturn(
+				2
+			);
+
+			Mockito.when(
+				selectResultSetMetaData.getColumnName(1)
+			).thenReturn(
+				_PRIMARY_KEY_COLUMN
+			);
+
+			Mockito.when(
+				selectResultSetMetaData.getColumnName(2)
+			).thenReturn(
+				_COLUMN_NAME
+			);
+
+			Mockito.when(
+				selectResultSet.next()
+			).thenReturn(
+				true, true, false
+			);
+
+			Mockito.when(
+				selectResultSet.getString(_PRIMARY_KEY_COLUMN)
+			).thenReturn(
+				"1", "2"
+			);
+
+			Mockito.when(
+				selectResultSet.getString(_COLUMN_NAME)
+			).thenReturn(
+				"value1"
+			);
+
+			PreparedStatement deletePreparedStatement = Mockito.mock(
+				PreparedStatement.class);
+
+			Mockito.when(
+				_connection.prepareStatement(Mockito.anyString())
+			).thenReturn(
+				groupByPreparedStatement, selectPreparedStatement,
+				deletePreparedStatement
+			);
+
+			Mockito.when(
+				_connection.getMetaData()
+			).thenReturn(
+				_databaseMetaData
+			);
+
+			Mockito.when(
+				_databaseMetaData.storesLowerCaseIdentifiers()
+			).thenReturn(
+				false
+			);
+
+			Mockito.when(
+				_databaseMetaData.storesUpperCaseIdentifiers()
+			).thenReturn(
+				false
+			);
+
+			ResultSet columnsResultSet = Mockito.mock(ResultSet.class);
+
+			Mockito.when(
+				_databaseMetaData.getColumns(
+					Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any())
+			).thenReturn(
+				columnsResultSet
+			);
+
+			Mockito.when(
+				columnsResultSet.getInt("DATA_TYPE")
+			).thenReturn(
+				Types.VARCHAR
+			);
+
+			DuplicateUniqueFinderRowsCleaner cleaner =
+				new DuplicateUniqueFinderRowsCleaner(
+					_connection, _TABLE_NAME, new String[] {_COLUMN_NAME},
+					_PRIMARY_KEY_COLUMN + " asc");
+
+			Assert.assertTrue(cleaner.deleteDuplicates());
+
+			Mockito.verify(
+				deletePreparedStatement
+			).execute();
+		}
+	}
+
+	@Test
+	public void testDeleteDuplicatesNoDuplicates() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class)) {
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				Mockito.mock(DB.class)
+			);
+
+			PreparedStatement groupByPreparedStatement = Mockito.mock(
+				PreparedStatement.class);
+			ResultSet groupByResultSet = Mockito.mock(ResultSet.class);
+
+			Mockito.when(
+				groupByPreparedStatement.executeQuery()
+			).thenReturn(
+				groupByResultSet
+			);
+
+			Mockito.when(
+				groupByResultSet.next()
+			).thenReturn(
+				false
+			);
+
+			Mockito.when(
+				_connection.prepareStatement(Mockito.anyString())
+			).thenReturn(
+				groupByPreparedStatement
+			);
+
+			DuplicateUniqueFinderRowsCleaner cleaner =
+				new DuplicateUniqueFinderRowsCleaner(
+					_connection, _TABLE_NAME, new String[] {_COLUMN_NAME},
+					_PRIMARY_KEY_COLUMN + " asc");
+
+			Assert.assertFalse(cleaner.deleteDuplicates());
+		}
+	}
+
+	@Test
+	public void testDeleteDuplicatesNullColumn() throws Exception {
+		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
+				Mockito.mockStatic(DBManagerUtil.class)) {
+
+			DB db = Mockito.mock(DB.class);
+
+			dbManagerUtilMockedStatic.when(
+				DBManagerUtil::getDB
+			).thenReturn(
+				db
+			);
+
+			Mockito.when(
+				db.getPrimaryKeyColumnNames(_connection, _TABLE_NAME)
+			).thenReturn(
+				new String[] {_PRIMARY_KEY_COLUMN}
+			);
+
+			PreparedStatement groupByPreparedStatement = Mockito.mock(
+				PreparedStatement.class);
+			ResultSet groupByResultSet = Mockito.mock(ResultSet.class);
+
+			Mockito.when(
+				groupByPreparedStatement.executeQuery()
+			).thenReturn(
+				groupByResultSet
+			);
+
+			Mockito.when(
+				groupByResultSet.next()
+			).thenReturn(
+				true, false
+			);
+
+			Mockito.when(
+				groupByResultSet.getString(1)
+			).thenReturn(
+				(String)null
+			);
+
+			PreparedStatement selectPreparedStatement = Mockito.mock(
+				PreparedStatement.class);
+			ResultSet selectResultSet = Mockito.mock(ResultSet.class);
+			ResultSetMetaData selectResultSetMetaData = Mockito.mock(
+				ResultSetMetaData.class);
+
+			Mockito.when(
+				selectPreparedStatement.executeQuery()
+			).thenReturn(
+				selectResultSet
+			);
+
+			Mockito.when(
+				selectResultSet.getMetaData()
+			).thenReturn(
+				selectResultSetMetaData
+			);
+
+			Mockito.when(
+				selectResultSetMetaData.getColumnCount()
+			).thenReturn(
+				2
+			);
+
+			Mockito.when(
+				selectResultSetMetaData.getColumnName(1)
+			).thenReturn(
+				_PRIMARY_KEY_COLUMN
+			);
+
+			Mockito.when(
+				selectResultSetMetaData.getColumnName(2)
+			).thenReturn(
+				_COLUMN_NAME
+			);
+
+			Mockito.when(
+				selectResultSet.next()
+			).thenReturn(
+				true, true, false
+			);
+
+			Mockito.when(
+				selectResultSet.getString(_PRIMARY_KEY_COLUMN)
+			).thenReturn(
+				"1", "2"
+			);
+
+			Mockito.when(
+				selectResultSet.getString(_COLUMN_NAME)
+			).thenReturn(
+				(String)null
+			);
+
+			PreparedStatement deletePreparedStatement = Mockito.mock(
+				PreparedStatement.class);
+
+			Mockito.when(
+				_connection.prepareStatement(Mockito.anyString())
+			).thenReturn(
+				groupByPreparedStatement, selectPreparedStatement,
+				deletePreparedStatement
+			);
+
+			Mockito.when(
+				_connection.getMetaData()
+			).thenReturn(
+				_databaseMetaData
+			);
+
+			Mockito.when(
+				_databaseMetaData.storesLowerCaseIdentifiers()
+			).thenReturn(
+				false
+			);
+
+			Mockito.when(
+				_databaseMetaData.storesUpperCaseIdentifiers()
+			).thenReturn(
+				false
+			);
+
+			DuplicateUniqueFinderRowsCleaner cleaner =
+				new DuplicateUniqueFinderRowsCleaner(
+					_connection, _TABLE_NAME, new String[] {_COLUMN_NAME},
+					_PRIMARY_KEY_COLUMN + " asc");
+
+			Assert.assertTrue(cleaner.deleteDuplicates());
+
+			Mockito.verify(
+				deletePreparedStatement
+			).execute();
+		}
+	}
+
+	private static final String _COLUMN_NAME = "col";
+
+	private static final String _PRIMARY_KEY_COLUMN = "id";
+
+	private static final String _TABLE_NAME = "TestTable";
+
+	private final Connection _connection = Mockito.mock(Connection.class);
+	private final DatabaseMetaData _databaseMetaData = Mockito.mock(
+		DatabaseMetaData.class);
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94069

**What is being fixed:** `DuplicateUniqueFinderRowsCleaner.deleteDuplicates()` returned `false` without attempting cleanup whenever any column in the unique index had all-null or all-empty values. This left duplicate rows in place and prevented the corresponding unique index from being created.

**How it is being fixed:** The `_hasUnpopulatedColumn` pre-check — which queried column metadata and row counts before attempting to delete duplicates — is removed entirely. The cleaner now proceeds unconditionally, correctly handling null and empty values in indexed columns. The now-unused `_isStringType` helper, along with its `HashMap` and `Types` imports, are removed as well. Unit tests are added to cover the normal duplicate-deletion path, the no-duplicates path, and the null-column path.