### PR TITLE
LPD-92495 Avoid switching CompanyThreadLocal from a secondary partition

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
@@ -14,7 +14,6 @@ import com.liferay.osgi.service.tracker.collections.EagerServiceTrackerCustomize
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiServiceUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -38,6 +36,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -135,6 +134,10 @@ public class FeatureFlagsBagProviderImpl
 
 		_initSystemFeatureFlags(false);
 
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			_loadSystemFeatureFlagsBag();
+		}
+
 		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
 			bundleContext, FeatureFlagListener.class, null,
 			(serviceReference, emitter) -> {
@@ -191,19 +194,7 @@ public class FeatureFlagsBagProviderImpl
 			}
 		}
 
-		if (companyId == CompanyThreadLocal.getCompanyId()) {
-			_populateFeatureFlagsMap(
-				companyId, featureFlags, systemFeatureFlags);
-		}
-		else {
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						companyId)) {
-
-				_populateFeatureFlagsMap(
-					companyId, featureFlags, systemFeatureFlags);
-			}
-		}
+		_populateFeatureFlagsMap(companyId, featureFlags, systemFeatureFlags);
 
 		return new FeatureFlagsBag(
 			companyId, Collections.unmodifiableMap(featureFlags));
@@ -278,6 +269,17 @@ public class FeatureFlagsBagProviderImpl
 		}
 
 		return true;
+	}
+
+	private void _loadSystemFeatureFlagsBag() {
+		FeatureFlagsBag systemFeatureFlagsBag = getOrCreateFeatureFlagsBag(
+			CompanyConstants.SYSTEM);
+
+		for (FeatureFlag featureFlag :
+				systemFeatureFlagsBag.getFeatureFlags(null)) {
+
+			featureFlag.isEnabled();
+		}
 	}
 
 	private void _populateFeatureFlagsMap(

--- a/modules/apps/feature-flag/source-formatter-suppressions.xml
+++ b/modules/apps/feature-flag/source-formatter-suppressions.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-
-<suppressions>
-	<source-check>
-		<suppress checks="JavaCompanyThreadLocalCheck" files="feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl\.java" />
-	</source-check>
-</suppressions>

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest.java
@@ -769,6 +769,23 @@ public class DBPartitionTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testIncrementSystemCounter() throws Exception {
+		long count = CompanyThreadLocal.incrementSystemCounter();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
+
+			Assert.assertEquals(
+				count + 1, CompanyThreadLocal.incrementSystemCounter());
+
+			Assert.assertEquals(
+				Long.valueOf(COMPANY_IDS[0]),
+				CompanyThreadLocal.getCompanyId());
+		}
+	}
+
+	@Test
 	public void testInitResourceActions() throws Exception {
 		DBPartitionUtil.forEachCompanyId(
 			companyId -> StartupHelperUtil.initResourceActions());

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.service.impl;
 
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.VirtualHost;
@@ -210,14 +208,8 @@ public class VirtualHostLocalServiceImpl
 			}
 
 			if (virtualHost == null) {
-				long virtualHostId = 0;
-
-				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							CompanyConstants.SYSTEM)) {
-
-					virtualHostId = counterLocalService.increment();
-				}
+				long virtualHostId =
+					CompanyThreadLocal.incrementSystemCounter();
 
 				virtualHost = virtualHostPersistence.create(virtualHostId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.security.auth;
 
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
@@ -104,6 +105,19 @@ public class CompanyThreadLocal {
 		}
 
 		return companyId;
+	}
+
+	public static long incrementSystemCounter() {
+		long originalCompanyId = getCompanyId();
+
+		_companyId.set(CompanyConstants.SYSTEM);
+
+		try {
+			return CounterLocalServiceUtil.increment();
+		}
+		finally {
+			_companyId.set(originalCompanyId);
+		}
 	}
 
 	public static boolean isInitializingPortalInstance() {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 10.1.0

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -87,7 +87,6 @@
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/internal/increment/BufferedIncreasableEntry\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/security/permission/PermissionCacheUtil\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
-		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/util/PortalInstances\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-kernel/src/com/liferay/portal/kernel/cache/transactional/TransactionalPortalCacheUtil\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterableInvokerUtil\.java" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92495

## What Is Being Fixed

LPD-51068 forbids calling `CompanyThreadLocal.setCompanyIdWithSafeCloseable` from a secondary partition when database partitioning is enabled. Two sites still did it for a legitimate reason, accessing default-partition data from a secondary-partition thread, and were suppressed by the SF rule from LPD-81801: `VirtualHostLocalServiceImpl` needs a globally unique ID from the shared `Counter_` table during a secondary-partition write, and `FeatureFlagsBagProviderImpl` read the SYSTEM-scoped feature flags (the `companyId = 0` rows) when building any company's flag bag.

## How It Is Being Fixed

For the virtual host counter, I added a narrow helper `CompanyThreadLocal.incrementSystemCounter()` that uses the internal raw setter on `_companyId` (the one sanctioned bypass) to run the counter increment in the SYSTEM context and then restores the original company. It returns only a `long`, so no caller-injected code runs in the SYSTEM context, and the LPD-51068 validation still fires for every other caller. `VirtualHostLocalServiceImpl` now calls this helper instead of switching the thread local.

For the feature flags, I removed the `setCompanyIdWithSafeCloseable(SYSTEM)` switch from `_createFeatureFlagsBag` and instead load the SYSTEM feature flags once at `activate()`, in the default-partition context, gated on `DATABASE_PARTITION_ENABLED`. `PreferenceAwareFeatureFlag` caches its enabled state on first read, so warming the SYSTEM bag in the default context means later reads from any partition return the cached value with no switch. The pre-warm runs before the eager `FeatureFlagListener` tracker opens, so the SYSTEM flags are always frozen in the correct context first. Both SF suppressions are removed now that neither class switches `CompanyThreadLocal` from a secondary partition.

One deviation from the ticket's draft: it also proposed guarding `clearCache()` so it would only run on the default company. I dropped that guard because in partition mode it broke `FeatureFlagListenerTest` (the test runs on a secondary company and relies on `clearCache` to reload flags) and `clearCache` has no production caller. The SYSTEM-bag invariant is held entirely by the `activate()` pre-warm, so `clearCache` keeps its original clear-and-reinitialize behavior.

## PR Check

**pr-check: PASS** — tested on `a0be1d1d9f90465eb339de2800d65bd43d73e946`

| Validation | Result |
| --- | --- |
| Service Builder | SKIPPED (body-only change, cannot drift) |
| Source Format | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a0be1d1d9f90465eb339de2800d65bd43d73e946"} -->
