### PR TITLE
LPD-92724 Add temporary index to speed up DDMFieldAttributeUpgradeProcess

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -9,8 +9,11 @@ import com.liferay.adaptive.media.image.html.constants.AMImageHTMLConstants;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -59,65 +62,73 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long classNameId = _classNameLocalService.getClassNameId(
-			"com.liferay.journal.model.JournalArticle");
+		DB db = DBManagerUtil.getDB();
 
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				StringBundler.concat(
-					"select DDMFieldAttribute.ctCollectionId, ",
-					"DDMFieldAttribute.fieldAttributeId, DDMFieldAttribute.",
-					"companyId, DDMFieldAttribute.largeAttributeValue, ",
-					"DDMFieldAttribute.smallAttributeValue from DDMStructure ",
-					"inner join DDMStructureVersion on DDMStructure.",
-					"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
-					"DDMStructure.structureId = DDMStructureVersion.",
-					"structureId inner join DDMField on DDMStructureVersion.",
-					"ctCollectionId = DDMField.ctCollectionId and ",
-					"DDMStructureVersion.structureVersionId = DDMField.",
-					"structureVersionId inner join DDMFieldAttribute on ",
-					"DDMField.ctCollectionId = DDMFieldAttribute.",
-					"ctCollectionId and DDMField.fieldId = DDMFieldAttribute.",
-					"fieldId where DDMStructure.classNameId = ? and DDMField.",
-					"fieldType = 'rich_text'"));
-			PreparedStatement preparedStatement2 =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					"update DDMFieldAttribute set largeAttributeValue = ?, " +
-						"smallAttributeValue = ? where ctCollectionId = ? " +
-							"and fieldAttributeId = ?")) {
+		String selectSQL = StringBundler.concat(
+			"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
+			"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
+			"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
+			"DDMStructure inner join DDMStructureVersion on DDMStructure.",
+			"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
+			"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
+			"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
+			"ctCollectionId and DDMStructureVersion.structureVersionId = ",
+			"DDMField.structureVersionId inner join DDMFieldAttribute on ",
+			"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
+			"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
+			"classNameId = ? and DDMField.fieldType = 'rich_text'");
 
-			preparedStatement1.setLong(1, classNameId);
+		String updateSQL =
+			"update DDMFieldAttribute set largeAttributeValue = ?, " +
+				"smallAttributeValue = ? where ctCollectionId = ? and " +
+					"fieldAttributeId = ?";
 
-			ResultSet resultSet = preparedStatement1.executeQuery();
+		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
+				connection, "DDMFieldAttribute", false, "fieldId",
+				"ctCollectionId")) {
 
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
+			long classNameId = _classNameLocalService.getClassNameId(
+				"com.liferay.journal.model.JournalArticle");
 
-				String largeAttributeValue = _transform(
-					companyId, resultSet.getString("largeAttributeValue"));
-				String smallAttributeValue = _transform(
-					companyId, resultSet.getString("smallAttributeValue"));
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(selectSQL);
+				PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection, updateSQL)) {
 
-				if ((smallAttributeValue != null) &&
-					(smallAttributeValue.length() > 255)) {
+				preparedStatement1.setLong(1, classNameId);
 
-					largeAttributeValue = smallAttributeValue;
+				ResultSet resultSet = preparedStatement1.executeQuery();
 
-					smallAttributeValue = null;
+				while (resultSet.next()) {
+					long companyId = resultSet.getLong("companyId");
+
+					String largeAttributeValue = _transform(
+						companyId, resultSet.getString("largeAttributeValue"));
+					String smallAttributeValue = _transform(
+						companyId, resultSet.getString("smallAttributeValue"));
+
+					if ((smallAttributeValue != null) &&
+						(smallAttributeValue.length() > 255)) {
+
+						largeAttributeValue = smallAttributeValue;
+
+						smallAttributeValue = null;
+					}
+
+					preparedStatement2.setString(1, largeAttributeValue);
+					preparedStatement2.setString(2, smallAttributeValue);
+
+					preparedStatement2.setLong(
+						3, resultSet.getLong("ctCollectionId"));
+					preparedStatement2.setLong(
+						4, resultSet.getLong("fieldAttributeId"));
+
+					preparedStatement2.addBatch();
 				}
 
-				preparedStatement2.setString(1, largeAttributeValue);
-				preparedStatement2.setString(2, smallAttributeValue);
-
-				preparedStatement2.setLong(
-					3, resultSet.getLong("ctCollectionId"));
-				preparedStatement2.setLong(
-					4, resultSet.getLong("fieldAttributeId"));
-
-				preparedStatement2.addBatch();
+				preparedStatement2.executeBatch();
 			}
-
-			preparedStatement2.executeBatch();
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -64,6 +64,9 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		DB db = DBManagerUtil.getDB();
 
+		long classNameId = _classNameLocalService.getClassNameId(
+			"com.liferay.journal.model.JournalArticle");
+
 		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
 				connection, "DDMFieldAttribute", false, "ctCollectionId",
 				"fieldId")) {
@@ -88,9 +91,6 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 				"update DDMFieldAttribute set largeAttributeValue = ?, " +
 					"smallAttributeValue = ? where ctCollectionId = ? and " +
 						"fieldAttributeId = ?";
-
-			long classNameId = _classNameLocalService.getClassNameId(
-				"com.liferay.journal.model.JournalArticle");
 
 			try (PreparedStatement preparedStatement1 =
 					connection.prepareStatement(selectSQL);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -84,8 +84,8 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 					"fieldAttributeId = ?";
 
 		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
-				connection, "DDMFieldAttribute", false, "fieldId",
-				"ctCollectionId")) {
+				connection, "DDMFieldAttribute", false, "ctCollectionId",
+				"fieldId")) {
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				"com.liferay.journal.model.JournalArticle");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -70,17 +70,19 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 
 			String selectSQL = StringBundler.concat(
 				"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
-				"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
-				"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
-				"DDMStructure inner join DDMStructureVersion on DDMStructure.",
-				"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
-				"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
-				"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
+				"fieldAttributeId, DDMFieldAttribute.companyId, ",
+				"DDMFieldAttribute.largeAttributeValue, DDMFieldAttribute.",
+				"smallAttributeValue from DDMStructure inner join ",
+				"DDMStructureVersion on DDMStructure.ctCollectionId = ",
+				"DDMStructureVersion.ctCollectionId and DDMStructure.",
+				"structureId = DDMStructureVersion.structureId inner join ",
+				"DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
 				"ctCollectionId and DDMStructureVersion.structureVersionId = ",
 				"DDMField.structureVersionId inner join DDMFieldAttribute on ",
-				"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
-				"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
-				"classNameId = ? and DDMField.fieldType = 'rich_text'");
+				"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId ",
+				"and DDMField.fieldId = DDMFieldAttribute.fieldId where ",
+				"DDMStructure.classNameId = ? and DDMField.fieldType = ",
+				"'rich_text'");
 
 			String updateSQL =
 				"update DDMFieldAttribute set largeAttributeValue = ?, " +

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -64,28 +64,28 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		DB db = DBManagerUtil.getDB();
 
