### PR TITLE
LPD-92724 Speed up DDMFieldAttributeUpgradeProcess with a temp index

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -64,28 +64,30 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		DB db = DBManagerUtil.getDB();
 
-		String selectSQL = StringBundler.concat(
-			"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
-			"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
-			"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
-			"DDMStructure inner join DDMStructureVersion on DDMStructure.",
-			"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
-			"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
-			"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
-			"ctCollectionId and DDMStructureVersion.structureVersionId = ",
-			"DDMField.structureVersionId inner join DDMFieldAttribute on ",
-			"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
-			"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
-			"classNameId = ? and DDMField.fieldType = 'rich_text'");
-
-		String updateSQL =
-			"update DDMFieldAttribute set largeAttributeValue = ?, " +
-				"smallAttributeValue = ? where ctCollectionId = ? and " +
-					"fieldAttributeId = ?";
-
 		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
 				connection, "DDMFieldAttribute", false, "ctCollectionId",
 				"fieldId")) {
+
+			String selectSQL = StringBundler.concat(
+				"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
+				"fieldAttributeId, DDMFieldAttribute.companyId, ",
+				"DDMFieldAttribute.largeAttributeValue, DDMFieldAttribute.",
+				"smallAttributeValue from DDMStructure inner join ",
+				"DDMStructureVersion on DDMStructure.ctCollectionId = ",
+				"DDMStructureVersion.ctCollectionId and DDMStructure.",
+				"structureId = DDMStructureVersion.structureId inner join ",
+				"DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
+				"ctCollectionId and DDMStructureVersion.structureVersionId = ",
+				"DDMField.structureVersionId inner join DDMFieldAttribute on ",
+				"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId ",
+				"and DDMField.fieldId = DDMFieldAttribute.fieldId where ",
+				"DDMStructure.classNameId = ? and DDMField.fieldType = ",
+				"'rich_text'");
+
+			String updateSQL =
+				"update DDMFieldAttribute set largeAttributeValue = ?, " +
+					"smallAttributeValue = ? where ctCollectionId = ? and " +
+						"fieldAttributeId = ?";
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				"com.liferay.journal.model.JournalArticle");
@@ -98,33 +100,35 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 
 				preparedStatement1.setLong(1, classNameId);
 
