### PR TITLE
LPD-92865 Fix Oracle CI grant path to run as sysdba via sqlplus

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -16062,12 +16062,9 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					<elseif>
 						<equals arg1="${database.type}" arg2="oracle" />
 						<then>
-							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" output="data.pump.log" password="${oracle.admin.password}" print="true" url="${database.oracle.url}" userid="${oracle.admin.user}">
-								<![CDATA[
-									drop user lportal cascade;
-									select directory_name, directory_path from dba_directories where directory_name='DATA_PUMP_DIR';
-								]]>
-							</sql>
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;whenever sqlerror continue&#10;set heading off&#10;set feedback off&#10;set pagesize 0&#10;set linesize 1000&#10;set trimspool on&#10;drop user lportal cascade;&#10;select directory_name || ',' || directory_path from dba_directories where directory_name='DATA_PUMP_DIR';&#10;exit&#10;" output="data.pump.log">
+								<arg value="/nolog" />
+							</exec>
 
 							<loadfile
 								property="data.pump.log.content"

--- a/build-test.xml
+++ b/build-test.xml
@@ -15874,7 +15874,8 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
-									sqlplus ${oracle.admin.user}/${oracle.admin.password} << -'EOF'
+									sqlplus /nolog <<-'EOF'
+									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
 									exit
@@ -16095,12 +16096,9 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<sql classpath="${test.app.server.lib.portal.dir}/${jdbc.oracle.driver}" driver="oracle.jdbc.OracleDriver" onerror="continue" password="${oracle.admin.password}" print="true" url="${database.oracle.url}" userid="${oracle.admin.user}">
-								<![CDATA[
-									grant select on sys.v_$session to lportal;
-									grant select on sys.v_$sql to lportal;
-								]]>
-							</sql>
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+								<arg value="/nolog" />
+							</exec>
 
 							<delete file="${data.pump.dir}/${database.type}.dmp" />
 						</then>

--- a/build-test.xml
+++ b/build-test.xml
@@ -15875,6 +15875,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 									impdp ${oracle.admin.user}/${oracle.admin.password} dumpfile=oracle.dmp table_exists_action=replace
 
 									sqlplus /nolog <<-'EOF'
+									whenever sqlerror exit failure
 									connect ${oracle.admin.user}/"${oracle.admin.password}" as sysdba
 									grant select on sys.v_$session to ${database.username};
 									grant select on sys.v_$sql to ${database.username};
@@ -16093,7 +16094,7 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 								<arg value="table_exists_action=replace" />
 							</exec>
 
-							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
+							<exec executable="${oracle.sqlplus.executable}" failonerror="true" inputstring="whenever sqlerror exit failure&#10;connect ${oracle.admin.user}/&quot;${oracle.admin.password}&quot; as sysdba&#10;grant select on sys.v_$session to lportal;&#10;grant select on sys.v_$sql to lportal;&#10;exit&#10;">
 								<arg value="/nolog" />
 							</exec>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92865

## What Is Being Fixed

The Oracle legacy-import CI path granted `SELECT` on the SYS performance views (`sys.v_$session`, `sys.v_$sql`) to `lportal` through an Ant JDBC `<sql>` task that connected as a normal user. Those grants require SYSDBA, so they failed silently, leaving `lportal` without access to the views `UpgradeQueryMonitor` reads and surfacing a generic `ORA-00942` instead of a permission-specific warning.

## How It Is Being Fixed

The change is organized as three concerns. First, both grant paths now connect as sysdba through `sqlplus /nolog` with the connection fed over stdin (credentials stay out of the process list), referencing the `${oracle.sqlplus.executable}` property to match the file's existing Oracle exec elements. Second, the data pump directory lookup is converted from a JDBC `<sql>` task to the same `sqlplus` exec form so a single mechanism runs Oracle SQL in the file; its query emits `directory_name || ',' || directory_path` so the existing `DATA_PUMP_DIR` regex still resolves `data.pump.dir`. Third, `whenever sqlerror exit failure` makes the grant step fail the build on a sqlplus connect or grant error rather than passing silently.

This supersedes #3669 with the same final change reorganized into three clean, self-contained commits.

## Why Are There No Tests?

This changes `build-test.xml`, the Ant CI database-setup script for Oracle, which has no unit-testable surface; its correctness is exercised by the Oracle CI database-provisioning run.

## PR Check

**pr-check: PASS** — tested on `7aa4469417bc1a4e9d17b47b0b5d7b9f7b71cbb0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "7aa4469417bc1a4e9d17b47b0b5d7b9f7b71cbb0"} -->