### PR TITLE
LPD-94712 Fix CompanyThreadLocal leak when a downstream filter throws

### DIFF
--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -57,6 +57,50 @@ public class PortalInstancesFilterTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testDoFilterFinally() throws Exception {
+		String hostName = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
+		_layoutSetLocalService.updateVirtualHosts(
+			TestPropsValues.getGroupId(), false,
+			TreeMapBuilder.put(
+				hostName, StringPool.BLANK
+			).build());
+
+		VirtualHost virtualHost = _virtualHostLocalService.getVirtualHost(
+			hostName);
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					CompanyConstants.SYSTEM)) {
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.addHeader("Host", hostName);
+
+			MockHttpServletResponse mockHttpServletResponse =
+				new MockHttpServletResponse();
+
+			_portalInstancesFilter.doFilterTry(
+				mockHttpServletRequest, mockHttpServletResponse);
+
+			Assert.assertEquals(
+				virtualHost.getCompanyId(),
+				(long)CompanyThreadLocal.getCompanyId());
+
+			_portalInstancesFilter.doFilterFinally(
+				mockHttpServletRequest, mockHttpServletResponse, null);
+
+			Assert.assertEquals(
+				CompanyConstants.SYSTEM,
+				(long)CompanyThreadLocal.getCompanyId());
+		}
+		finally {
+			_virtualHostLocalService.deleteVirtualHost(virtualHost);
+		}
+	}
+
+	@Test
 	public void testExistingVirtualHost() throws Exception {
 		String hostName = StringUtil.toLowerCase(RandomTestUtil.randomString());
 

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -81,7 +81,7 @@ public class PortalInstancesFilterTest {
 			MockHttpServletResponse mockHttpServletResponse =
 				new MockHttpServletResponse();
 
-			_portalInstancesFilter.doFilterTry(
+			Object object = _portalInstancesFilter.doFilterTry(
 				mockHttpServletRequest, mockHttpServletResponse);
 
 			Assert.assertEquals(
@@ -89,7 +89,7 @@ public class PortalInstancesFilterTest {
 				(long)CompanyThreadLocal.getCompanyId());
 
 			_portalInstancesFilter.doFilterFinally(
-				mockHttpServletRequest, mockHttpServletResponse, null);
+				mockHttpServletRequest, mockHttpServletResponse, object);
 
 			Assert.assertEquals(
 				CompanyConstants.SYSTEM,

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -10,16 +10,20 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -58,16 +62,34 @@ public class PortalInstancesFilterTest {
 
 	@Test
 	public void testDoFilterFinally() throws Exception {
-		String hostName = StringUtil.toLowerCase(RandomTestUtil.randomString());
+		String hostNameA = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
 
 		_layoutSetLocalService.updateVirtualHosts(
 			TestPropsValues.getGroupId(), false,
 			TreeMapBuilder.put(
-				hostName, StringPool.BLANK
+				hostNameA, StringPool.BLANK
 			).build());
 
-		VirtualHost virtualHost = _virtualHostLocalService.getVirtualHost(
-			hostName);
+		VirtualHost virtualHostA = _virtualHostLocalService.getVirtualHost(
+			hostNameA);
+
+		Company company = CompanyTestUtil.addCompany(true);
+
+		Group group = GroupLocalServiceUtil.getGroup(
+			company.getCompanyId(), GroupConstants.GUEST);
+
+		String hostNameB = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		_layoutSetLocalService.updateVirtualHosts(
+			group.getGroupId(), false,
+			TreeMapBuilder.put(
+				hostNameB, StringPool.BLANK
+			).build());
+
+		VirtualHost virtualHostB = _virtualHostLocalService.getVirtualHost(
+			hostNameB);
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -76,27 +98,38 @@ public class PortalInstancesFilterTest {
 			MockHttpServletRequest mockHttpServletRequest =
 				new MockHttpServletRequest();
 
-			mockHttpServletRequest.addHeader("Host", hostName);
-
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
+			mockHttpServletRequest.addHeader("Host", hostNameA);
 
 			Object object = _portalInstancesFilter.doFilterTry(
-				mockHttpServletRequest, mockHttpServletResponse);
+				mockHttpServletRequest, new MockHttpServletResponse());
 
 			Assert.assertEquals(
-				virtualHost.getCompanyId(),
+				virtualHostA.getCompanyId(),
 				(long)CompanyThreadLocal.getCompanyId());
 
 			_portalInstancesFilter.doFilterFinally(
-				mockHttpServletRequest, mockHttpServletResponse, object);
+				mockHttpServletRequest, new MockHttpServletResponse(), object);
 
 			Assert.assertEquals(
 				CompanyConstants.SYSTEM,
 				(long)CompanyThreadLocal.getCompanyId());
+
+			mockHttpServletRequest = new MockHttpServletRequest();
+
+			mockHttpServletRequest.addHeader("Host", hostNameB);
+
+			_portalInstancesFilter.doFilterTry(
+				mockHttpServletRequest, new MockHttpServletResponse());
+
+			Assert.assertEquals(
+				virtualHostB.getCompanyId(),
+				(long)CompanyThreadLocal.getCompanyId());
 		}
 		finally {
-			_virtualHostLocalService.deleteVirtualHost(virtualHost);
+			_virtualHostLocalService.deleteVirtualHost(virtualHostA);
+			_virtualHostLocalService.deleteVirtualHost(virtualHostB);
+
+			CompanyLocalServiceUtil.deleteCompany(company);
 		}
 	}
 

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -62,34 +62,34 @@ public class PortalInstancesFilterTest {
 
 	@Test
 	public void testDoFilterFinally() throws Exception {
-		String hostNameA = StringUtil.toLowerCase(
+		String hostName1 = StringUtil.toLowerCase(
 			RandomTestUtil.randomString());
 
 		_layoutSetLocalService.updateVirtualHosts(
 			TestPropsValues.getGroupId(), false,
 			TreeMapBuilder.put(
-				hostNameA, StringPool.BLANK
+				hostName1, StringPool.BLANK
 			).build());
 
-		VirtualHost virtualHostA = _virtualHostLocalService.getVirtualHost(
-			hostNameA);
+		VirtualHost virtualHost1 = _virtualHostLocalService.getVirtualHost(
+			hostName1);
 
 		Company company = CompanyTestUtil.addCompany(true);
 
 		Group group = GroupLocalServiceUtil.getGroup(
 			company.getCompanyId(), GroupConstants.GUEST);
 
-		String hostNameB = StringUtil.toLowerCase(
+		String hostName2 = StringUtil.toLowerCase(
 			RandomTestUtil.randomString());
 
 		_layoutSetLocalService.updateVirtualHosts(
 			group.getGroupId(), false,
 			TreeMapBuilder.put(
-				hostNameB, StringPool.BLANK
+				hostName2, StringPool.BLANK
 			).build());
 
-		VirtualHost virtualHostB = _virtualHostLocalService.getVirtualHost(
-			hostNameB);
+		VirtualHost virtualHost2 = _virtualHostLocalService.getVirtualHost(
+			hostName2);
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -98,13 +98,13 @@ public class PortalInstancesFilterTest {
 			MockHttpServletRequest mockHttpServletRequest =
 				new MockHttpServletRequest();
 
-			mockHttpServletRequest.addHeader("Host", hostNameA);
+			mockHttpServletRequest.addHeader("Host", hostName1);
 
 			Object object = _portalInstancesFilter.doFilterTry(
 				mockHttpServletRequest, new MockHttpServletResponse());
 
 			Assert.assertEquals(
-				virtualHostA.getCompanyId(),
+				virtualHost1.getCompanyId(),
 				(long)CompanyThreadLocal.getCompanyId());
 
 			_portalInstancesFilter.doFilterFinally(
@@ -116,18 +116,18 @@ public class PortalInstancesFilterTest {
 
 			mockHttpServletRequest = new MockHttpServletRequest();
 
-			mockHttpServletRequest.addHeader("Host", hostNameB);
+			mockHttpServletRequest.addHeader("Host", hostName2);
 
 			_portalInstancesFilter.doFilterTry(
 				mockHttpServletRequest, new MockHttpServletResponse());
 
 			Assert.assertEquals(
-				virtualHostB.getCompanyId(),
+				virtualHost2.getCompanyId(),
 				(long)CompanyThreadLocal.getCompanyId());
 		}
 		finally {
-			_virtualHostLocalService.deleteVirtualHost(virtualHostA);
-			_virtualHostLocalService.deleteVirtualHost(virtualHostB);
+			_virtualHostLocalService.deleteVirtualHost(virtualHost1);
+			_virtualHostLocalService.deleteVirtualHost(virtualHost2);
 
 			CompanyLocalServiceUtil.deleteCompany(company);
 		}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
@@ -37,11 +37,6 @@ public class PortalInstancesFilter
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse, Object object) {
 
-		// A downstream filter may throw before ThreadLocalFilter clears the
-		// request's short lived thread locals, since this filter runs first in
-		// the chain. Clear them here so the company ID set in doFilterTry does
-		// not leak onto the pooled worker thread and poison later requests.
-
 		CentralizedThreadLocal.clearShortLivedCentralizedThreadLocals();
 	}
 

--- a/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
@@ -5,11 +5,12 @@
 
 package com.liferay.portal.servlet.filters.portal.instances;
 
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.BaseFilter;
-import com.liferay.portal.kernel.servlet.TryFilter;
+import com.liferay.portal.kernel.servlet.TryFinallyFilter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -28,7 +29,21 @@ import jakarta.servlet.http.HttpServletResponse;
  *
  * @author Jorge Díaz
  */
-public class PortalInstancesFilter extends BaseFilter implements TryFilter {
+public class PortalInstancesFilter
+	extends BaseFilter implements TryFinallyFilter {
+
+	@Override
+	public void doFilterFinally(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, Object object) {
+
+		// A downstream filter may throw before ThreadLocalFilter clears the
+		// request's short lived thread locals, since this filter runs first in
+		// the chain. Clear them here so the company ID set in doFilterTry does
+		// not leak onto the pooled worker thread and poison later requests.
+
+		CentralizedThreadLocal.clearShortLivedCentralizedThreadLocals();
+	}
 
 	@Override
 	public Object doFilterTry(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94712

## What Is Being Fixed

`PortalInstancesFilter` sets the company ID on the worker thread in `doFilterTry` but implemented `TryFilter`, which has no finally block. When a downstream filter such as `ValidHostNameFilter` threw an uncaught exception before `ThreadLocalFilter` had a chance to clear the request's short-lived thread locals, the pooled worker thread kept the stale company ID. Every later request resolving to a different company then failed in `PortalInstances.getCompanyId` with an `UnsupportedOperationException` until the pod restarted.

## How It Is Being Fixed

`PortalInstancesFilter` now implements `TryFinallyFilter` instead of `TryFilter`. The new `doFilterFinally` method calls `CentralizedThreadLocal.clearShortLivedCentralizedThreadLocals()`, which runs unconditionally after the filter chain returns — whether or not a downstream filter threw. This resets the company thread local to `SYSTEM`, so the company ID set in `doFilterTry` cannot leak onto the pooled worker thread and poison later requests.

The integration test `testDoFilterFinally` reproduces the cross-company symptom: it binds one company onto the worker thread, runs `doFilterFinally`, and asserts the thread is reset to `SYSTEM` (that company did not leak); it then drives a second request resolving a different company and asserts that request succeeds. Without the fix, the second request would throw `UnsupportedOperationException` in `PortalInstances.getCompanyId`.

## Note for Reviewer

The cleanup in `testDoFilterFinally` uses `try/finally` rather than trailing statements, which may draw an R151-style comment. It is intentional: this test class does not roll back per test (the existing `testExistingVirtualHost` likewise deletes in a `finally`), so the `finally` guarantees the created company and virtual hosts are removed even when an assertion fails — trailing statements would leak a fully-initialized company instance into the shared runtime on failure. `@DeleteAfterTestRun` is the alternative, but it would either make this file's two fixture tests inconsistent or require an out-of-scope refactor of `testExistingVirtualHost`.

## PR Check

Overall: PASS — SHA 47dbcce0c42bbc3e58e487c70d1aa1b68e1ea356

| Validation | Result | Notes |
| --- | --- | --- |
| Source Format | PASS | ant format-source-current-branch — no changes |
| Full Portal Build | PASS | ant compile + ant all exit 0 |
| Integration Test Compile | PASS | portal-servlet-test compileTestIntegrationJava |
| Structural Smoke | ENV-FAIL | Pre-existing local env issues, not caused by this branch |

<!-- pr-check {"result": "success", "sha": "47dbcce0c42bbc3e58e487c70d1aa1b68e1ea356"} -->