### PR TITLE
LPD-93239 Compute counter max server-side and run cleanup concurrently

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
@@ -248,6 +248,50 @@ public class CounterDataCleanupPreupgradeProcessTest
 	}
 
 	@Test
+	public void testUpgradeDLFileEntrySpecificCounterFilters()
+		throws Exception {
+
+		long fileEntryId1 = CounterLocalServiceUtil.increment();
+		long fileEntryId2 = CounterLocalServiceUtil.increment();
+		long fileEntryId3 = CounterLocalServiceUtil.increment();
+		long name =
+			CounterLocalServiceUtil.getCurrentId(DLFileEntry.class.getName()) +
+				100;
+
+		_test(
+			(UnsafeRunnable<Exception>)() -> runSQL(
+				StringBundler.concat(
+					"delete from DLFileEntry where fileEntryId in (",
+					fileEntryId1, ", ", fileEntryId2, ", ", fileEntryId3, ")")),
+			(UnsafeRunnable<Exception>)() -> {
+				runSQL(
+					StringBundler.concat(
+						"insert into DLFileEntry (mvccVersion, ",
+						"ctCollectionId, fileEntryId, name) values (0, 0,",
+						fileEntryId1, ", '", name, "')"));
+				runSQL(
+					StringBundler.concat(
+						"insert into DLFileEntry (mvccVersion, ",
+						"ctCollectionId, fileEntryId, name) values (0, 0,",
+						fileEntryId2, ", 'non-numeric')"));
+				runSQL(
+					StringBundler.concat(
+						"insert into DLFileEntry (mvccVersion, ",
+						"ctCollectionId, fileEntryId, name) values (0, 0,",
+						fileEntryId3, ", '99999999999999999999')"));
+			},
+			(UnsafeConsumer<List<String>, Exception>)messages -> {
+				Assert.assertEquals(messages.toString(), 1, messages.size());
+				Assert.assertTrue(
+					messages.toString(),
+					messages.contains(
+						StringBundler.concat(
+							"Counter ", DLFileEntry.class.getName(),
+							" has been reset to value ", name)));
+			});
+	}
+
+	@Test
 	public void testUpgradeKernelCounter() throws Exception {
 		long roleId =
 			CounterLocalServiceUtil.getCurrentId(Counter.class.getName()) +

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -14,7 +14,6 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -164,9 +163,7 @@ public class CounterDataCleanupPreupgradeProcess
 					return;
 				}
 
