### PR TITLE
LPD-93701 Drain the result set in the progress tracker concurrency test

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
@@ -427,12 +427,22 @@ public class UpgradeLogProgressTrackerTest {
 				tasks.add(
 					() -> {
 						for (int j = 0; j < _ITERATIONS_PER_THREAD; j++) {
-							ResultSet resultSet = _mockResultSet();
+							ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+							Mockito.when(
+								resultSet.next()
+							).thenReturn(
+								true, false
+							);
 
 							ResultSet wrappedResultSet = _wrapResultSet(
 								resultSet, _UPGRADE_PROCESS_CLASS_NAME);
 
-							wrappedResultSet.next();
+							_resetLogTime(wrappedResultSet);
+
+							while (wrappedResultSet.next()) {
+							}
+
 							wrappedResultSet.close();
 						}
 


### PR DESCRIPTION
## Summary

`testConcurrentResultSetIterationDoesNotCorruptProgresses` fails intermittently: the progress map is occasionally non-empty after all threads finish.

The cause is a timing window in the test, not in production. The test runs with `upgrade.log.progress.interval=1` (1 ms) and a mock whose `next()` always returns `true`, so the cursor is never drained. Each iteration stamps `_lastLogTime` in the handler constructor, then calls `next()` once. If more than 1 ms elapses before that call (GC or scheduling on a loaded CI box), `_captureProgress()` fires and puts an entry in the map; `close()` does not remove it, because the entry is only removed when `next()` returns `false`. The stranded entry makes the final assertion fail. On a fast machine under 1 ms elapses, nothing is captured, and the test passes.

The fix makes the iteration deterministic: the mock now returns `true` then `false`, the body resets the log time to force a capture, and the loop drains the cursor to exhaustion. Each iteration therefore performs a put followed by a remove through the real code path, so the map ends empty regardless of timing, and the test still exercises concurrent puts and removes on the shared map, which is its actual purpose.

This is a test-only change. Removing the entry on `close()` instead would also drop processes that fail mid-iteration from the report, which is the opposite of the intended behavior, and would break `testCloseIsIdempotent`, which asserts the entry survives `close()`.

Related: LPD-84022.

## Test plan

- [x] `UpgradeLogProgressTrackerTest`: 33 unit tests pass across three consecutive runs
- [x] `ant format-source-current-branch`: clean