### PR TITLE
LPD-93238 Group ResourcePermission class names by target table for cleanup

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -19,7 +20,11 @@ import com.liferay.portal.security.permission.ResourceActionsImpl;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * @author Luis Ortiz
@@ -40,6 +45,8 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
+		Map<String, List<String>> namesByTableName = new TreeMap<>();
+
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select distinct name from ResourcePermission where name " +
 					"like 'com.liferay.%' and primKeyId != 0 and primKeyId " +
@@ -51,12 +58,14 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 				ResourceActionsImpl resourceActionsImpl =
 					new ResourceActionsImpl();
 
+				String compositeModelNameSeparator =
+					resourceActionsImpl.getCompositeModelNameSeparator();
+
 				while (resultSet.next()) {
 					String name = resultSet.getString("name");
 
 					String[] classNames = StringUtil.split(
-						name,
-						resourceActionsImpl.getCompositeModelNameSeparator());
+						name, compositeModelNameSeparator);
 
 					String tableName = null;
 
@@ -102,38 +111,56 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 						continue;
 					}
 
-					String primaryKeyColumnName = "resourcePrimKey";
+					List<String> names = namesByTableName.computeIfAbsent(
+						tableName, key -> new ArrayList<>());
 
-					if (!dbInspector.hasColumn(
-							tableName, primaryKeyColumnName)) {
-
-						primaryKeyColumnName =
-							DataCleanupPreupgradeProcessUtil.
-								getPrimaryKeyColumnName(
-									connection, dbInspector, tableName);
-					}
-
-					if (primaryKeyColumnName == null) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(
-								"Skipping table " + tableName +
-									" because it does not have a primary key");
-						}
-
-						continue;
-					}
-
-					upgrade(
-						new TableOrphanReferencesDataCleanupPreupgradeProcess(
-							null,
-							StringBundler.concat(
-								"[$SOURCE_TABLE_ALIAS$].scope = ",
-								ResourceConstants.SCOPE_INDIVIDUAL, " and ",
-								"[$SOURCE_TABLE_ALIAS$].name = '", name, "'"),
-							"primKeyId", "ResourcePermission",
-							primaryKeyColumnName, tableName));
+					names.add(name);
 				}
 			}
+		}
+
+		for (Map.Entry<String, List<String>> entry :
+				namesByTableName.entrySet()) {
+
+			String tableName = entry.getKey();
+
+			String primaryKeyColumnName = "resourcePrimKey";
+
+			if (!dbInspector.hasColumn(tableName, primaryKeyColumnName)) {
+				primaryKeyColumnName =
+					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
+						connection, dbInspector, tableName);
+			}
+
+			if (primaryKeyColumnName == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Skipping table " + tableName +
+							" because it does not have a primary key");
+				}
+
+				continue;
+			}
+
+			List<String> names = entry.getValue();
+
+			List<String> quotedNames = new ArrayList<>(names.size());
+
+			for (String name : names) {
+				quotedNames.add(StringBundler.concat("'", name, "'"));
+			}
+
+			upgrade(
+				new TableOrphanReferencesDataCleanupPreupgradeProcess(
+					null,
+					StringBundler.concat(
+						"[$SOURCE_TABLE_ALIAS$].scope = ",
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						" and [$SOURCE_TABLE_ALIAS$].name in (",
+						String.join(StringPool.COMMA_AND_SPACE, quotedNames),
+						")"),
+					"primKeyId", "ResourcePermission", primaryKeyColumnName,
+					tableName));
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93238

## What Is Being Fixed

ResourcePermissionDataCleanupPreupgradeProcess was issuing one TableOrphanReferencesDataCleanupPreupgradeProcess upgrade() call per resource class name, resulting in roughly 32 separate passes over the ResourcePermission table — one per name — even when many names resolve to the same target table (e.g., composite and simple class names that both map to JournalArticle).

## How It Is Being Fixed

Class names are now grouped by their resolved target table into a Map<String, List<String>> (namesByTableName). After the ResultSet loop finishes, one upgrade() call is issued per table, passing a `name in ('...', '...')` clause as the sourceAdditionalWhereClause instead of a single `name = '...'` equality check. The compositeModelNameSeparator is extracted to a local variable before the loop so getCompositeModelNameSeparator() is not called on every iteration. This reduces roughly 32 per-name passes to one pass per distinct target table.

## Why Are There No Tests?

The existing integration test ResourcePermissionDataCleanupPreupgradeProcessTest already covers the behavior, including the grouping case where composite and simple class names map to the same JournalArticle table. No new test is needed.

## PR Check

**pr-check: PASS** — tested on `7b7228a762267286d7ad5d88a8aa5e161d08f1fd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | — no unit counterpart in portal-impl (covered by existing integration test) |

<!-- pr-check {"result": "success", "sha": "7b7228a762267286d7ad5d88a8aa5e161d08f1fd"} -->