-				try (Connection threadConnection =
-						DataAccess.getConnection()) {
-
+				try (Connection threadConnection = getConnection()) {
 					String columnName =
 						DataCleanupPreupgradeProcessUtil.
 							getPrimaryKeyColumnName(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -10,7 +10,10 @@ import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -25,7 +28,9 @@ import java.sql.ResultSet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -115,7 +120,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 				if (!dbInspector.hasTable(tableName)) {
 					if (_log.isWarnEnabled()) {
-						_log.warn("Table " + tableName + " does not exist");
+						_log.warn("Table \"" + tableName + "\" does not exist");
 					}
 
 					continue;
@@ -146,31 +151,45 @@ public class CounterDataCleanupPreupgradeProcess
 		tableNames.remove(dbInspector.normalizeName("Counter"));
 		tableNames.removeAll(excludedTableNames);
 
+		Map<String, Long> tableMaxValues = new ConcurrentHashMap<>();
+
+		processConcurrently(
+			tableNames.toArray(new String[0]),
+			tableName -> {
+				if (!dbInspector.isObjectTable(tableName) &&
+					!_liferayTableNames.contains(tableName)) {
+
+					return;
+				}
+
+				String columnName =
+					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
+						connection, dbInspector, tableName);
+
+				if ((columnName == null) ||
+					!dbInspector.isNumeric(tableName, columnName)) {
+
+					return;
+				}
+
+				long maxValue = _getMaxValue(
+					columnName, dbInspector, tableName);
+
+				if (maxValue > 0) {
+					tableMaxValues.put(tableName, maxValue);
+				}
+			},
+			null);
+
 		long latestCounterValue = 0L;
 		String maxValueTableName = null;
 
-		for (String tableName : tableNames) {
-			if (!dbInspector.isObjectTable(tableName) &&
-				!_liferayTableNames.contains(tableName)) {
+		for (Map.Entry<String, Long> entry : tableMaxValues.entrySet()) {
+			long value = entry.getValue();
 
-				continue;
-			}
-
-			String columnName =
-				DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
-					connection, dbInspector, tableName);
-
-			if ((columnName == null) ||
-				!dbInspector.isNumeric(tableName, columnName)) {
-
-				continue;
-			}
-
-			long maxValue = _getMaxValue(columnName, dbInspector, tableName);
-
-			if (maxValue > latestCounterValue) {
-				latestCounterValue = maxValue;
-				maxValueTableName = tableName;
+			if (value > latestCounterValue) {
+				latestCounterValue = value;
+				maxValueTableName = entry.getKey();
 			}
 		}
 
@@ -205,7 +224,7 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.hasTable("Layout")) {
-			_log.error("Table Layout does not exist");
+			_log.error("Table \"Layout\" does not exist");
 
 			return;
 		}
@@ -289,10 +308,10 @@ public class CounterDataCleanupPreupgradeProcess
 	}
 
 	private String _getLogMessage(
-		String counterName, long countervalue, String tableName) {
+		String counterName, long counterValue, String tableName) {
 
 		return StringBundler.concat(
-			"Counter ", counterName, " has been reset to value ", countervalue,
+			"Counter ", counterName, " has been reset to value ", counterValue,
 			(tableName != null) ? " due to table " + tableName : "");
 	}
 
@@ -301,6 +320,123 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
+			DB db = DBManagerUtil.getDB();
+
+			DBType dbType = db.getDBType();
+
+			if (dbType == DBType.DB2) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName, " where regexp_like(", columnName,
+								", '^[0-9]+$')"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as unsigned)) as ", columnName, " from ",
+								tableName, " where ", columnName,
+								" regexp '^[0-9]+$'"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.ORACLE) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(to_number(", columnName, ")) as ",
+								columnName, " from ", tableName, " where ",
+								"regexp_like(", columnName, ", '^[0-9]+$')"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.POSTGRESQL) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName, " where ", columnName,
+								" ~ '^[0-9]+$'"));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
+			if (dbType == DBType.SQLSERVER) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select max(try_cast(", columnName,
+								" as bigint)) as ", columnName, " from ",
+								tableName));
+
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					if (resultSet.next()) {
+						long maxValue = resultSet.getLong(columnName);
+
+						if (!resultSet.wasNull()) {
+							return maxValue;
+						}
+					}
+				}
+
+				return 0L;
+			}
+
 			long maxValue = 0;
 
 			try (PreparedStatement preparedStatement =
@@ -311,13 +447,13 @@ public class CounterDataCleanupPreupgradeProcess
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					String value = resultSet.getString(columnName);
+					String valueString = resultSet.getString(columnName);
 
 					try {
-						long valueLong = Long.parseLong(value);
+						long value = Long.parseLong(valueString);
 
-						if (valueLong > maxValue) {
-							maxValue = valueLong;
+						if (value > maxValue) {
+							maxValue = value;
 						}
 					}
 					catch (NumberFormatException numberFormatException) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -120,7 +120,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 				if (!dbInspector.hasTable(tableName)) {
 					if (_log.isWarnEnabled()) {
-						_log.warn("Table \"" + tableName + "\" does not exist");
+						_log.warn("Table " + tableName + " does not exist");
 					}
 
 					continue;
@@ -308,10 +308,10 @@ public class CounterDataCleanupPreupgradeProcess
 	}
 
 	private String _getLogMessage(
-		String counterName, long counterValue, String tableName) {
+		String counterName, long countervalue, String tableName) {
 
 		return StringBundler.concat(
-			"Counter ", counterName, " has been reset to value ", counterValue,
+			"Counter ", counterName, " has been reset to value ", countervalue,
 			(tableName != null) ? " due to table " + tableName : "");
 	}
 
@@ -324,105 +324,11 @@ public class CounterDataCleanupPreupgradeProcess
 
 			DBType dbType = db.getDBType();
 
-			if (dbType == DBType.DB2) {
+			String sql = _getMaxValueSQL(columnName, dbType, tableName);
+
+			if (sql != null) {
 				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(cast(", columnName,
-								" as bigint)) as ", columnName, " from ",
-								tableName, " where regexp_like(", columnName,
-								", '^[0-9]{1,18}$')"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(cast(", columnName,
-								" as unsigned)) as ", columnName, " from ",
-								tableName, " where ", columnName,
-								" regexp '^[0-9]{1,18}$'"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if (dbType == DBType.ORACLE) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(to_number(", columnName, ")) as ",
-								columnName, " from ", tableName, " where ",
-								"regexp_like(", columnName,
-								", '^[0-9]{1,18}$')"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if (dbType == DBType.POSTGRESQL) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(cast(", columnName,
-								" as bigint)) as ", columnName, " from ",
-								tableName, " where ", columnName,
-								" ~ '^[0-9]{1,18}$'"));
-
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					if (resultSet.next()) {
-						long maxValue = resultSet.getLong(columnName);
-
-						if (!resultSet.wasNull()) {
-							return maxValue;
-						}
-					}
-				}
-
-				return 0L;
-			}
-
-			if (dbType == DBType.SQLSERVER) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select max(try_cast(", columnName,
-								" as bigint)) as ", columnName, " from ",
-								tableName));
+						connection.prepareStatement(sql);
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -448,13 +354,13 @@ public class CounterDataCleanupPreupgradeProcess
 				ResultSet resultSet = preparedStatement.executeQuery()) {
 
 				while (resultSet.next()) {
-					String valueString = resultSet.getString(columnName);
+					String value = resultSet.getString(columnName);
 
 					try {
-						long value = Long.parseLong(valueString);
+						long valueLong = Long.parseLong(value);
 
-						if (value > maxValue) {
-							maxValue = value;
+						if (valueLong > maxValue) {
+							maxValue = valueLong;
 						}
 					}
 					catch (NumberFormatException numberFormatException) {
@@ -481,6 +387,46 @@ public class CounterDataCleanupPreupgradeProcess
 		}
 
 		return 0L;
+	}
+
+	private String _getMaxValueSQL(
+		String columnName, DBType dbType, String tableName) {
+
+		if (dbType == DBType.DB2) {
+			return StringBundler.concat(
+				"select max(cast(", columnName, " as bigint)) as ", columnName,
+				" from ", tableName, " where regexp_like(", columnName,
+				", '^[0-9]{1,18}$')");
+		}
+
+		if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
+			return StringBundler.concat(
+				"select max(cast(", columnName, " as unsigned)) as ", columnName,
+				" from ", tableName, " where ", columnName,
+				" regexp '^[0-9]{1,18}$'");
+		}
+
+		if (dbType == DBType.ORACLE) {
+			return StringBundler.concat(
+				"select max(to_number(", columnName, ")) as ", columnName,
+				" from ", tableName, " where regexp_like(", columnName,
+				", '^[0-9]{1,18}$')");
+		}
+
+		if (dbType == DBType.POSTGRESQL) {
+			return StringBundler.concat(
+				"select max(cast(", columnName, " as bigint)) as ", columnName,
+				" from ", tableName, " where ", columnName,
+				" ~ '^[0-9]{1,18}$'");
+		}
+
+		if (dbType == DBType.SQLSERVER) {
+			return StringBundler.concat(
+				"select max(try_cast(", columnName, " as bigint)) as ",
+				columnName, " from ", tableName);
+		}
+
+		return null;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -321,7 +321,6 @@ public class CounterDataCleanupPreupgradeProcess
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
 			DB db = DBManagerUtil.getDB();
-
 			DBType dbType = db.getDBType();
 
 			if (dbType == DBType.DB2) {
@@ -331,7 +330,7 @@ public class CounterDataCleanupPreupgradeProcess
 								"select max(cast(", columnName,
 								" as bigint)) as ", columnName, " from ",
 								tableName, " where regexp_like(", columnName,
-								", '^[0-9]+$')"));
+								", '^[0-9]{1,18}$')"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -354,7 +353,7 @@ public class CounterDataCleanupPreupgradeProcess
 								"select max(cast(", columnName,
 								" as unsigned)) as ", columnName, " from ",
 								tableName, " where ", columnName,
-								" regexp '^[0-9]+$'"));
+								" regexp '^[0-9]{1,18}$'"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -376,7 +375,8 @@ public class CounterDataCleanupPreupgradeProcess
 							StringBundler.concat(
 								"select max(to_number(", columnName, ")) as ",
 								columnName, " from ", tableName, " where ",
-								"regexp_like(", columnName, ", '^[0-9]+$')"));
+								"regexp_like(", columnName,
+								", '^[0-9]{1,18}$')"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -399,7 +399,7 @@ public class CounterDataCleanupPreupgradeProcess
 								"select max(cast(", columnName,
 								" as bigint)) as ", columnName, " from ",
 								tableName, " where ", columnName,
-								" ~ '^[0-9]+$'"));
+								" ~ '^[0-9]{1,18}$'"));
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -321,6 +321,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
 			DB db = DBManagerUtil.getDB();
