### PR TITLE
LPD-92724 Speed up DDMFieldAttributeUpgradeProcess with a temp index

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -64,31 +64,30 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		DB db = DBManagerUtil.getDB();
 
-		String selectSQL = StringBundler.concat(
-			"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
-			"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
-			"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
-			"DDMStructure inner join DDMStructureVersion on DDMStructure.",
-			"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
-			"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
-			"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
-			"ctCollectionId and DDMStructureVersion.structureVersionId = ",
-			"DDMField.structureVersionId inner join DDMFieldAttribute on ",
-			"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
-			"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
-			"classNameId = ? and DDMField.fieldType = 'rich_text'");
-
-		String updateSQL =
-			"update DDMFieldAttribute set largeAttributeValue = ?, " +
-				"smallAttributeValue = ? where ctCollectionId = ? and " +
-					"fieldAttributeId = ?";
-
 		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
 				connection, "DDMFieldAttribute", false, "ctCollectionId",
 				"fieldId")) {
 
-			long classNameId = _classNameLocalService.getClassNameId(
-				"com.liferay.journal.model.JournalArticle");
+			String selectSQL = StringBundler.concat(
+				"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
+				"fieldAttributeId, DDMFieldAttribute.companyId, ",
+				"DDMFieldAttribute.largeAttributeValue, DDMFieldAttribute.",
+				"smallAttributeValue from DDMStructure inner join ",
+				"DDMStructureVersion on DDMStructure.ctCollectionId = ",
+				"DDMStructureVersion.ctCollectionId and DDMStructure.",
+				"structureId = DDMStructureVersion.structureId inner join ",
+				"DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
+				"ctCollectionId and DDMStructureVersion.structureVersionId = ",
+				"DDMField.structureVersionId inner join DDMFieldAttribute on ",
+				"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId ",
+				"and DDMField.fieldId = DDMFieldAttribute.fieldId where ",
+				"DDMStructure.classNameId = ? and DDMField.fieldType = ",
+				"'rich_text'");
+
+			String updateSQL =
+				"update DDMFieldAttribute set largeAttributeValue = ?, " +
+					"smallAttributeValue = ? where ctCollectionId = ? and " +
+						"fieldAttributeId = ?";
 
 			try (PreparedStatement preparedStatement1 =
 					connection.prepareStatement(selectSQL);
@@ -96,35 +95,40 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 					AutoBatchPreparedStatementUtil.autoBatch(
 						connection, updateSQL)) {
 
-				preparedStatement1.setLong(1, classNameId);
+				preparedStatement1.setLong(
+					1,
+					_classNameLocalService.getClassNameId(
+						"com.liferay.journal.model.JournalArticle"));
 
-				ResultSet resultSet = preparedStatement1.executeQuery();
+				try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+					while (resultSet.next()) {
+						long companyId = resultSet.getLong("companyId");
 
-				while (resultSet.next()) {
-					long companyId = resultSet.getLong("companyId");
+						String largeAttributeValue = _transform(
+							companyId,
+							resultSet.getString("largeAttributeValue"));
+						String smallAttributeValue = _transform(
+							companyId,
+							resultSet.getString("smallAttributeValue"));
 
-					String largeAttributeValue = _transform(
-						companyId, resultSet.getString("largeAttributeValue"));
-					String smallAttributeValue = _transform(
-						companyId, resultSet.getString("smallAttributeValue"));
+						if ((smallAttributeValue != null) &&
+							(smallAttributeValue.length() > 255)) {
 
-					if ((smallAttributeValue != null) &&
-						(smallAttributeValue.length() > 255)) {
+							largeAttributeValue = smallAttributeValue;
 
-						largeAttributeValue = smallAttributeValue;
+							smallAttributeValue = null;
+						}
 
-						smallAttributeValue = null;
+						preparedStatement2.setString(1, largeAttributeValue);
+						preparedStatement2.setString(2, smallAttributeValue);
+
+						preparedStatement2.setLong(
+							3, resultSet.getLong("ctCollectionId"));
+						preparedStatement2.setLong(
+							4, resultSet.getLong("fieldAttributeId"));
+
+						preparedStatement2.addBatch();
 					}
-
-					preparedStatement2.setString(1, largeAttributeValue);
-					preparedStatement2.setString(2, smallAttributeValue);
-
-					preparedStatement2.setLong(
-						3, resultSet.getLong("ctCollectionId"));
-					preparedStatement2.setLong(
-						4, resultSet.getLong("fieldAttributeId"));
-
-					preparedStatement2.addBatch();
 				}
 
 				preparedStatement2.executeBatch();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -9,8 +9,11 @@ import com.liferay.adaptive.media.image.html.constants.AMImageHTMLConstants;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -59,65 +62,73 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long classNameId = _classNameLocalService.getClassNameId(
-			"com.liferay.journal.model.JournalArticle");
+		DB db = DBManagerUtil.getDB();
 
-		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				StringBundler.concat(
-					"select DDMFieldAttribute.ctCollectionId, ",
-					"DDMFieldAttribute.fieldAttributeId, DDMFieldAttribute.",
-					"companyId, DDMFieldAttribute.largeAttributeValue, ",
-					"DDMFieldAttribute.smallAttributeValue from DDMStructure ",
-					"inner join DDMStructureVersion on DDMStructure.",
-					"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
-					"DDMStructure.structureId = DDMStructureVersion.",
-					"structureId inner join DDMField on DDMStructureVersion.",
-					"ctCollectionId = DDMField.ctCollectionId and ",
-					"DDMStructureVersion.structureVersionId = DDMField.",
-					"structureVersionId inner join DDMFieldAttribute on ",
-					"DDMField.ctCollectionId = DDMFieldAttribute.",
-					"ctCollectionId and DDMField.fieldId = DDMFieldAttribute.",
-					"fieldId where DDMStructure.classNameId = ? and DDMField.",
-					"fieldType = 'rich_text'"));
-			PreparedStatement preparedStatement2 =
-				AutoBatchPreparedStatementUtil.autoBatch(
-					connection,
-					"update DDMFieldAttribute set largeAttributeValue = ?, " +
-						"smallAttributeValue = ? where ctCollectionId = ? " +
-							"and fieldAttributeId = ?")) {
+		String selectSQL = StringBundler.concat(
+			"select DDMFieldAttribute.ctCollectionId, DDMFieldAttribute.",
+			"fieldAttributeId, DDMFieldAttribute.companyId, DDMFieldAttribute.",
+			"largeAttributeValue, DDMFieldAttribute.smallAttributeValue from ",
+			"DDMStructure inner join DDMStructureVersion on DDMStructure.",
+			"ctCollectionId = DDMStructureVersion.ctCollectionId and ",
+			"DDMStructure.structureId = DDMStructureVersion.structureId inner ",
+			"join DDMField on DDMStructureVersion.ctCollectionId = DDMField.",
+			"ctCollectionId and DDMStructureVersion.structureVersionId = ",
+			"DDMField.structureVersionId inner join DDMFieldAttribute on ",
+			"DDMField.ctCollectionId = DDMFieldAttribute.ctCollectionId and ",
+			"DDMField.fieldId = DDMFieldAttribute.fieldId where DDMStructure.",
+			"classNameId = ? and DDMField.fieldType = 'rich_text'");
 
-			preparedStatement1.setLong(1, classNameId);
+		String updateSQL =
+			"update DDMFieldAttribute set largeAttributeValue = ?, " +
+				"smallAttributeValue = ? where ctCollectionId = ? and " +
+					"fieldAttributeId = ?";
 
-			ResultSet resultSet = preparedStatement1.executeQuery();
+		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
+				connection, "DDMFieldAttribute", false, "fieldId",
+				"ctCollectionId")) {
 
-			while (resultSet.next()) {
-				long companyId = resultSet.getLong("companyId");
+			long classNameId = _classNameLocalService.getClassNameId(
+				"com.liferay.journal.model.JournalArticle");
 
-				String largeAttributeValue = _transform(
-					companyId, resultSet.getString("largeAttributeValue"));
-				String smallAttributeValue = _transform(
-					companyId, resultSet.getString("smallAttributeValue"));
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(selectSQL);
+				PreparedStatement preparedStatement2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection, updateSQL)) {
 
-				if ((smallAttributeValue != null) &&
-					(smallAttributeValue.length() > 255)) {
+				preparedStatement1.setLong(1, classNameId);
 
-					largeAttributeValue = smallAttributeValue;
+				ResultSet resultSet = preparedStatement1.executeQuery();
 
-					smallAttributeValue = null;
+				while (resultSet.next()) {
+					long companyId = resultSet.getLong("companyId");
+
+					String largeAttributeValue = _transform(
+						companyId, resultSet.getString("largeAttributeValue"));
+					String smallAttributeValue = _transform(
+						companyId, resultSet.getString("smallAttributeValue"));
+
+					if ((smallAttributeValue != null) &&
+						(smallAttributeValue.length() > 255)) {
+
+						largeAttributeValue = smallAttributeValue;
+
+						smallAttributeValue = null;
+					}
+
+					preparedStatement2.setString(1, largeAttributeValue);
+					preparedStatement2.setString(2, smallAttributeValue);
+
+					preparedStatement2.setLong(
+						3, resultSet.getLong("ctCollectionId"));
+					preparedStatement2.setLong(
+						4, resultSet.getLong("fieldAttributeId"));
+
+					preparedStatement2.addBatch();
 				}
 
-				preparedStatement2.setString(1, largeAttributeValue);
-				preparedStatement2.setString(2, smallAttributeValue);
-
-				preparedStatement2.setLong(
-					3, resultSet.getLong("ctCollectionId"));
-				preparedStatement2.setLong(
-					4, resultSet.getLong("fieldAttributeId"));
-
-				preparedStatement2.addBatch();
+				preparedStatement2.executeBatch();
 			}
-
-			preparedStatement2.executeBatch();
 		}
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_6_1/DDMFieldAttributeUpgradeProcess.java
@@ -84,8 +84,8 @@ public class DDMFieldAttributeUpgradeProcess extends UpgradeProcess {
 					"fieldAttributeId = ?";
 
 		try (SafeCloseable safeCloseable = db.addTemporaryIndex(
-				connection, "DDMFieldAttribute", false, "fieldId",
-				"ctCollectionId")) {
+				connection, "DDMFieldAttribute", false, "ctCollectionId",
+				"fieldId")) {
 
 			long classNameId = _classNameLocalService.getClassNameId(
 				"com.liferay.journal.model.JournalArticle");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92724

## What Is Being Fixed

The v5_6_1 DDMFieldAttributeUpgradeProcess scans DDMFieldAttribute through a multi-table join (DDMStructure → DDMStructureVersion → DDMField → DDMFieldAttribute) to transform rich text field values. On large datasets the join over DDMFieldAttribute has no supporting index, so the upgrade runs slowly.

## How It Is Being Fixed

The upgrade now wraps its work in a temporary index on DDMFieldAttribute (ctCollectionId, fieldId) via db.addTemporaryIndex, created before the query runs and dropped automatically when the try-with-resources block closes. The index accelerates the join for the duration of the upgrade without leaving a permanent schema change behind. The select and update SQL are extracted into the temporary-index block, the ResultSet is managed in its own try-with-resources, and the classNameId lookup is passed directly into setLong at its single use site.

## Why Are There No Tests?

This change only adds a temporary index to speed up the upgrade; the behavior is unchanged and the existing DDMFieldAttributeUpgradeProcess upgrade coverage exercises it.

## PR Check

**pr-check: PASS** — tested on `071abd9d7d9b6516d09b86c73daba9108deb35e6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "071abd9d7d9b6516d09b86c73daba9108deb35e6"} -->