### PR TITLE
LPD-92865 Fix Oracle CI grant path to run as sysdba via sqlplus /nolog

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15874,7 +15874,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
-									sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba << -'EOF'
+									sqlplus /nolog <<-'EOF'
+									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -16097,7 +16098,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 							<exec executable="/bin/bash" failonerror="true">
 								<arg value="-c" />
-								<arg value="printf 'grant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+								<arg value="printf 'connect ${oracle.admin.user}/${oracle.admin.password} as sysdba\ngrant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus /nolog" />
 							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -15874,7 +15874,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
-									sqlplus ${oracle.admin.user}/${oracle.admin.password} << -'EOF'
+									sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba << -'EOF'
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -16095,12 +16095,10 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" password="${oracle.admin.password}" print="true" url="${database.oracle.url}" userid="${oracle.admin.user}">
-								<![CDATA[
-									grant select on sys.v_$session to lportal;
-									grant select on sys.v_$sql to lportal;
-								]]>
-							</sql>
+							<exec executable="/bin/bash" failonerror="true">
+								<arg value="-c" />
+								<arg value="printf 'grant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />
 						</then>

--- a/build-test.xml
+++ b/build-test.xml
@@ -16096,9 +16096,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="/bin/bash" failonerror="true">
-								<arg value="-c" />
-								<arg value="printf 'connect ${oracle.admin.user}/${oracle.admin.password} as sysdba\ngrant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus /nolog" />
+							<exec executable="sqlplus" failonerror="true" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+								<arg value="/nolog" />
 							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92865

## What Is Being Fixed

The Oracle CI legacy-import path grants `SELECT` on `sys.v_$session` and `sys.v_$sql` using either a JDBC `<sql>` Ant task or a plain `sqlplus` heredoc, both of which run as SYSTEM. SYSTEM cannot grant on SYS-owned views, so the grants silently fail and `UpgradeQueryMonitor` surfaces a generic `ORA-00942` instead of the expected permission warning.

## How It Is Being Fixed

Both grant paths in `build-test.xml` now run as sysdba via `sqlplus /nolog` with an explicit `connect ... as sysdba` step. The JDBC `<sql>` Ant task path is replaced with an `<exec>` that feeds the connect and grant statements to `sqlplus` through its `inputstring`, which avoids invoking a shell, keeps the Oracle admin password out of the process list, and removes the single-quote escaping hazard of a `printf` pipe.

## Why Are There No Tests?

Changes are confined to `build-test.xml` CI test infrastructure that configures the Oracle database before tests run. There is no application logic to unit test.

## PR Check

**pr-check: PASS** — tested on `ba7190b14755b3410bf5593a73b32ce05fe2f067`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "ba7190b14755b3410bf5593a73b32ce05fe2f067"} -->