### PR TITLE
LPD-94750 Enable widget pages on the second portal instance

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/VirtualInstanceCache.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/portalconfiguration/systemmanagement/VirtualInstanceCache.testcase
@@ -163,6 +163,10 @@ definition {
 			userEmailAddress = "test@www.able.com",
 			virtualHostsURL = "http://www.able.com:8080");
 
+		task ("Enable widget pages on the second portal instance") {
+			PagesAdmin.enableWidgetPages();
+		}
+
 		Site.openSitesAdmin(baseURL = "http://www.able.com:8080");
 
 		Site.addBlankCP(siteName = "Site on Partition");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94750

## What Is Being Fixed

`LocalFile.VirtualInstanceCache#NullCacheDoesNotBreakSiteFromAnotherPartition` fails at the page-type selection step when adding a Widget Page. [LPD-89086](https://liferay.atlassian.net/browse/LPD-89086) deprecated the Widget Page page type and gated it behind the [LPD-76864](https://liferay.atlassian.net/browse/LPD-76864) feature flag, and newly created portal instances run with that flag disabled, so the "Widget Page" card is not offered in the add-page selector. The test creates a second instance (www.able.com) and adds a Widget Page there, but the existing `enableWidgetPages` call lives in `setUp` and only enables the flag on the default instance, since the flag is **Virtual Instance Scope**. The second instance therefore never has it enabled.

## How It Is Being Fixed

Enable the Widget Pages feature flag on the second instance as well, right after logging into www.able.com and before the page is added. This mirrors the existing `enableWidgetPages` call in setUp and the `enablePrivatePages` calls used in other tests.

## Why Are There No Tests?

This change is itself a fix to a Poshi functional test. It only enables, on the second portal instance, the feature flag the test already requires. There is no product code change, so no additional test coverage applies.

## PR Check

**pr-check: PASS** — tested on `c5857a664fc6da30a994dede11f6794329517e45`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "c5857a664fc6da30a994dede11f6794329517e45"} -->


[LPD-89086]: https://liferay.atlassian.net/browse/LPD-89086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-76864]: https://liferay.atlassian.net/browse/LPD-76864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