### PR TITLE
LPD-92865 Fix Oracle grant statements to run as sysdba

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15947,7 +15947,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
-									sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba << -'EOF'
+									sqlplus /nolog << -'EOF'
+									connect ${oracle.admin.user}/${oracle.admin.password} as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -16170,7 +16171,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 							<exec executable="/bin/bash" failonerror="true">
 								<arg value="-c" />
-								<arg value="printf 'grant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+								<arg value="printf 'connect ${oracle.admin.user}/${oracle.admin.password} as sysdba\ngrant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus /nolog" />
 							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -15947,7 +15947,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
-									sqlplus ${oracle.admin.user}/${oracle.admin.password} << -'EOF'
+									sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba << -'EOF'
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -16168,12 +16168,10 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" password="${oracle.admin.password}" print="true" url="${database.oracle.url}" userid="${oracle.admin.user}">
-								<![CDATA[
-									grant select on sys.v_$session to lportal;
-									grant select on sys.v_$sql to lportal;
-								]]>
-							</sql>
+							<exec executable="/bin/bash" failonerror="true">
+								<arg value="-c" />
+								<arg value="printf 'grant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />
 						</then>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92865

**What is being fixed:** The CI legacy-import Oracle path in `build-test.xml` issued `grant select on sys.v_$session` and `grant select on sys.v_$sql` via the Ant `<sql>` task running as SYSTEM with `onerror="continue"`. Granting SELECT on SYS-owned `v_$` views requires SYSDBA authority — SYSTEM cannot do it — so the grants silently failed, leaving `lportal` without the required privileges and causing `UpgradeQueryMonitor` to log a warning that failed the upgrade smoke test.

**How it is being fixed:** Both grant invocations in the legacy-import Oracle branch are replaced with `sqlplus ... as sysdba` shell calls via `<exec executable="/bin/bash">`. Running as SYSDBA has the authority to grant on SYS-owned views, so the privilege actually lands on `lportal` before the upgrade test starts.