### PR TITLE
LPD-94712 Restore CompanyThreadLocal when a downstream filter throws

### DIFF
--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -10,16 +10,20 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -55,6 +59,79 @@ public class PortalInstancesFilterTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testDoFilterFinally() throws Exception {
+		String hostName1 = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		_layoutSetLocalService.updateVirtualHosts(
+			TestPropsValues.getGroupId(), false,
+			TreeMapBuilder.put(
+				hostName1, StringPool.BLANK
+			).build());
+
+		VirtualHost virtualHost1 = _virtualHostLocalService.getVirtualHost(
+			hostName1);
+
+		Company company = CompanyTestUtil.addCompany(true);
+
+		Group group = GroupLocalServiceUtil.getGroup(
+			company.getCompanyId(), GroupConstants.GUEST);
+
+		String hostName2 = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		_layoutSetLocalService.updateVirtualHosts(
+			group.getGroupId(), false,
+			TreeMapBuilder.put(
+				hostName2, StringPool.BLANK
+			).build());
+
+		VirtualHost virtualHost2 = _virtualHostLocalService.getVirtualHost(
+			hostName2);
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					CompanyConstants.SYSTEM)) {
+
+			MockHttpServletRequest mockHttpServletRequest =
+				new MockHttpServletRequest();
+
+			mockHttpServletRequest.addHeader("Host", hostName1);
+
+			Object object = _portalInstancesFilter.doFilterTry(
+				mockHttpServletRequest, new MockHttpServletResponse());
+
+			Assert.assertEquals(
+				virtualHost1.getCompanyId(),
+				(long)CompanyThreadLocal.getCompanyId());
+
+			_portalInstancesFilter.doFilterFinally(
+				mockHttpServletRequest, new MockHttpServletResponse(), object);
+
+			Assert.assertEquals(
+				CompanyConstants.SYSTEM,
+				(long)CompanyThreadLocal.getCompanyId());
+
+			mockHttpServletRequest = new MockHttpServletRequest();
+
+			mockHttpServletRequest.addHeader("Host", hostName2);
+
+			_portalInstancesFilter.doFilterTry(
+				mockHttpServletRequest, new MockHttpServletResponse());
+
+			Assert.assertEquals(
+				virtualHost2.getCompanyId(),
+				(long)CompanyThreadLocal.getCompanyId());
+		}
+		finally {
+			_virtualHostLocalService.deleteVirtualHost(virtualHost1);
+			_virtualHostLocalService.deleteVirtualHost(virtualHost2);
+
+			CompanyLocalServiceUtil.deleteCompany(company);
+		}
+	}
 
 	@Test
 	public void testExistingVirtualHost() throws Exception {

--- a/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/testIntegration/java/com/liferay/portal/servlet/filters/portal/instances/test/PortalInstancesFilterTest.java
@@ -10,20 +10,16 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -62,34 +58,16 @@ public class PortalInstancesFilterTest {
 
 	@Test
 	public void testDoFilterFinally() throws Exception {
-		String hostName1 = StringUtil.toLowerCase(
-			RandomTestUtil.randomString());
+		String hostName = StringUtil.toLowerCase(RandomTestUtil.randomString());
 
 		_layoutSetLocalService.updateVirtualHosts(
 			TestPropsValues.getGroupId(), false,
 			TreeMapBuilder.put(
-				hostName1, StringPool.BLANK
+				hostName, StringPool.BLANK
 			).build());
 
-		VirtualHost virtualHost1 = _virtualHostLocalService.getVirtualHost(
-			hostName1);
-
-		Company company = CompanyTestUtil.addCompany(true);
-
-		Group group = GroupLocalServiceUtil.getGroup(
-			company.getCompanyId(), GroupConstants.GUEST);
-
-		String hostName2 = StringUtil.toLowerCase(
-			RandomTestUtil.randomString());
-
-		_layoutSetLocalService.updateVirtualHosts(
-			group.getGroupId(), false,
-			TreeMapBuilder.put(
-				hostName2, StringPool.BLANK
-			).build());
-
-		VirtualHost virtualHost2 = _virtualHostLocalService.getVirtualHost(
-			hostName2);
+		VirtualHost virtualHost = _virtualHostLocalService.getVirtualHost(
+			hostName);
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -98,13 +76,13 @@ public class PortalInstancesFilterTest {
 			MockHttpServletRequest mockHttpServletRequest =
 				new MockHttpServletRequest();
 
-			mockHttpServletRequest.addHeader("Host", hostName1);
+			mockHttpServletRequest.addHeader("Host", hostName);
 
 			Object object = _portalInstancesFilter.doFilterTry(
 				mockHttpServletRequest, new MockHttpServletResponse());
 
 			Assert.assertEquals(
-				virtualHost1.getCompanyId(),
+				virtualHost.getCompanyId(),
 				(long)CompanyThreadLocal.getCompanyId());
 
 			_portalInstancesFilter.doFilterFinally(
@@ -113,23 +91,9 @@ public class PortalInstancesFilterTest {
 			Assert.assertEquals(
 				CompanyConstants.SYSTEM,
 				(long)CompanyThreadLocal.getCompanyId());
-
-			mockHttpServletRequest = new MockHttpServletRequest();
-
-			mockHttpServletRequest.addHeader("Host", hostName2);
-
-			_portalInstancesFilter.doFilterTry(
-				mockHttpServletRequest, new MockHttpServletResponse());
-
-			Assert.assertEquals(
-				virtualHost2.getCompanyId(),
-				(long)CompanyThreadLocal.getCompanyId());
 		}
 		finally {
-			_virtualHostLocalService.deleteVirtualHost(virtualHost1);
-			_virtualHostLocalService.deleteVirtualHost(virtualHost2);
-
-			CompanyLocalServiceUtil.deleteCompany(company);
+			_virtualHostLocalService.deleteVirtualHost(virtualHost);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
@@ -5,11 +5,12 @@
 
 package com.liferay.portal.servlet.filters.portal.instances;
 
+import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.BaseFilter;
-import com.liferay.portal.kernel.servlet.TryFilter;
+import com.liferay.portal.kernel.servlet.TryFinallyFilter;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -28,7 +29,16 @@ import jakarta.servlet.http.HttpServletResponse;
  *
  * @author Jorge Díaz
  */
-public class PortalInstancesFilter extends BaseFilter implements TryFilter {
+public class PortalInstancesFilter
+	extends BaseFilter implements TryFinallyFilter {
+
+	@Override
+	public void doFilterFinally(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse, Object object) {
+
+		CentralizedThreadLocal.clearShortLivedCentralizedThreadLocals();
+	}
 
 	@Override
 	public Object doFilterTry(

--- a/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter.java
@@ -5,10 +5,10 @@
 
 package com.liferay.portal.servlet.filters.portal.instances;
 
-import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.portal.kernel.exception.NoSuchVirtualHostException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.servlet.BaseFilter;
 import com.liferay.portal.kernel.servlet.TryFinallyFilter;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -37,7 +37,7 @@ public class PortalInstancesFilter
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse, Object object) {
 
-		CentralizedThreadLocal.clearShortLivedCentralizedThreadLocals();
+		CompanyThreadLocal.setCompanyId(GetterUtil.getLong(object));
 	}
 
 	@Override
@@ -45,6 +45,8 @@ public class PortalInstancesFilter
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
+
+		long companyId = CompanyThreadLocal.getCompanyId();
 
 		// Company ID needs to always be called here so that it is properly set
 		// in subsequent calls
@@ -61,11 +63,9 @@ public class PortalInstancesFilter
 				WebKeys.UNKNOWN_VIRTUAL_HOST, Boolean.TRUE);
 
 			httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
-
-			return null;
 		}
 
-		return null;
+		return companyId;
 	}
 
 	@Override

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -88,6 +88,7 @@
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/security/permission/PermissionCacheUtil\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl\.java" />
+		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/util/PortalInstances\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-kernel/src/com/liferay/portal/kernel/cache/transactional/TransactionalPortalCacheUtil\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-kernel/src/com/liferay/portal/kernel/cluster/ClusterableInvokerUtil\.java" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94712

## What Is Being Fixed

`PortalInstancesFilter` sets the company ID on the worker thread in `doFilterTry`, but as a `TryFilter` it had no `finally`. When a downstream filter throws an uncaught exception before `ThreadLocalFilter` clears the request's short-lived thread locals — for example `ValidHostNameFilter` rejecting an unknown `Host` header, which scanner-bot traffic triggers daily in production — the pooled worker thread keeps the stale company ID. Every later request on that worker resolving to a different company then fails in `PortalInstances.getCompanyId` with `UnsupportedOperationException: Unable to set company ID on locked company thread local`, until the pod restarts.

## How It Is Being Fixed

`PortalInstancesFilter` now implements `TryFinallyFilter`. `doFilterTry` snapshots the company ID the thread held on entry and returns it; `doFilterFinally` restores exactly that value, so the company resolved during the request cannot leak onto the pooled worker even when a downstream filter throws. This gives the bare `setCompanyId` call the same balanced try/finally discipline the lock thread local already has through its `SafeCloseable`, and leaves `ThreadLocalFilter` as the sole owner of the general short-lived thread-local clear rather than duplicating that cleanup. The integration test drives `doFilterTry` then `doFilterFinally` and asserts the company thread local returns to `SYSTEM`.

## PR Check

**pr-check: PASS** — tested on `e4653507b411fc63a8ec099fc79ce0486eef45af`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |

Full Portal Build was validated on the identical code diff at the pre-rebase commit `a5e942372e74239d629e03db4043c828578184fb`.

<!-- pr-check {"result": "success", "sha": "e4653507b411fc63a8ec099fc79ce0486eef45af"} -->