-				ResultSet resultSet = preparedStatement1.executeQuery();
+				try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+					while (resultSet.next()) {
+						long companyId = resultSet.getLong("companyId");
 
-				while (resultSet.next()) {
-					long companyId = resultSet.getLong("companyId");
+						String largeAttributeValue = _transform(
+							companyId,
+							resultSet.getString("largeAttributeValue"));
+						String smallAttributeValue = _transform(
+							companyId,
+							resultSet.getString("smallAttributeValue"));
 
-					String largeAttributeValue = _transform(
-						companyId, resultSet.getString("largeAttributeValue"));
-					String smallAttributeValue = _transform(
-						companyId, resultSet.getString("smallAttributeValue"));
+						if ((smallAttributeValue != null) &&
+							(smallAttributeValue.length() > 255)) {
 
-					if ((smallAttributeValue != null) &&
-						(smallAttributeValue.length() > 255)) {
+							largeAttributeValue = smallAttributeValue;
 
-						largeAttributeValue = smallAttributeValue;
+							smallAttributeValue = null;
+						}
 
-						smallAttributeValue = null;
+						preparedStatement2.setString(1, largeAttributeValue);
+						preparedStatement2.setString(2, smallAttributeValue);
+
+						preparedStatement2.setLong(
+							3, resultSet.getLong("ctCollectionId"));
+						preparedStatement2.setLong(
+							4, resultSet.getLong("fieldAttributeId"));
+
+						preparedStatement2.addBatch();
 					}
-
-					preparedStatement2.setString(1, largeAttributeValue);
-					preparedStatement2.setString(2, smallAttributeValue);
-
-					preparedStatement2.setLong(
-						3, resultSet.getLong("ctCollectionId"));
-					preparedStatement2.setLong(
-						4, resultSet.getLong("fieldAttributeId"));
-
-					preparedStatement2.addBatch();
 				}
 
 				preparedStatement2.executeBatch();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -9,8 +9,11 @@ import com.liferay.adaptive.media.image.html.constants.AMImageHTMLConstants;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -59,65 +62,73 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long classNameId = _classNameLocalService.getClassNameId(
-			"com.liferay.journal.model.JournalArticle");
+		DB db = DBManagerUtil.getDB();
 
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				StringBundler.concat(
-					"select DDMFieldAttribute.ctCollectionId, ",
-					"DDMFieldAttribute.fieldAttributeId, DDMFieldAttribute.",
-					"companyId, DDMFieldAttribute.largeAttributeValue, ",
-					"DDMFieldAttribute.smallAttributeValue from DDMStructure ",
-					"inner join DDMStructureVersion on DDMStructure.",
-					"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
-					"DDMStructure.structureId = DDMStructureVersion.",
-					"structureId inner join DDMField on DDMStructureVersion.",
-					"ctCollectionId = DDMField.ctCollectionId and ",
-					"DDMStructureVersion.structureVersionId = DDMField.",
-					"structureVersionId inner join DDMFieldAttribute on ",
-					"DDMField.ctCollectionId = DDMFieldAttribute.",
-					"ctCollectionId and DDMField.fieldId = DDMFieldAttribute.",
-					"fieldId where DDMStructure.classNameId = ? and DDMField.",
-					"fieldType = 'rich_text'"));
-			PreparedStatement preparedStatement2 =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					"update DDMFieldAttribute set largeAttributeValue = ?, " +
-						"smallAttributeValue = ? where ctCollectionId = ? " +
-							"and fieldAttributeId = ?")) {
+		String selectSQL = StringBundler.concat(
+			"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
+			"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
+			"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
+			"DDMStructure inner join DDMStructureVersion on DDMStructure.",
+			"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
+			"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
+			"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
+			"ctCollectionId and DDMStructureVersion.structureVersionId = ",
+			"DDMField.structureVersionId inner join DDMFieldAttribute on ",
+			"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
+			"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
+			"classNameId = ? and DDMField.fieldType = 'rich_text'");
 
-			preparedStatement1.setLong(1, classNameId);
+		String updateSQL =
+			"update DDMFieldAttribute set largeAttributeValue = ?, " +
+				"smallAttributeValue = ? where ctCollectionId = ? and " +
+					"fieldAttributeId = ?";
 
-			ResultSet resultSet = preparedStatement1.executeQuery();
+		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
+				connection, "DDMFieldAttribute", false, "fieldId",
+				"ctCollectionId")) {
 
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
+			long classNameId = _classNameLocalService.getClassNameId(
+				"com.liferay.journal.model.JournalArticle");
 
-				String largeAttributeValue = _transform(
-					companyId, resultSet.getString("largeAttributeValue"));
-				String smallAttributeValue = _transform(
-					companyId, resultSet.getString("smallAttributeValue"));
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(selectSQL);
+				PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection, updateSQL)) {
 
-				if ((smallAttributeValue != null) &&
-					(smallAttributeValue.length() > 255)) {
+				preparedStatement1.setLong(1, classNameId);
 
-					largeAttributeValue = smallAttributeValue;
+				ResultSet resultSet = preparedStatement1.executeQuery();
 
-					smallAttributeValue = null;
+				while (resultSet.next()) {
+					long companyId = resultSet.getLong("companyId");
+
+					String largeAttributeValue = _transform(
+						companyId, resultSet.getString("largeAttributeValue"));
+					String smallAttributeValue = _transform(
+						companyId, resultSet.getString("smallAttributeValue"));
+
+					if ((smallAttributeValue != null) &&
+						(smallAttributeValue.length() > 255)) {
+
+						largeAttributeValue = smallAttributeValue;
+
+						smallAttributeValue = null;
+					}
+
+					preparedStatement2.setString(1, largeAttributeValue);
+					preparedStatement2.setString(2, smallAttributeValue);
+
+					preparedStatement2.setLong(
+						3, resultSet.getLong("ctCollectionId"));
+					preparedStatement2.setLong(
+						4, resultSet.getLong("fieldAttributeId"));
+
+					preparedStatement2.addBatch();
 				}
 
-				preparedStatement2.setString(1, largeAttributeValue);
-				preparedStatement2.setString(2, smallAttributeValue);
-
-				preparedStatement2.setLong(
-					3, resultSet.getLong("ctCollectionId"));
-				preparedStatement2.setLong(
-					4, resultSet.getLong("fieldAttributeId"));
-
-				preparedStatement2.addBatch();
+				preparedStatement2.executeBatch();
 			}
-
-			preparedStatement2.executeBatch();
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -84,8 +84,8 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 					"fieldAttributeId = ?";
 
 		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
-				connection, "DDMFieldAttribute", false, "fieldId",
-				"ctCollectionId")) {
+				connection, "DDMFieldAttribute", false, "ctCollectionId",
+				"fieldId")) {
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				"com.liferay.journal.model.JournalArticle");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92724

## What Is Being Fixed

DDMFieldAttributeUpgradeProcess (v5_6_1) migrates rich-text field attributes by joining DDMStructure, DDMStructureVersion, DDMField, and DDMFieldAttribute. The join from DDMField to DDMFieldAttribute is on ctCollectionId and fieldId, but DDMFieldAttribute has no index covering those columns, so on large datasets the upgrade falls back to full table scans and runs slowly.

## How It Is Being Fixed

The migration is now wrapped in db.addTemporaryIndex on DDMFieldAttribute(ctCollectionId, fieldId), which creates the index before the work runs and drops it through the returned SafeCloseable when the block exits, so the schema is unchanged once the upgrade completes. The index columns are listed alphabetically, and the select and update SQL strings together with the classNameId lookup live inside the addTemporaryIndex try block so that only the DB handle is resolved before it, keeping the temporary index open for the shortest possible window.

## Why Are There No Tests?

This is a performance optimization to an existing upgrade process. The temporary index speeds up the data migration without changing its functional outcome, which is already exercised by the existing upgrade infrastructure, so no new test is warranted.

## PR Check

**pr-check: PASS** — tested on `071abd9d7d9b6516d09b86c73daba9108deb35e6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | — no unit-test counterpart |

<!-- pr-check {"result": "success", "sha": "071abd9d7d9b6516d09b86c73daba9108deb35e6"} -->
