### PR TITLE
LPD-92725 Skip XML processing for unchanged Journal Content preferences

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/UpgradePortletPreferences.java
@@ -56,6 +56,10 @@ public class UpgradePortletPreferences
 			String portletId, String xml)
 		throws Exception {
 
+		if (!xml.contains("<name>articleId</name>")) {
+			return xml;
+		}
+
 		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.fromXML(
 				companyId, ownerId, ownerType, plid, portletId, xml);
@@ -65,20 +69,20 @@ public class UpgradePortletPreferences
 			portletPreferences.getValue("groupId", null));
 
 		if (Validator.isNull(articleId) || (groupId == 0)) {
-			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+			return xml;
 		}
 
 		Group group = _groupLocalService.fetchGroup(groupId);
 
 		if (group == null) {
-			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+			return xml;
 		}
 
 		JournalArticle journalArticle =
 			_journalArticleLocalService.fetchArticle(groupId, articleId);
 
 		if (journalArticle == null) {
-			return PortletPreferencesFactoryUtil.toXML(portletPreferences);
+			return xml;
 		}
 
 		portletPreferences.reset("articleId");

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/test/UpgradePortletPreferencesTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/content/web/internal/upgrade/v1_1_1/test/UpgradePortletPreferencesTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -217,6 +218,15 @@ public class UpgradePortletPreferencesTest {
 			).put(
 				"groupExternalReferenceCode", _group.getExternalReferenceCode()
 			).build());
+	}
+
+	@Test
+	public void testUpgradePortletPreferencesWithoutArticle() throws Exception {
+		Map<String, String> portletPreferencesMap = HashMapBuilder.put(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString()
+		).build();
+
+		_assertUpgrade(portletPreferencesMap, portletPreferencesMap);
 	}
 
 	private void _assertPortletPreferences(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92725

## What Is Being Fixed

The v1.1.1 `UpgradePortletPreferences` in `journal-content-web` iterates every Journal Content portlet preference (~17K rows on the partition-large dump) and, for each row, parses the preferences XML and re-serializes it — even for rows it does not modify. Because the re-serialized XML can differ from the stored form, this forces a needless `UPDATE` on most rows. The original scope of this ticket cached the `Group`, `JournalArticle`, and `DDMTemplate` lookups, but measurement showed no improvement: those lookups already resolve through the portal Entity and Finder caches, so they were never the bottleneck — the per-row XML parse and serialize plus the spurious writes are.

## How It Is Being Fixed

The upgrade now skips the XML work for rows that cannot be migrated. A cheap guard returns the original XML untouched when the raw preferences do not contain a `<name>articleId</name>` element, avoiding the `fromXML`/`toXML` round trip entirely. The remaining no-op paths (missing group, missing article) also return the original XML rather than a re-serialized copy, so the base class's change detection skips the `UPDATE` for unaffected rows. An integration test covers the no-op case.

## PR Check

**pr-check: PASS** — tested on `778fa31743cfcc57086526bf8f4edf3a990123b9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "778fa31743cfcc57086526bf8f4edf3a990123b9"} -->
