### PR TITLE
LPD-93831 Fix scope check in JournalDataCleanupPreupgradeProcess

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/JournalDataCleanupPreupgradeProcessTest.java
@@ -16,14 +16,22 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFeed;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.cache.CacheRegistryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -38,6 +46,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -61,10 +70,13 @@ public class JournalDataCleanupPreupgradeProcessTest
 	public void setUp() throws Exception {
 		_classNames = _classNameLocalService.getClassNames(
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		_group = GroupTestUtil.addGroup();
 	}
 
 	@After
 	public void tearDown() throws Exception {
+		_groupLocalService.deleteGroup(_group);
+
 		List<ClassName> classNames = ListUtil.remove(
 			_classNameLocalService.getClassNames(
 				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
@@ -77,17 +89,16 @@ public class JournalDataCleanupPreupgradeProcessTest
 
 	@Test
 	public void testUpgrade() throws Exception {
-		Group group = GroupTestUtil.addGroup();
-
 		JournalArticle journalArticle = JournalTestUtil.addArticle(
-			group.getGroupId(), JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			Collections.emptyMap());
 
-		Layout layout = LayoutTestUtil.addTypeContentLayout(group);
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
 
 		JournalFeed journalFeed = JournalTestUtil.addFeed(
-			group.getGroupId(), layout.getPlid(), RandomTestUtil.randomString(),
-			journalArticle.getDDMStructureId(),
+			_group.getGroupId(), layout.getPlid(),
+			RandomTestUtil.randomString(), journalArticle.getDDMStructureId(),
 			journalArticle.getDDMTemplateKey(),
 			journalArticle.getDDMTemplateKey());
 
@@ -103,16 +114,7 @@ public class JournalDataCleanupPreupgradeProcessTest
 		_ddmTemplateLocalService.deleteTemplate(
 			journalArticle.getDDMTemplate());
 
-		DDMStructure ddmStructure = journalArticle.getDDMStructure();
-
-		DDMStructureVersion ddmStructureVersion =
-			ddmStructure.getStructureVersion();
-
-		_ddmFieldLocalService.deleteDDMFields(
-			ddmStructureVersion.getStructureId());
-
-		_ddmStructureLocalService.deleteStructure(
-			journalArticle.getDDMStructure());
+		_deleteDDMStructure(journalArticle);
 
 		String originalName = PrincipalThreadLocal.getName();
 
@@ -124,8 +126,75 @@ public class JournalDataCleanupPreupgradeProcessTest
 		finally {
 			PrincipalThreadLocal.setName(originalName);
 		}
+	}
 
-		_groupLocalService.deleteGroup(group);
+	@Test
+	public void testUpgradeJournalArticleResourcePermissionScopeCheck()
+		throws Exception {
+
+		JournalArticle journalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			Collections.emptyMap());
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		Role ownerRole = RoleLocalServiceUtil.getRole(companyId, "Owner");
+
+		long ownerRoleId = ownerRole.getRoleId();
+
+		ResourcePermissionLocalServiceUtil.setResourcePermissions(
+			companyId, JournalArticle.class.getName(),
+			ResourceConstants.SCOPE_GROUP, String.valueOf(_group.getGroupId()),
+			ownerRoleId, new String[] {ActionKeys.VIEW});
+
+		runSQL(
+			"delete from JournalArticle where articleId = '" +
+				journalArticle.getArticleId() + "'");
+
+		upgrade();
+
+		CacheRegistryUtil.clear();
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, JournalArticle.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(journalArticle.getResourcePrimKey()),
+				ownerRoleId, ActionKeys.VIEW));
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, JournalArticle.class.getName(),
+				ResourceConstants.SCOPE_GROUP,
+				String.valueOf(_group.getGroupId()), ownerRoleId,
+				ActionKeys.VIEW));
+
+		runSQL(
+			StringBundler.concat(
+				"delete from ResourcePermission where name = '",
+				JournalArticle.class.getName(), "' and scope = ",
+				ResourceConstants.SCOPE_GROUP, " and primKey = '",
+				_group.getGroupId(), "'"));
+
+		_ddmTemplateLocalService.deleteTemplate(
+			journalArticle.getDDMTemplate());
+
+		_deleteDDMStructure(journalArticle);
+	}
+
+	private void _deleteDDMStructure(JournalArticle journalArticle)
+		throws Exception {
+
+		DDMStructure ddmStructure = journalArticle.getDDMStructure();
+
+		DDMStructureVersion ddmStructureVersion =
+			ddmStructure.getStructureVersion();
+
+		_ddmFieldLocalService.deleteDDMFields(
+			ddmStructureVersion.getStructureId());
+
+		_ddmStructureLocalService.deleteStructure(ddmStructure);
 	}
 
 	@Inject
@@ -142,10 +211,15 @@ public class JournalDataCleanupPreupgradeProcessTest
 	@Inject
 	private DDMTemplateLocalService _ddmTemplateLocalService;
 
+	private Group _group;
+
 	@Inject
 	private GroupLocalService _groupLocalService;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/JournalDataCleanupPreupgradeProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.upgrade.data.cleanup.FilterableAllTablesOrphanReferencesDataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.upgrade.data.cleanup.TableOrphanReferencesDataCleanupPreupgradeProcess;
@@ -45,15 +46,21 @@ public class JournalDataCleanupPreupgradeProcess
 		upgrade(
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
-				"[$SOURCE_TABLE_ALIAS$].name = 'com.liferay.journal.model." +
-					"JournalArticle'",
+				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					" and [$SOURCE_TABLE_ALIAS$].name = ",
+					"'com.liferay.journal.model.JournalArticle'"),
 				"primKeyId", "ResourcePermission", "resourcePrimKey",
 				"JournalArticle"));
 		upgrade(
 			new TableOrphanReferencesDataCleanupPreupgradeProcess(
 				null,
-				"[$SOURCE_TABLE_ALIAS$].name = 'com.liferay.journal.model." +
-					"JournalFeed'",
+				StringBundler.concat(
+					"[$SOURCE_TABLE_ALIAS$].scope = ",
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					" and [$SOURCE_TABLE_ALIAS$].name = ",
+					"'com.liferay.journal.model.JournalFeed'"),
 				"primKeyId", "ResourcePermission", "id_", "JournalFeed"));
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93831

## What Is Being Fixed

In JournalDataCleanupPreupgradeProcess, introduced in LPD-69584. The cleanup step removes ResourcePermission rows for JournalArticle where primKeyId has no matching resourcePrimKey in the JournalArticle table. Because it filters only by name and not by scope, it also evaluates group-level permissions (SCOPE_GROUP), whose primKeyId holds the site's groupId. Since a groupId never appears in JournalArticle.resourcePrimKey, those rows are incorrectly treated as orphans and deleted.

## How It Is Being Fixed

The sourceAdditionalWhereClause for both the JournalArticle and JournalFeed ResourcePermission cleanup steps is narrowed to scope = SCOPE_INDIVIDUAL. This restricts the orphan check to individual-resource permissions — the only scope where primKeyId is expected to match a row in the entity table. Company-, group-template-, and group-level permissions are left untouched.

## How to verify the fix

Run the included tests