### PR TITLE
LPD-93702 Fix long-running query log message assertion in test

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/upgrade/monitor/UpgradeQueryMonitorTest.java
@@ -318,7 +318,7 @@ public class UpgradeQueryMonitorTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"Long-running query \"", query, "\" with ID ", id,
+				"Long running query \"", query, "\" with ID ", id,
 				" in schema \"", schema, "\" has been running for 630 seconds"),
 			logEntry.getMessage());
 		Assert.assertEquals("INFO", logEntry.getPriority());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93702

## What Is Being Fixed

`UpgradeQueryMonitorTest._testPollLongRunningWithOneQuery` was asserting `"Long-running query"` but source formatter changed the log message in `UpgradeQueryMonitor` to `"Long running query"` (no hyphen), causing the assertion to fail.

## How It Is Being Fixed

Updated the expected string in the assertion from `"Long-running"` to `"Long running"` to match the formatted source.

## PR Check

**pr-check: PASS** — tested on `09e412e993d11fc5179a9de2ab66d3f677aee2ed`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "09e412e993d11fc5179a9de2ab66d3f677aee2ed"} -->