### PR TITLE
LPD-91685 Assert clean upgrade log and extend PortalLogAssertorTest gate

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3748,7 +3748,10 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
 
 									<if>
-										<equals arg1="${playwright.project.name}" arg2="smoke" />
+										<or>
+											<equals arg1="${playwright.project.name}" arg2="smoke.main" />
+											<contains string="${playwright.project.name}" substring="upgrade" />
+										</or>
 										<then>
 											<ant dir="portal-kernel" inheritAll="false" target="test-class">
 												<property name="test.class" value="PortalLogAssertorTest" />

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+function assert_clean_upgrade_log {
+	local upgrade_log="${LIFERAY_HOME}/tools/portal-tools-db-upgrade-client/logs/upgrade.log"
+
+	if [[ ! -f "${upgrade_log}" ]]
+	then
+		echo "Unable to find upgrade log at ${upgrade_log}."
+
+		return
+	fi
+
+	if grep -q -E "^[0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} (ERROR|FATAL)" "${upgrade_log}"
+	then
+		echo "Unable to validate upgrade log due to ERROR or FATAL entries:"
+
+		grep -E "^[0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} (ERROR|FATAL)" "${upgrade_log}"
+
+		exit 1
+	fi
+}
+
 function cluster_set_up {
 	default_set_up
 

--- a/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
@@ -20,6 +22,8 @@ function main {
 		rebuild-legacy-database
 
 	ant -f build-test.xml upgrade-legacy-database
+
+	assert_clean_upgrade_log
 
 	default_set_up
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91685

## What Is Being Fixed

Playwright upgrade tests were completing without surfacing ERROR/FATAL entries in the DB upgrade client log, and the PortalLogAssertorTest gate had been silently matching nothing since April 2025 when the smoke project was renamed.

Two gaps:
1. `set_up.sh` had no `set -e`, so ant failures in `rebuild-legacy-database` or `upgrade-legacy-database` were silently swallowed.
2. The DB upgrade client writes to `${LIFERAY_HOME}/tools/portal-tools-db-upgrade-client/logs/upgrade.log` — a plain-text file that `PortalLogAssertorTest` never reads. Upgrade errors logged there were invisible to CI.
3. The `PortalLogAssertorTest` gate in `build-test-batch.xml` checked `playwright.project.name == "smoke"`. LPD-54411 renamed the project to `smoke.main` in April 2025 without updating this check, so the gate has matched no project since then.

## How It Is Being Fixed

**`build-test-batch.xml`** — the gate condition is updated from `smoke` to `smoke.main` and extended with a substring match on `upgrade`, covering `object-web.upgrade` and all future upgrade migrations from LPD-83440 automatically.

**`common.sh`** — a new `assert_clean_upgrade_log` function greps `upgrade.log` for lines where ERROR or FATAL is the level field. The grep pattern is anchored to the log4j timestamp prefix (`^HH:MM:SS,mmm (ERROR|FATAL)`) so it only matches lines where ERROR or FATAL appears as the actual log level, not in message bodies. `grep -q` is used for the existence check to exit early without reading the whole file; a second `grep` prints the matching lines when a failure is found. WARN is excluded because `EnvPropertiesUtil:54` produces a WARN on every clean CI run. The function lives in `common.sh` so all 26 future upgrade migrations from LPD-83440 can reuse it with a single call.

**`set_up.sh`** — `set -e -x` is added so any ant failure aborts setup immediately, matching the convention already used by `osb-faro-web/main`, `segments-web/main`, and `segment-experiment-web/main`. `assert_clean_upgrade_log` is called after `upgrade-legacy-database` and before `default_set_up`.

## Why Are There No Tests?

This is a spike/research ticket — the implementation is a PoC demonstrating the approach, not production-ready code under test.

## PR Check

**pr-check: SKIPPED** — this is a spike/research ticket — the implementation is a PoC demonstrating the approach, not production-ready code under test.

<!-- pr-check {"reason": "this is a spike/research ticket — the implementation is a PoC demonstrating the approach, not production-ready code under test.", "result": "skipped", "sha": "bd2c74947f7f9"} -->