### PR TITLE
LPD-92865 Fix Oracle CI grant path to run as sysdba via sqlplus

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -15874,7 +15874,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
-									sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba << -'EOF'
+									sqlplus /nolog <<-'EOF'
+									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -16097,7 +16098,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 							<exec executable="/bin/bash" failonerror="true">
 								<arg value="-c" />
-								<arg value="printf 'grant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+								<arg value="printf 'connect ${oracle.admin.user}/${oracle.admin.password} as sysdba\ngrant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus /nolog" />
 							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -15874,7 +15874,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
-									sqlplus ${oracle.admin.user}/${oracle.admin.password} << -'EOF'
+									sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba << -'EOF'
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -16095,12 +16095,10 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" password="${oracle.admin.password}" print="true" url="${database.oracle.url}" userid="${oracle.admin.user}">
-								<![CDATA[
-									grant select on sys.v_$session to lportal;
-									grant select on sys.v_$sql to lportal;
-								]]>
-							</sql>
+							<exec executable="/bin/bash" failonerror="true">
+								<arg value="-c" />
+								<arg value="printf 'grant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus ${oracle.admin.user}/${oracle.admin.password} as sysdba" />
+							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />
 						</then>

--- a/build-test.xml
+++ b/build-test.xml
@@ -16096,9 +16096,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="/bin/bash" failonerror="true">
-								<arg value="-c" />
-								<arg value="printf 'connect ${oracle.admin.user}/${oracle.admin.password} as sysdba\ngrant select on sys.v_$session to lportal;\ngrant select on sys.v_$sql to lportal;\nexit\n' | sqlplus /nolog" />
+							<exec executable="sqlplus" failonerror="true" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+								<arg value="/nolog" />
 							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />

--- a/build-test.xml
+++ b/build-test.xml
@@ -15875,6 +15875,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
 									sqlplus /nolog <<-'EOF'
+									whenever sqlerror exit failure
 									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
@@ -16093,7 +16094,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -16062,12 +16062,9 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					<elseif>
 						<equals arg1="${database.type}" arg2="oracle" />
 						<then>
-							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" output="data.pump.log" password="${oracle.admin.password}" print="true" url="${database.oracle.url}" userid="${oracle.admin.user}">
-								<![CDATA[
-									drop user lportal cascade;
-									select directory_name, directory_path from dba_directories where directory_name='DATA_PUMP_DIR';
-								]]>
-							</sql>
+							<exec executable="${oracle.sqlplus.executable}" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;whenever sqlerror continue&#10;set heading off&#10;set feedback off&#10;set pagesize 0&#10;set linesize 1000&#10;set trimspool on&#10;drop user lportal cascade;&#10;select directory_name || ',' || directory_path from dba_directories where directory_name='DATA_PUMP_DIR';&#10;exit&#10;" output="data.pump.log">
+								<arg value="/nolog" />
+							</exec>
 
 							<loadfile
 								property="data.pump.log.content"

--- a/build-test.xml
+++ b/build-test.xml
@@ -16096,7 +16096,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="sqlplus" failonerror="true" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92865

## What Is Being Fixed

The legacy-import CI path for Oracle granted SELECT on the SYS performance views (v_$session, v_$sql) to lportal through an Ant JDBC `<sql>` task connecting as a normal user. Those grants require SYSDBA, so they failed, leaving lportal without access to the views UpgradeQueryMonitor reads.

## How It Is Being Fixed

The grants now run through sqlplus connecting as sysdba (via `/nolog` with the connection fed over stdin, keeping credentials out of the process list). The sqlplus executable is referenced through `${oracle.sqlplus.executable}` rather than a hardcoded `sqlplus`, matching the file's existing Oracle exec elements. The data pump directory lookup, previously a JDBC `<sql>` task, is converted to the same sqlplus exec form so a single mechanism runs Oracle SQL in the file; its query emits `directory_name || ',' || directory_path` so the existing `DATA_PUMP_DIR` regex still resolves `data.pump.dir`.

## Why Are There No Tests?

This changes `build-test.xml`, the Ant CI database-setup script for Oracle, which has no unit-testable surface; its correctness is exercised by the Oracle CI database-provisioning run. The behavior was verified manually against a real Oracle container: the grants execute as sysdba and the data pump query still resolves `data.pump.dir` through the existing regex.

## PR Check

**pr-check: PASS** — tested on `1f76cb5866a90b26b07a23c53c9d3da024c21196`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "1f76cb5866a90b26b07a23c53c9d3da024c21196"} -->
