### PR TITLE
LPD-93701 Drain the result set in the progress tracker concurrency test

### DIFF
--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/recorder/UpgradeLogProgressTrackerTest.java
@@ -427,12 +427,22 @@ public class UpgradeLogProgressTrackerTest {
 				tasks.add(
 					() -> {
 						for (int j = 0; j < _ITERATIONS_PER_THREAD; j++) {
-							ResultSet resultSet = _mockResultSet();
+							ResultSet resultSet = Mockito.mock(ResultSet.class);
+
+							Mockito.when(
+								resultSet.next()
+							).thenReturn(
+								true, false
+							);
 
 							ResultSet wrappedResultSet = _wrapResultSet(
 								resultSet, _UPGRADE_PROCESS_CLASS_NAME);
 
-							wrappedResultSet.next();
+							_resetLogTime(wrappedResultSet);
+
+							Assert.assertTrue(wrappedResultSet.next());
+							Assert.assertFalse(wrappedResultSet.next());
+
 							wrappedResultSet.close();
 						}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93701

## What Is Being Fixed

`testConcurrentResultSetIterationDoesNotCorruptProgresses` in `UpgradeLogProgressTrackerTest` fails intermittently with an AssertionFailedError: the progress map is sometimes not empty after all threads finish. The test runs with a one millisecond log interval and a mock whose `next()` always returns true, so the cursor is never drained. Each iteration stamps the log time in the handler constructor and then calls `next()` once. When more than one millisecond elapses before that call on a loaded CI machine, `_captureProgress()` adds an entry to the map, and because the entry is only removed when `next()` returns false, `close()` leaves it stranded. The assertion then fails non-deterministically.

## How It Is Being Fixed

The fix makes the iteration deterministic without changing production code. The mock now returns true and then false, the body resets the log time to force a capture, and two assertions drive `next()` to the end of the result set. Each iteration therefore performs a put followed by a remove through the real code path, so the map ends empty regardless of timing while the test still exercises concurrent puts and removes on the shared map.

The two assertions are ordered by cursor position rather than alphabetically, because each `next()` call advances the result set: the first returns true for the row and the second returns false at the end. Asserting on a stateful `next()` or `hasNext()` call in invocation order rather than alphabetically is an established pattern, for example [ConcurrentIdentityHashMapTest](https://github.com/liferay/liferay-portal/blob/6737a2337308d2f8b144fb7bbe40d5bb497d5038/modules/core/petra/petra-concurrent/src/test/java/com/liferay/petra/concurrent/ConcurrentIdentityHashMapTest.java#L72-L73) asserts `iterator.next()` and then `iterator.hasNext()` in sequence.

## PR Check

**pr-check: PASS** — tested on `5fd2b16084524b805ca6c57810b7efe6fb174727`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Java Unit Tests | PASS |
| Full Portal Build | SKIPPED (not applicable to a test-only change) |

<!-- pr-check {"result": "success", "sha": "5fd2b16084524b805ca6c57810b7efe6fb174727"} -->
