### PR TITLE
LPD-93238 Group ResourcePermission cleanup by target table

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -19,7 +20,11 @@ import com.liferay.portal.security.permission.ResourceActionsImpl;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * @author Luis Ortiz
@@ -40,6 +45,8 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 		Set<String> liferayTableNames = DBResourceUtil.getLiferayTableNames(
 			connection);
 
+		Map<String, List<String>> namesByTableName = new TreeMap<>();
+
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select distinct name from ResourcePermission where name " +
 					"like 'com.liferay.%' and primKeyId != 0 and primKeyId " +
@@ -51,12 +58,14 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 				ResourceActionsImpl resourceActionsImpl =
 					new ResourceActionsImpl();
 
+				String compositeModelNameSeparator =
+					resourceActionsImpl.getCompositeModelNameSeparator();
+
 				while (resultSet.next()) {
 					String name = resultSet.getString("name");
 
 					String[] classNames = StringUtil.split(
-						name,
-						resourceActionsImpl.getCompositeModelNameSeparator());
+						name, compositeModelNameSeparator);
 
 					String tableName = null;
 
@@ -102,38 +111,56 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 						continue;
 					}
 
-					String primaryKeyColumnName = "resourcePrimKey";
+					List<String> names = namesByTableName.computeIfAbsent(
+						tableName, key -> new ArrayList<>());
 
-					if (!dbInspector.hasColumn(
-							tableName, primaryKeyColumnName)) {
-
-						primaryKeyColumnName =
-							DataCleanupPreupgradeProcessUtil.
-								getPrimaryKeyColumnName(
-									connection, dbInspector, tableName);
-					}
-
-					if (primaryKeyColumnName == null) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(
-								"Skipping table " + tableName +
-									" because it does not have a primary key");
-						}
-
-						continue;
-					}
-
-					upgrade(
-						new TableOrphanReferencesDataCleanupPreupgradeProcess(
-							null,
-							StringBundler.concat(
-								"[$SOURCE_TABLE_ALIAS$].scope = ",
-								ResourceConstants.SCOPE_INDIVIDUAL, " and ",
-								"[$SOURCE_TABLE_ALIAS$].name = '", name, "'"),
-							"primKeyId", "ResourcePermission",
-							primaryKeyColumnName, tableName));
+					names.add(name);
 				}
 			}
+		}
+
+		for (Map.Entry<String, List<String>> entry :
+				namesByTableName.entrySet()) {
+
+			String tableName = entry.getKey();
+
+			String primaryKeyColumnName = "resourcePrimKey";
+
+			if (!dbInspector.hasColumn(tableName, primaryKeyColumnName)) {
+				primaryKeyColumnName =
+					DataCleanupPreupgradeProcessUtil.getPrimaryKeyColumnName(
+						connection, dbInspector, tableName);
+			}
+
+			if (primaryKeyColumnName == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Skipping table " + tableName +
+							" because it does not have a primary key");
+				}
+
+				continue;
+			}
+
+			List<String> names = entry.getValue();
+
+			List<String> quotedNames = new ArrayList<>(names.size());
+
+			for (String name : names) {
+				quotedNames.add(StringBundler.concat("'", name, "'"));
+			}
+
+			upgrade(
+				new TableOrphanReferencesDataCleanupPreupgradeProcess(
+					null,
+					StringBundler.concat(
+						"[$SOURCE_TABLE_ALIAS$].scope = ",
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						" and [$SOURCE_TABLE_ALIAS$].name in (",
+						String.join(StringPool.COMMA_AND_SPACE, quotedNames),
+						")"),
+					"primKeyId", "ResourcePermission", primaryKeyColumnName,
+					tableName));
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ResourcePermissionDataCleanupPreupgradeProcess.java
@@ -6,7 +6,6 @@
 package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -142,23 +141,14 @@ public class ResourcePermissionDataCleanupPreupgradeProcess
 				continue;
 			}
 
-			List<String> names = entry.getValue();
-
-			List<String> quotedNames = new ArrayList<>(names.size());
-
-			for (String name : names) {
-				quotedNames.add(StringBundler.concat("'", name, "'"));
-			}
-
 			upgrade(
 				new TableOrphanReferencesDataCleanupPreupgradeProcess(
 					null,
 					StringBundler.concat(
 						"[$SOURCE_TABLE_ALIAS$].scope = ",
 						ResourceConstants.SCOPE_INDIVIDUAL,
-						" and [$SOURCE_TABLE_ALIAS$].name in (",
-						String.join(StringPool.COMMA_AND_SPACE, quotedNames),
-						")"),
+						" and [$SOURCE_TABLE_ALIAS$].name in ('",
+						StringUtil.merge(entry.getValue(), "', '"), "')"),
 					"primKeyId", "ResourcePermission", primaryKeyColumnName,
 					tableName));
 		}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93238

## What Is Being Fixed

ResourcePermissionDataCleanupPreupgradeProcess issued one cleanup pass per distinct resource name — roughly 32 passes in practice. Class names that resolved to the same target table caused that table to be rescanned once per name, multiplying the work the preupgrade cleanup had to perform.

## How It Is Being Fixed

Resource names are now grouped into a Map keyed by the resolved target table, so each table receives a single cleanup pass instead of one per class name. Each table's TableOrphanReferencesDataCleanupPreupgradeProcess call uses a `name in (...)` source where clause built from every name that maps to it, reducing the cleanup from one pass per class name to one pass per target table. A follow-up commit simplifies the IN-clause construction with StringUtil.merge.

## Why Are There No Tests?

This is a behavior-preserving optimization: grouping the cleanup by target table produces the same orphan removal as the previous per-name passes, only with fewer scans. The existing data-cleanup integration coverage — including ResourcePermissionDataCleanupPreupgradeProcessTest in portal-upgrade-test — already exercises this process.

## PR Check

**pr-check: SKIPPED** — Change reverts one line to the inline getter form already present in master, so it cannot affect compilation; the full pr-check on 349d0ee already passed.

<!-- pr-check {"reason": "Change reverts one line to the inline getter form already present in master, so it cannot affect compilation; the full pr-check on 349d0ee already passed.", "result": "skipped", "sha": "2e91d1c0b749d76e4d5624103d6ead6f6ef5eab8"} -->