+
 			DBType dbType = db.getDBType();
 
 			if (dbType == DBType.DB2) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -224,7 +224,7 @@ public class CounterDataCleanupPreupgradeProcess
 		throws Exception {
 
 		if (!dbInspector.hasTable("Layout")) {
-			_log.error("Table \"Layout\" does not exist");
+			_log.error("Table Layout does not exist");
 
 			return;
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -322,9 +322,7 @@ public class CounterDataCleanupPreupgradeProcess
 		if (!dbInspector.isNumeric(tableName, columnName)) {
 			DB db = DBManagerUtil.getDB();
 
-			DBType dbType = db.getDBType();
-
-			String sql = _getMaxValueSQL(columnName, dbType, tableName);
+			String sql = _getMaxValueSQL(columnName, db.getDBType(), tableName);
 
 			if (sql != null) {
 				try (PreparedStatement preparedStatement =
@@ -401,8 +399,8 @@ public class CounterDataCleanupPreupgradeProcess
 
 		if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
 			return StringBundler.concat(
-				"select max(cast(", columnName, " as unsigned)) as ", columnName,
-				" from ", tableName, " where ", columnName,
+				"select max(cast(", columnName, " as unsigned)) as ",
+				columnName, " from ", tableName, " where ", columnName,
 				" regexp '^[0-9]{1,18}$'");
 		}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -23,6 +24,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
@@ -162,21 +164,26 @@ public class CounterDataCleanupPreupgradeProcess
 					return;
 				}
 
-				String columnName =
-					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
-						connection, dbInspector, tableName);
+				try (Connection threadConnection =
+						DataAccess.getConnection()) {
 
-				if ((columnName == null) ||
-					!dbInspector.isNumeric(tableName, columnName)) {
+					String columnName =
+						DataCleanupPreupgradeProcessUtil.
+							getPrimaryKeyColumnName(
+								threadConnection, dbInspector, tableName);
 
-					return;
-				}
+					if ((columnName == null) ||
+						!dbInspector.isNumeric(tableName, columnName)) {
 
-				long maxValue = _getMaxValue(
-					columnName, dbInspector, tableName);
+						return;
+					}
 
-				if (maxValue > 0) {
-					tableMaxValues.put(tableName, maxValue);
+					long maxValue = _getMaxValue(
+						columnName, dbInspector, tableName, threadConnection);
+
+					if (maxValue > 0) {
+						tableMaxValues.put(tableName, maxValue);
+					}
 				}
 			},
 			null);
@@ -316,7 +323,8 @@ public class CounterDataCleanupPreupgradeProcess
 	}
 
 	private long _getMaxValue(
-			String columnName, DBInspector dbInspector, String tableName)
+			String columnName, DBInspector dbInspector, String tableName,
+			Connection threadConnection)
 		throws Exception {
 
 		if (!dbInspector.isNumeric(tableName, columnName)) {
@@ -326,7 +334,7 @@ public class CounterDataCleanupPreupgradeProcess
 
 			if (sql != null) {
 				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(sql);
+						threadConnection.prepareStatement(sql);
 
 					ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -345,7 +353,7 @@ public class CounterDataCleanupPreupgradeProcess
 			long maxValue = 0;
 
 			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(
+					threadConnection.prepareStatement(
 						StringBundler.concat(
 							"select ", columnName, " from ", tableName));
 
@@ -372,10 +380,11 @@ public class CounterDataCleanupPreupgradeProcess
 			return maxValue;
 		}
 
-		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"select max(", columnName, ") as ", columnName, " from ",
-					tableName));
+		try (PreparedStatement preparedStatement =
+				threadConnection.prepareStatement(
+					StringBundler.concat(
+						"select max(", columnName, ") as ", columnName,
+						" from ", tableName));
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93239

**What is being fixed:** CounterDataCleanupPreupgradeProcess was fetching all
rows from non-numeric name columns into Java to find the maximum numeric-looking
value, and it processed tables sequentially — making the cleanup both
memory-intensive and slow on large installations.

**How it is being fixed:** Each DB vendor now receives a native SQL query that
filters and casts in the database: DB2/Oracle/PostgreSQL use regex + cast to
bigint, MariaDB/MySQL use a regexp + cast-to-unsigned, and SQL Server uses
try_cast (which handles non-numeric values implicitly). The per-table max
queries are also parallelised with processConcurrently, collecting results into
a ConcurrentHashMap before the final reduction. A new test
testUpgradeDLFileEntrySpecificCounterFilters covers non-numeric names and
values that would overflow a long, confirming they are skipped correctly.

Supersedes: https://github.com/liferay-database-infra/liferay-portal/pull/3631

**pr-check: PASS** — tested on `73f990f5d608c683b9547227c330e8d57b440e76`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "73f990f5d608c683b9547227c330e8d57b440e76"} -->