### PR TITLE
LPD-94287 Paginate and isolate expired journal article cleanup

### DIFF
--- a/modules/apps/cookies/cookies-rest-api/src/main/java/com/liferay/cookies/rest/resource/v1_0/CookiesConsentPreferenceResource.java
+++ b/modules/apps/cookies/cookies-rest-api/src/main/java/com/liferay/cookies/rest/resource/v1_0/CookiesConsentPreferenceResource.java
@@ -14,15 +14,12 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import jakarta.annotation.Generated;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -44,10 +41,10 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CookiesConsentPreferenceResource {
 
+	public void deleteCookiesConsentPreference() throws Exception;
+
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception;
-
-	public void deleteCookiesConsentPreferences() throws Exception;
 
 	public CookiesConsentPreference getCookiesConsentPreferenceByName(
 			String name)
@@ -55,10 +52,6 @@ public interface CookiesConsentPreferenceResource {
 
 	public CookiesConsentPreference putCookiesConsentPreference(
 			CookiesConsentPreference cookiesConsentPreference)
-		throws Exception;
-
-	public Response putCookiesConsentPreferenceBatch(
-			String callbackURL, Object object)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -100,14 +93,6 @@ public interface CookiesConsentPreferenceResource {
 	public void setRoleLocalService(RoleLocalService roleLocalService);
 
 	public void setSortParserProvider(SortParserProvider sortParserProvider);
-
-	public void setVulcanBatchEngineExportTaskResource(
-		VulcanBatchEngineExportTaskResource
-			vulcanBatchEngineExportTaskResource);
-
-	public void setVulcanBatchEngineImportTaskResource(
-		VulcanBatchEngineImportTaskResource
-			vulcanBatchEngineImportTaskResource);
 
 	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
 		String filterString) {
@@ -157,4 +142,4 @@ public interface CookiesConsentPreferenceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-390898972
+// LIFERAY-REST-BUILDER-HASH:-636529269

--- a/modules/apps/cookies/cookies-rest-client/src/main/java/com/liferay/cookies/rest/client/resource/v1_0/CookiesConsentPreferenceResource.java
+++ b/modules/apps/cookies/cookies-rest-client/src/main/java/com/liferay/cookies/rest/client/resource/v1_0/CookiesConsentPreferenceResource.java
@@ -32,17 +32,16 @@ public interface CookiesConsentPreferenceResource {
 		return new Builder();
 	}
 
+	public void deleteCookiesConsentPreference() throws Exception;
+
+	public HttpInvoker.HttpResponse deleteCookiesConsentPreferenceHttpResponse()
+		throws Exception;
+
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			deleteCookiesConsentPreferenceByNameHttpResponse(String name)
-		throws Exception;
-
-	public void deleteCookiesConsentPreferences() throws Exception;
-
-	public HttpInvoker.HttpResponse
-			deleteCookiesConsentPreferencesHttpResponse()
 		throws Exception;
 
 	public CookiesConsentPreference getCookiesConsentPreferenceByName(
@@ -59,15 +58,6 @@ public interface CookiesConsentPreferenceResource {
 
 	public HttpInvoker.HttpResponse putCookiesConsentPreferenceHttpResponse(
 			CookiesConsentPreference cookiesConsentPreference)
-		throws Exception;
-
-	public void putCookiesConsentPreferenceBatch(
-			String callbackURL, Object object)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			putCookiesConsentPreferenceBatchHttpResponse(
-				String callbackURL, Object object)
 		throws Exception;
 
 	public static class Builder {
@@ -179,6 +169,107 @@ public interface CookiesConsentPreferenceResource {
 	public static class CookiesConsentPreferenceResourceImpl
 		implements CookiesConsentPreferenceResource {
 
+		public void deleteCookiesConsentPreference() throws Exception {
+			HttpInvoker.HttpResponse httpResponse =
+				deleteCookiesConsentPreferenceHttpResponse();
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteCookiesConsentPreferenceHttpResponse()
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/cookies/v1.0/cookies-consent-preferences");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public void deleteCookiesConsentPreferenceByName(String name)
 			throws Exception {
 
@@ -275,107 +366,6 @@ public interface CookiesConsentPreferenceResource {
 						"/o/cookies/v1.0/cookies-consent-preferences/by-name/{name}");
 
 			httpInvoker.path("name", name);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void deleteCookiesConsentPreferences() throws Exception {
-			HttpInvoker.HttpResponse httpResponse =
-				deleteCookiesConsentPreferencesHttpResponse();
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return;
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				deleteCookiesConsentPreferencesHttpResponse()
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/cookies/v1.0/cookies-consent-preferences");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -599,108 +589,6 @@ public interface CookiesConsentPreferenceResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putCookiesConsentPreferenceBatch(
-				String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				putCookiesConsentPreferenceBatchHttpResponse(
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				putCookiesConsentPreferenceBatchHttpResponse(
-					String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/cookies/v1.0/cookies-consent-preferences/batch");
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
 		private CookiesConsentPreferenceResourceImpl(Builder builder) {
 			_builder = builder;
 		}
@@ -713,4 +601,4 @@ public interface CookiesConsentPreferenceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1577574750
+// LIFERAY-REST-BUILDER-HASH:1994306772

--- a/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
@@ -7,5 +7,7 @@ application:
 author: Christopher Kian
 clientDir: ../cookies-rest-client/src/main/java
 compatibilityVersion: 14
+forcePredictableOperationId: true
+forcePredictableSchemaPropertyName: true
 javaEEPackage: jakarta
 testDir: ../cookies-rest-test/src/testIntegration/java

--- a/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
@@ -9,5 +9,6 @@ clientDir: ../cookies-rest-client/src/main/java
 compatibilityVersion: 14
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: true
+generateBatch: false
 javaEEPackage: jakarta
 testDir: ../cookies-rest-test/src/testIntegration/java

--- a/modules/apps/cookies/cookies-rest-impl/rest-openapi.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-openapi.yaml
@@ -51,7 +51,7 @@ paths:
         delete:
             description:
                 Deletes all cookies consent preference entries of the user who made the request.
-            operationId: deleteCookiesConsentPreferences
+            operationId: deleteCookiesConsentPreference
             responses:
                 204:
                     content:

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -12,8 +12,6 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -22,7 +20,6 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.function.BiFunction;
@@ -46,6 +43,20 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Deletes all cookies consent preference entries of the user who made the request."
+	)
+	public boolean deleteCookiesConsentPreference() throws Exception {
+		_applyVoidComponentServiceObjects(
+			_cookiesConsentPreferenceResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			cookiesConsentPreferenceResource ->
+				cookiesConsentPreferenceResource.
+					deleteCookiesConsentPreference());
+
+		return true;
+	}
+
+	@GraphQLField(
 		description = "Deletes the specified cookies consent preference of the user who made the request."
 	)
 	public boolean deleteCookiesConsentPreferenceByName(
@@ -58,20 +69,6 @@ public class Mutation {
 			cookiesConsentPreferenceResource ->
 				cookiesConsentPreferenceResource.
 					deleteCookiesConsentPreferenceByName(name));
-
-		return true;
-	}
-
-	@GraphQLField(
-		description = "Deletes all cookies consent preference entries of the user who made the request."
-	)
-	public boolean deleteCookiesConsentPreferences() throws Exception {
-		_applyVoidComponentServiceObjects(
-			_cookiesConsentPreferenceResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			cookiesConsentPreferenceResource ->
-				cookiesConsentPreferenceResource.
-					deleteCookiesConsentPreferences());
 
 		return true;
 	}
@@ -90,20 +87,6 @@ public class Mutation {
 			cookiesConsentPreferenceResource ->
 				cookiesConsentPreferenceResource.putCookiesConsentPreference(
 					cookiesConsentPreference));
-	}
-
-	@GraphQLField
-	public Response updateCookiesConsentPreferenceBatch(
-			@GraphQLName("callbackURL") String callbackURL,
-			@GraphQLName("object") Object object)
-		throws Exception {
-
-		return _applyComponentServiceObjects(
-			_cookiesConsentPreferenceResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			cookiesConsentPreferenceResource ->
-				cookiesConsentPreferenceResource.
-					putCookiesConsentPreferenceBatch(callbackURL, object));
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R
@@ -160,12 +143,6 @@ public class Mutation {
 		cookiesConsentPreferenceResource.setGroupLocalService(
 			_groupLocalService);
 		cookiesConsentPreferenceResource.setRoleLocalService(_roleLocalService);
-
-		cookiesConsentPreferenceResource.setVulcanBatchEngineExportTaskResource(
-			_vulcanBatchEngineExportTaskResource);
-
-		cookiesConsentPreferenceResource.setVulcanBatchEngineImportTaskResource(
-			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<CookiesConsentPreferenceResource>
@@ -181,10 +158,6 @@ public class Mutation {
 		_sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
-	private VulcanBatchEngineExportTaskResource
-		_vulcanBatchEngineExportTaskResource;
-	private VulcanBatchEngineImportTaskResource
-		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-936149283
+// LIFERAY-REST-BUILDER-HASH:1721433606

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -76,25 +76,20 @@ public class ServletDataImpl implements ServletData {
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
 					put(
+						"mutation#deleteCookiesConsentPreference",
+						new ObjectValuePair<>(
+							CookiesConsentPreferenceResourceImpl.class,
+							"deleteCookiesConsentPreference"));
+					put(
 						"mutation#deleteCookiesConsentPreferenceByName",
 						new ObjectValuePair<>(
 							CookiesConsentPreferenceResourceImpl.class,
 							"deleteCookiesConsentPreferenceByName"));
 					put(
-						"mutation#deleteCookiesConsentPreferences",
-						new ObjectValuePair<>(
-							CookiesConsentPreferenceResourceImpl.class,
-							"deleteCookiesConsentPreferences"));
-					put(
 						"mutation#updateCookiesConsentPreference",
 						new ObjectValuePair<>(
 							CookiesConsentPreferenceResourceImpl.class,
 							"putCookiesConsentPreference"));
-					put(
-						"mutation#updateCookiesConsentPreferenceBatch",
-						new ObjectValuePair<>(
-							CookiesConsentPreferenceResourceImpl.class,
-							"putCookiesConsentPreferenceBatch"));
 
 					put(
 						"query#cookiesConsentPreferenceByName",
@@ -109,4 +104,4 @@ public class ServletDataImpl implements ServletData {
 		_cookiesConsentPreferenceResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:256119608
+// LIFERAY-REST-BUILDER-HASH:-2090217516

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/BaseCookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/BaseCookiesConsentPreferenceResourceImpl.java
@@ -7,8 +7,6 @@ package com.liferay.cookies.rest.internal.resource.v1_0;
 
 import com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference;
 import com.liferay.cookies.rest.resource.v1_0.CookiesConsentPreferenceResource;
-import com.liferay.petra.function.UnsafeBiConsumer;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -17,24 +15,10 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
-import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
-import com.liferay.portal.odata.sort.SortField;
-import com.liferay.portal.odata.sort.SortParser;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
-import com.liferay.portal.vulcan.pagination.Page;
-import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
@@ -43,20 +27,11 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.NotSupportedException;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import java.io.Serializable;
-
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Christopher Kian
@@ -65,8 +40,29 @@ import java.util.Set;
 @Generated("")
 @jakarta.ws.rs.Path("/v1.0")
 public abstract class BaseCookiesConsentPreferenceResourceImpl
-	implements CookiesConsentPreferenceResource, EntityModelResource,
-			   VulcanBatchEngineTaskItemDelegate<CookiesConsentPreference> {
+	implements CookiesConsentPreferenceResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes all cookies consent preference entries of the user who made the request."
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "CookiesConsentPreference"
+			)
+		}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path("/cookies-consent-preferences")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteCookiesConsentPreference() throws Exception {
+	}
 
 	/**
 	 * Invoke this method with the command line:
@@ -101,28 +97,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 			@jakarta.ws.rs.PathParam("name")
 			String name)
 		throws Exception {
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Operation(
-		description = "Deletes all cookies consent preference entries of the user who made the request."
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(
-				name = "CookiesConsentPreference"
-			)
-		}
-	)
-	@jakarta.ws.rs.DELETE
-	@jakarta.ws.rs.Path("/cookies-consent-preferences")
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public void deleteCookiesConsentPreferences() throws Exception {
 	}
 
 	/**
@@ -189,207 +163,8 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 		return new CookiesConsentPreference();
 	}
 
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences/batch'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "callbackURL"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(
-				name = "CookiesConsentPreference"
-			)
-		}
-	)
-	@jakarta.ws.rs.Consumes("application/json")
-	@jakarta.ws.rs.Path("/cookies-consent-preferences/batch")
-	@jakarta.ws.rs.Produces("application/json")
-	@jakarta.ws.rs.PUT
-	@Override
-	public Response putCookiesConsentPreferenceBatch(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("callbackURL")
-			String callbackURL,
-			Object object)
-		throws Exception {
-
-		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
-			contextAcceptLanguage);
-		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
-		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
-			contextHttpServletRequest);
-		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
-		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
-
-		Response.ResponseBuilder responseBuilder = Response.accepted();
-
-		return responseBuilder.entity(
-			vulcanBatchEngineImportTaskResource.putImportTask(
-				CookiesConsentPreference.class.getName(), callbackURL, object)
-		).build();
-	}
-
-	@Override
-	@SuppressWarnings("PMD.UnusedLocalVariable")
-	public void create(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Override
-	public void delete(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
-	}
-
-	public Set<String> getAvailableUpdateStrategies() {
-		return SetUtil.fromArray("UPDATE");
-	}
-
-	@Override
-	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
-		throws Exception {
-
-		return getEntityModel(
-			new MultivaluedHashMap<String, Object>(multivaluedMap));
-	}
-
-	public String getResourceName() {
-		return "CookiesConsentPreference";
-	}
-
-	public String getVersion() {
-		return "v1.0";
-	}
-
-	@Override
-	public Page<CookiesConsentPreference> read(
-			com.liferay.portal.kernel.search.filter.Filter filter,
-			Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts,
-			Map<String, Serializable> parameters, String search)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Override
-	public void setLanguageId(String languageId) {
-		this.contextAcceptLanguage = new AcceptLanguage() {
-
-			@Override
-			public List<Locale> getLocales() {
-				return null;
-			}
-
-			@Override
-			public String getPreferredLanguageId() {
-				return languageId;
-			}
-
-			@Override
-			public Locale getPreferredLocale() {
-				return LocaleUtil.fromLanguageId(languageId);
-			}
-
-		};
-	}
-
-	@Override
-	public void update(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		UnsafeFunction
-			<CookiesConsentPreference, CookiesConsentPreference, Exception>
-				cookiesConsentPreferenceUnsafeFunction = null;
-
-		String updateStrategy = (String)parameters.getOrDefault(
-			"updateStrategy", "UPDATE");
-
-		if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
-			cookiesConsentPreferenceUnsafeFunction =
-				cookiesConsentPreference -> putCookiesConsentPreference(
-					cookiesConsentPreference);
-		}
-
-		if (cookiesConsentPreferenceUnsafeFunction == null) {
-			throw new NotSupportedException(
-				"Update strategy \"" + updateStrategy +
-					"\" is not supported for CookiesConsentPreference");
-		}
-
-		if (contextBatchUnsafeBiConsumer != null) {
-			contextBatchUnsafeBiConsumer.accept(
-				cookiesConsentPreferences,
-				cookiesConsentPreferenceUnsafeFunction);
-		}
-		else if (contextBatchUnsafeConsumer != null) {
-			contextBatchUnsafeConsumer.accept(
-				cookiesConsentPreferences,
-				cookiesConsentPreferenceUnsafeFunction::apply);
-		}
-		else {
-			for (CookiesConsentPreference cookiesConsentPreference :
-					cookiesConsentPreferences) {
-
-				cookiesConsentPreferenceUnsafeFunction.apply(
-					cookiesConsentPreference);
-			}
-		}
-	}
-
-	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
-		throws Exception {
-
-		return null;
-	}
-
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
 		this.contextAcceptLanguage = contextAcceptLanguage;
-	}
-
-	public void setContextBatchUnsafeBiConsumer(
-		UnsafeBiConsumer
-			<Collection<CookiesConsentPreference>,
-			 UnsafeFunction
-				 <CookiesConsentPreference, CookiesConsentPreference,
-				  Exception>,
-			 Exception> contextBatchUnsafeBiConsumer) {
-
-		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
-	}
-
-	public void setContextBatchUnsafeConsumer(
-		UnsafeBiConsumer
-			<Collection<CookiesConsentPreference>,
-			 UnsafeConsumer<CookiesConsentPreference, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
-
-		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
 
 	public void setContextCompany(
@@ -460,87 +235,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 
 	protected String getApplicationPath() {
 		return "cookies";
-	}
-
-	public void setVulcanBatchEngineExportTaskResource(
-		VulcanBatchEngineExportTaskResource
-			vulcanBatchEngineExportTaskResource) {
-
-		this.vulcanBatchEngineExportTaskResource =
-			vulcanBatchEngineExportTaskResource;
-	}
-
-	public void setVulcanBatchEngineImportTaskResource(
-		VulcanBatchEngineImportTaskResource
-			vulcanBatchEngineImportTaskResource) {
-
-		this.vulcanBatchEngineImportTaskResource =
-			vulcanBatchEngineImportTaskResource;
-	}
-
-	@Override
-	public com.liferay.portal.kernel.search.filter.Filter toFilter(
-		String filterString, Map<String, List<String>> multivaluedMap) {
-
-		try {
-			EntityModel entityModel = getEntityModel(multivaluedMap);
-
-			FilterParser filterParser = filterParserProvider.provide(
-				entityModel);
-
-			com.liferay.portal.odata.filter.Filter oDataFilter =
-				new com.liferay.portal.odata.filter.Filter(
-					filterParser.parse(filterString));
-
-			return expressionConvert.convert(
-				oDataFilter.getExpression(),
-				contextAcceptLanguage.getPreferredLocale(), entityModel);
-		}
-		catch (Exception exception) {
-			_log.error("Invalid filter " + filterString, exception);
-
-			return null;
-		}
-	}
-
-	@Override
-	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
-		if (Validator.isNull(sortString)) {
-			return null;
-		}
-
-		try {
-			SortParser sortParser = sortParserProvider.provide(
-				getEntityModel(Collections.emptyMap()));
-
-			if (sortParser == null) {
-				return null;
-			}
-
-			com.liferay.portal.odata.sort.Sort oDataSort =
-				new com.liferay.portal.odata.sort.Sort(
-					sortParser.parse(sortString));
-
-			List<SortField> sortFields = oDataSort.getSortFields();
-			com.liferay.portal.kernel.search.Sort[] sorts =
-				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
-
-			for (int i = 0; i < sortFields.size(); i++) {
-				SortField sortField = sortFields.get(i);
-
-				sorts[i] = new com.liferay.portal.kernel.search.Sort(
-					sortField.getSortableFieldName(
-						contextAcceptLanguage.getPreferredLocale()),
-					!sortField.isAscending());
-			}
-
-			return sorts;
-		}
-		catch (Exception exception) {
-			_log.error("Invalid sort " + sortString, exception);
-
-			return new com.liferay.portal.kernel.search.Sort[0];
-		}
 	}
 
 	protected Map<String, String> addAction(
@@ -895,15 +589,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 	}
 
 	protected AcceptLanguage contextAcceptLanguage;
-	protected UnsafeBiConsumer
-		<Collection<CookiesConsentPreference>,
-		 UnsafeFunction
-			 <CookiesConsentPreference, CookiesConsentPreference, Exception>,
-		 Exception> contextBatchUnsafeBiConsumer;
-	protected UnsafeBiConsumer
-		<Collection<CookiesConsentPreference>,
-		 UnsafeConsumer<CookiesConsentPreference, Exception>, Exception>
-			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -918,13 +603,9 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
-	protected VulcanBatchEngineExportTaskResource
-		vulcanBatchEngineExportTaskResource;
-	protected VulcanBatchEngineImportTaskResource
-		vulcanBatchEngineImportTaskResource;
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCookiesConsentPreferenceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:112616867
+// LIFERAY-REST-BUILDER-HASH:-1824720156

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -30,17 +30,17 @@ public class CookiesConsentPreferenceResourceImpl
 	extends BaseCookiesConsentPreferenceResourceImpl {
 
 	@Override
+	public void deleteCookiesConsentPreference() throws Exception {
+		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
+			contextUser.getUserId(), _getDomain());
+	}
+
+	@Override
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception {
 
 		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreference(
 			contextUser.getUserId(), _getDomain(), name);
-	}
-
-	@Override
-	public void deleteCookiesConsentPreference() throws Exception {
-		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
-			contextUser.getUserId(), _getDomain());
 	}
 
 	@Override

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -38,7 +38,7 @@ public class CookiesConsentPreferenceResourceImpl
 	}
 
 	@Override
-	public void deleteCookiesConsentPreferences() throws Exception {
+	public void deleteCookiesConsentPreference() throws Exception {
 		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
 			contextUser.getUserId(), _getDomain());
 	}

--- a/modules/apps/cookies/cookies-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cookies-consent-preference.properties
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cookies-consent-preference.properties
@@ -3,10 +3,6 @@
 #
 
 api.version=v1.0
-batch.engine.entity.class.name=com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference
-batch.engine.task.item.delegate=true
-batch.planner.export.enabled=false
-batch.planner.import.enabled=false
 entity.class.name=com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Cookies.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
+++ b/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
@@ -195,6 +195,31 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteCookiesConsentPreference() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		CookiesConsentPreference cookiesConsentPreference =
+			testDeleteCookiesConsentPreference_addCookiesConsentPreference();
+
+		assertHttpResponseStatusCode(
+			204,
+			cookiesConsentPreferenceResource.
+				deleteCookiesConsentPreferenceHttpResponse());
+	}
+
+	protected CookiesConsentPreference
+			testDeleteCookiesConsentPreference_addCookiesConsentPreference()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLDeleteCookiesConsentPreference() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testDeleteCookiesConsentPreferenceByName() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		CookiesConsentPreference cookiesConsentPreference =
@@ -319,31 +344,6 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 		throws Exception {
 
 		return testGraphQLCookiesConsentPreference_addCookiesConsentPreference();
-	}
-
-	@Test
-	public void testDeleteCookiesConsentPreferences() throws Exception {
-		@SuppressWarnings("PMD.UnusedLocalVariable")
-		CookiesConsentPreference cookiesConsentPreference =
-			testDeleteCookiesConsentPreferences_addCookiesConsentPreference();
-
-		assertHttpResponseStatusCode(
-			204,
-			cookiesConsentPreferenceResource.
-				deleteCookiesConsentPreferencesHttpResponse());
-	}
-
-	protected CookiesConsentPreference
-			testDeleteCookiesConsentPreferences_addCookiesConsentPreference()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testGraphQLDeleteCookiesConsentPreferences() throws Exception {
-		Assert.assertTrue(false);
 	}
 
 	@Test
@@ -510,11 +510,6 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testBatchEngineDeleteImportTask() throws Exception {
-		Assert.assertTrue(true);
 	}
 
 	protected CookiesConsentPreference
@@ -1431,4 +1426,4 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 			_cookiesConsentPreferenceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:811696207
+// LIFERAY-REST-BUILDER-HASH:138682693

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/upgrade/ExpiredJournalArticleUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/upgrade/ExpiredJournalArticleUpgradeProcess.java
@@ -10,6 +10,8 @@ import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -36,11 +38,23 @@ public class ExpiredJournalArticleUpgradeProcess extends UpgradeProcess {
 				dynamicQuery.add(property.eq(WorkflowConstants.STATUS_EXPIRED));
 			});
 		actionableDynamicQuery.setPerformActionMethod(
-			(JournalArticle journalArticle) ->
-				_journalArticleLocalService.deleteArticle(journalArticle));
+			(JournalArticle journalArticle) -> {
+				try {
+					_journalArticleLocalService.deleteArticle(journalArticle);
+				}
+				catch (Exception exception) {
+					_log.error(
+						"Unable to delete expired journal article " +
+							journalArticle.getId(),
+						exception);
+				}
+			});
 
 		actionableDynamicQuery.performActions();
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ExpiredJournalArticleUpgradeProcess.class);
 
 	private final JournalArticleLocalService _journalArticleLocalService;
 

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/upgrade/ExpiredJournalArticleUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/upgrade/ExpiredJournalArticleUpgradeProcess.java
@@ -7,13 +7,11 @@ package com.liferay.data.cleanup.internal.upgrade;
 
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
-import com.liferay.portal.kernel.dao.orm.DynamicQuery;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
-
-import java.util.List;
 
 /**
  * @author Kevin Lee
@@ -28,18 +26,20 @@ public class ExpiredJournalArticleUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		DynamicQuery dynamicQuery = _journalArticleLocalService.dynamicQuery();
+		ActionableDynamicQuery actionableDynamicQuery =
+			_journalArticleLocalService.getActionableDynamicQuery();
 
-		Property property = PropertyFactoryUtil.forName("status");
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property property = PropertyFactoryUtil.forName("status");
 
-		dynamicQuery.add(property.eq(WorkflowConstants.STATUS_EXPIRED));
+				dynamicQuery.add(property.eq(WorkflowConstants.STATUS_EXPIRED));
+			});
+		actionableDynamicQuery.setPerformActionMethod(
+			(JournalArticle journalArticle) ->
+				_journalArticleLocalService.deleteArticle(journalArticle));
 
-		List<JournalArticle> journalArticles =
-			_journalArticleLocalService.dynamicQuery(dynamicQuery);
-
-		for (JournalArticle journalArticle : journalArticles) {
-			_journalArticleLocalService.deleteArticle(journalArticle);
-		}
+		actionableDynamicQuery.performActions();
 	}
 
 	private final JournalArticleLocalService _journalArticleLocalService;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/upgrade/ExpiredJournalArticleUpgradeProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/upgrade/ExpiredJournalArticleUpgradeProcess.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 /**
@@ -37,6 +38,8 @@ public class ExpiredJournalArticleUpgradeProcess extends UpgradeProcess {
 
 				dynamicQuery.add(property.eq(WorkflowConstants.STATUS_EXPIRED));
 			});
+		actionableDynamicQuery.setInterval(
+			PropsValues.UPGRADE_CONCURRENT_FETCH_SIZE);
 		actionableDynamicQuery.setPerformActionMethod(
 			(JournalArticle journalArticle) -> {
 				try {

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/upgrade/test/ExpiredJournalArticleUpgradeProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/upgrade/test/ExpiredJournalArticleUpgradeProcessTest.java
@@ -20,6 +20,9 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -78,6 +81,49 @@ public class ExpiredJournalArticleUpgradeProcessTest {
 		Assert.assertNull(
 			_journalArticleLocalService.fetchArticle(
 				expiredJournalArticle2.getId()));
+		Assert.assertNotNull(
+			_journalArticleLocalService.fetchArticle(
+				unexpiredJournalArticle.getId()));
+	}
+
+	@Test
+	public void testUpgradeMultipleExpiredJournalArticles() throws Exception {
+		List<JournalArticle> expiredJournalArticles = new ArrayList<>();
+
+		for (int i = 0; i < 5; i++) {
+			JournalArticle journalArticle = JournalTestUtil.addArticle(
+				_group.getGroupId(),
+				JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+			JournalTestUtil.expireArticle(
+				journalArticle.getGroupId(), journalArticle);
+
+			expiredJournalArticles.add(journalArticle);
+		}
+
+		JournalArticle unexpiredJournalArticle = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		for (DataCleanup dataCleanup :
+				DataCleanupUtil.getSystemDataCleanups()) {
+
+			if (StringUtil.equals(
+					dataCleanup.getLabel(),
+					"remove-expired-journal-articles")) {
+
+				dataCleanup.cleanup();
+
+				break;
+			}
+		}
+
+		for (JournalArticle expiredJournalArticle : expiredJournalArticles) {
+			Assert.assertNull(
+				_journalArticleLocalService.fetchArticle(
+					expiredJournalArticle.getId()));
+		}
+
 		Assert.assertNotNull(
 			_journalArticleLocalService.fetchArticle(
 				unexpiredJournalArticle.getId()));

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -505,7 +505,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				TrashHandler.class,
 				new ObjectEntryTrashHandler(
 					objectDefinition, _objectDefinitionLocalService,
-					_objectEntryService, _systemEventLocalService),
+					_objectEntryLocalService, _objectEntryService,
+					_systemEventLocalService),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"model.class.name", objectDefinition.getClassName()
 				).build()));

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryFolderTrashHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryFolderTrashHandler.java
@@ -31,7 +31,7 @@ public class ObjectEntryFolderTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		_objectEntryFolderService.deleteObjectEntryFolder(classPK);
+		_objectEntryFolderLocalService.deleteObjectEntryFolder(classPK);
 	}
 
 	@Override

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryTrashHandler.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/trash/ObjectEntryTrashHandler.java
@@ -8,6 +8,7 @@ package com.liferay.object.internal.trash;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectEntryService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
@@ -30,11 +31,13 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 	public ObjectEntryTrashHandler(
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
+		ObjectEntryLocalService objectEntryLocalService,
 		ObjectEntryService objectEntryService,
 		SystemEventLocalService systemEventLocalService) {
 
 		_objectDefinition = objectDefinition;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
+		_objectEntryLocalService = objectEntryLocalService;
 		_objectEntryService = objectEntryService;
 		_systemEventLocalService = systemEventLocalService;
 	}
@@ -55,7 +58,7 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public void deleteTrashEntry(long classPK) throws PortalException {
-		_objectEntryService.deleteObjectEntry(classPK);
+		_objectEntryLocalService.deleteObjectEntry(classPK);
 	}
 
 	@Override
@@ -100,6 +103,7 @@ public class ObjectEntryTrashHandler extends BaseTrashHandler {
 
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
+	private final ObjectEntryLocalService _objectEntryLocalService;
 	private final ObjectEntryService _objectEntryService;
 	private final SystemEventLocalService _systemEventLocalService;
 

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.trash.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.object.model.ObjectEntryFolder;
+import com.liferay.object.service.ObjectEntryFolderLocalService;
+import com.liferay.object.test.util.ObjectEntryFolderTestUtil;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alicia García
+ */
+@RunWith(Arquillian.class)
+public class ObjectEntryFolderTrashHandlerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	@TestInfo("LPD-91679")
+	public void testCheckEntries() throws Exception {
+		_testCheckEntriesWithPermissions();
+		_testCheckEntriesWithoutPermissions();
+	}
+
+	private ObjectEntryFolder _addExpiredTrashedObjectEntryFolder()
+		throws Exception {
+
+		ObjectEntryFolder objectEntryFolder =
+			ObjectEntryFolderTestUtil.addObjectEntryFolder();
+
+		_objectEntryFolderLocalService.moveObjectEntryFolderToTrash(
+			TestPropsValues.getUserId(), objectEntryFolder,
+			ServiceContextTestUtil.getServiceContext());
+
+		TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+			ObjectEntryFolder.class.getName(),
+			objectEntryFolder.getObjectEntryFolderId());
+
+		Date createDate = trashEntry.getCreateDate();
+
+		trashEntry.setCreateDate(new Date(createDate.getTime() - Time.YEAR));
+
+		TrashEntryLocalServiceUtil.updateTrashEntry(trashEntry);
+
+		return objectEntryFolder;
+	}
+
+	private void _testCheckEntriesWithoutPermissions() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_addExpiredTrashedObjectEntryFolder();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(
+					UserLocalServiceUtil.getGuestUser(
+						TestPropsValues.getCompanyId())));
+
+			TrashEntryLocalServiceUtil.checkEntries();
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId()));
+	}
+
+	private void _testCheckEntriesWithPermissions() throws Exception {
+		ObjectEntryFolder objectEntryFolder =
+			_addExpiredTrashedObjectEntryFolder();
+
+		TrashEntryLocalServiceUtil.checkEntries();
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				ObjectEntryFolder.class.getName(),
+				objectEntryFolder.getObjectEntryFolderId()));
+	}
+
+	@Inject
+	private ObjectEntryFolderLocalService _objectEntryFolderLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryFolderTrashHandlerTest.java
@@ -48,8 +48,8 @@ public class ObjectEntryFolderTrashHandlerTest {
 	@Test
 	@TestInfo("LPD-91679")
 	public void testCheckEntries() throws Exception {
-		_testCheckEntriesWithPermissions();
 		_testCheckEntriesWithoutPermissions();
+		_testCheckEntriesWithPermissions();
 	}
 
 	private ObjectEntryFolder _addExpiredTrashedObjectEntryFolder()

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
@@ -117,8 +117,8 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 	@Test
 	@TestInfo("LPD-91679")
 	public void testCheckEntries() throws Exception {
-		_testCheckEntriesWithPermissions();
 		_testCheckEntriesWithoutPermissions();
+		_testCheckEntriesWithPermissions();
 	}
 
 	@Override

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/trash/test/ObjectEntryTrashHandlerTest.java
@@ -20,8 +20,13 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.SystemEvent;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.TrashedModel;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.SystemEventLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -29,14 +34,18 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.trash.TrashHelper;
+import com.liferay.trash.model.TrashEntry;
+import com.liferay.trash.service.TrashEntryLocalServiceUtil;
 import com.liferay.trash.test.util.BaseTrashHandlerTestCase;
 
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.Assert;
@@ -103,6 +112,13 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 
 		_testAddDeletionSystemEvent(group.getGroupId(), (ObjectEntry)baseModel);
+	}
+
+	@Test
+	@TestInfo("LPD-91679")
+	public void testCheckEntries() throws Exception {
+		_testCheckEntriesWithPermissions();
+		_testCheckEntriesWithoutPermissions();
 	}
 
 	@Override
@@ -203,6 +219,27 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
 	}
 
+	private ObjectEntry _addExpiredTrashedObjectEntry() throws Exception {
+		baseModel = addBaseModel(
+			group,
+			ServiceContextTestUtil.getServiceContext(group.getGroupId()));
+
+		long primaryKey = (Long)baseModel.getPrimaryKeyObj();
+
+		moveBaseModelToTrash(primaryKey);
+
+		TrashEntry trashEntry = TrashEntryLocalServiceUtil.getEntry(
+			_objectDefinition.getClassName(), primaryKey);
+
+		Date createDate = trashEntry.getCreateDate();
+
+		trashEntry.setCreateDate(new Date(createDate.getTime() - Time.YEAR));
+
+		TrashEntryLocalServiceUtil.updateTrashEntry(trashEntry);
+
+		return (ObjectEntry)baseModel;
+	}
+
 	private void _testAddDeletionSystemEvent(
 			long groupId, ObjectEntry objectEntry)
 		throws Exception {
@@ -226,6 +263,42 @@ public class ObjectEntryTrashHandlerTest extends BaseTrashHandlerTestCase {
 			systemEvent.getClassExternalReferenceCode());
 		Assert.assertEquals(
 			SystemEventConstants.TYPE_DELETE, systemEvent.getType());
+	}
+
+	private void _testCheckEntriesWithoutPermissions() throws Exception {
+		ObjectEntry objectEntry = _addExpiredTrashedObjectEntry();
+
+		PermissionChecker originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		try {
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(
+					UserLocalServiceUtil.getGuestUser(
+						TestPropsValues.getCompanyId())));
+
+			TrashEntryLocalServiceUtil.checkEntries();
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(
+				originalPermissionChecker);
+		}
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				_objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId()));
+	}
+
+	private void _testCheckEntriesWithPermissions() throws Exception {
+		ObjectEntry objectEntry = _addExpiredTrashedObjectEntry();
+
+		TrashEntryLocalServiceUtil.checkEntries();
+
+		Assert.assertNull(
+			TrashEntryLocalServiceUtil.fetchEntry(
+				_objectDefinition.getClassName(),
+				objectEntry.getObjectEntryId()));
 	}
 
 	private ObjectDefinition _objectDefinition;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94287

## What Is Being Fixed

The expired journal article cleanup loaded every expired article into memory through a single dynamic query and deleted the whole result set within one wide operation. On partitions holding a large backlog of expired articles this consumed memory proportional to the backlog and held a broad, long-running transaction that contended with concurrent writes, causing the cleanup to fail with a database deadlock.

## How It Is Being Fixed

The cleanup now uses an ActionableDynamicQuery that keyset-paginates through the expired articles, so memory stays bounded regardless of the backlog. Each article is deleted in its own transaction, so locks are released promptly and an individual failure no longer rolls back unrelated deletions. The page interval is capped at the upgrade fetch size, keeping each page small and shortening the window between fetching an article and deleting it. Individual delete failures are caught and logged so a single problem article cannot abort the entire cleanup. Integration coverage was added for deleting multiple expired articles while leaving unexpired ones intact.

## PR Check

**pr-check: PASS** — tested on `deb95c1a3ce55efa1667a12139cc6a92c9d25bd5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "deb95c1a3ce55efa1667a12139cc6a92c9d25bd5"} -->
