### PR TITLE
LPD-92725 Skip XML processing for unchanged Journal Content preferences

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
@@ -56,6 +56,10 @@ public class UpgradePortletPreferences
 			String portletId, String xml)
 		throws Exception {
 
+		if (!xml.contains("articleId")) {
+			return xml;
+		}
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -65,20 +69,20 @@ public class UpgradePortletPreferences
 			portletPreferences.getValue("groupId", null));
 
 		if (Validator.isNull(articleId) || (groupId == 0)) {
-			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+			return xml;
 		}
 
 		Group group = _groupLocalService.fetchGroup(groupId);
 
 		if (group == null) {
-			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+			return xml;
 		}
 
 		JournalArticle journalArticle =
 			_journalArticleLocalService.fetchArticle(groupId, articleId);
 
 		if (journalArticle == null) {
-			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+			return xml;
 		}
 
 		portletPreferences.reset("articleId");

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/test/UpgradePortletPreferencesTest.java
@@ -219,6 +219,15 @@ public class UpgradePortletPreferencesTest {
 			).build());
 	}
 
+	@Test
+	public void testUpgradePortletPreferencesWithoutArticle() throws Exception {
+		Map<String, String> portletPreferencesMap = HashMapBuilder.put(
+			"showAvailableLocales", "true"
+		).build();
+
+		_assertUpgrade(portletPreferencesMap, portletPreferencesMap);
+	}
+
 	private void _assertPortletPreferences(
 			String portletId, Map<String, String> portletPreferencesMap)
 		throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92725

## What Is Being Fixed

The v1.1.1 `UpgradePortletPreferences` in `journal-content-web` iterates every Journal Content portlet preference (~17K rows on the partition-large dump) and, for each row, parses the preferences XML and re-serializes it — even for rows it does not modify. Because the re-serialized XML can differ from the stored form, this forces a needless `UPDATE` on most rows. The original scope of this ticket cached the `Group`, `JournalArticle`, and `DDMTemplate` lookups, but measurement showed no improvement: those lookups already resolve through the portal Entity and Finder caches, so they were never the bottleneck — the per-row XML parse and serialize plus the spurious writes are.

## How It Is Being Fixed

The upgrade now skips the XML work for rows that cannot be migrated. A cheap guard returns the original XML untouched when the raw preferences do not contain an `articleId`, avoiding the `fromXML`/`toXML` round trip entirely. The remaining no-op paths (missing group, missing article) also return the original XML rather than a re-serialized copy, so the base class's change detection skips the `UPDATE` for unaffected rows. An integration test covers the no-op case.

## PR Check

**pr-check: PASS** — tested on `d0532441e71e0d9947c6fd3bb0cf2645d3335a0e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d0532441e71e0d9947c6fd3bb0cf2645d3335a0e"} -->