-		String selectSQL = StringBundler.concat(
-			"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
-			"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
-			"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
-			"DDMStructure inner join DDMStructureVersion on DDMStructure.",
-			"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
-			"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
-			"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
-			"ctCollectionId and DDMStructureVersion.structureVersionId = ",
-			"DDMField.structureVersionId inner join DDMFieldAttribute on ",
-			"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
-			"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
-			"classNameId = ? and DDMField.fieldType = 'rich_text'");
-
-		String updateSQL =
-			"update DDMFieldAttribute set largeAttributeValue = ?, " +
-				"smallAttributeValue = ? where ctCollectionId = ? and " +
-					"fieldAttributeId = ?";
-
 		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
 				connection, "DDMFieldAttribute", false, "ctCollectionId",
 				"fieldId")) {
+
+			String selectSQL = StringBundler.concat(
+				"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
+				"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
+				"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
+				"DDMStructure inner join DDMStructureVersion on DDMStructure.",
+				"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
+				"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
+				"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
+				"ctCollectionId and DDMStructureVersion.structureVersionId = ",
+				"DDMField.structureVersionId inner join DDMFieldAttribute on ",
+				"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
+				"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
+				"classNameId = ? and DDMField.fieldType = 'rich_text'");
+
+			String updateSQL =
+				"update DDMFieldAttribute set largeAttributeValue = ?, " +
+					"smallAttributeValue = ? where ctCollectionId = ? and " +
+						"fieldAttributeId = ?";
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				"com.liferay.journal.model.JournalArticle");

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/AssetEntryResourceTest.java
@@ -189,6 +189,7 @@ public class AssetEntryResourceTest extends BaseAssetEntryResourceTestCase {
 		Long groupId = testGroup.getGroupId();
 
 		BlogsEntry approvedBlogsEntry = _addBlogsEntry(groupId);
+
 		BlogsEntry draftBlogsEntry = _addBlogsEntry(groupId);
 
 		BlogsEntryLocalServiceUtil.updateStatus(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92724

## What Is Being Fixed

The v5_6_1 DDMFieldAttributeUpgradeProcess runs a SELECT that joins DDMStructure → DDMStructureVersion → DDMField → DDMFieldAttribute filtered on DDMField.fieldType = 'rich_text'. With no index covering the (ctCollectionId, fieldId) lookup, the query executes as a full table scan against DDMFieldAttribute (~3.5M rows), taking ~81s on a partition-large database dump.

## How It Is Being Fixed

A temporary composite index on (ctCollectionId, fieldId) is created inside DDMFieldAttributeUpgradeProcess.doUpgrade() via db.addTemporaryIndex() wrapped in a SafeCloseable try-with-resources block. The index is automatically dropped when doUpgrade() completes, leaving no permanent write overhead on the table.

## Why Are There No Tests?

The upgrade logic is an optimization to an existing doUpgrade() method. The temporary index is created and dropped within the same transaction scope — there is no new behavior to assert, only a performance improvement to the existing upgrade path.

## PR Check

**pr-check: PASS** — tested on `84b39848f526ce2836e98d725429e1de7001865a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Structural Smoke | PASS (pre-existing unrelated failures excluded) |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "84b39848f526ce2836e98d725429e1de7001865a"} -->