### PR TITLE
LPD-93236 Cache schema metadata in DBInspector during data cleanup

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -115,18 +115,14 @@ public class DataCleanupPreupgradeProcessSuiteTest
 					_createDataCleanupPreupgradeProcess(
 						() ->
 							snapshotEnabledDuringUpgrade[0] =
-								ReflectionTestUtil.getFieldValue(
-									DBInspector.class,
-									"_schemaSnapshotEnabled")),
+								DBInspector.isSchemaSnapshotEnabled()),
 					DataCleanupPreupgradeProcess.dependsOn()
 				).build());
 
 		cleanUp();
 
 		Assert.assertTrue(snapshotEnabledDuringUpgrade[0]);
-		Assert.assertFalse(
-			(boolean)ReflectionTestUtil.getFieldValue(
-				DBInspector.class, "_schemaSnapshotEnabled"));
+		Assert.assertFalse(DBInspector.isSchemaSnapshotEnabled());
 
 		ReflectionTestUtil.setFieldValue(
 			this, "_dataCleanupPreupgradeProcessesMap",
@@ -150,9 +146,7 @@ public class DataCleanupPreupgradeProcessSuiteTest
 				exception instanceof DataCleanupPreupgradeException);
 		}
 
-		Assert.assertFalse(
-			(boolean)ReflectionTestUtil.getFieldValue(
-				DBInspector.class, "_schemaSnapshotEnabled"));
+		Assert.assertFalse(DBInspector.isSchemaSnapshotEnabled());
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -9,7 +9,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ReleaseConstants;
@@ -101,52 +100,6 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		ReflectionTestUtil.setFieldValue(
 			this, "_dataCleanupPreupgradeProcessesMap",
 			_originalDataCleanupPreupgradeProcessesMap);
-	}
-
-	@Test
-	public void testCleanUp() throws Exception {
-		boolean[] snapshotEnabledDuringUpgrade = {false};
-
-		ReflectionTestUtil.setFieldValue(
-			this, "_dataCleanupPreupgradeProcessesMap",
-			HashMapBuilder.
-				<DataCleanupPreupgradeProcess,
-				 List<DataCleanupPreupgradeProcess>>put(
-					_createDataCleanupPreupgradeProcess(
-						() ->
-							snapshotEnabledDuringUpgrade[0] =
-								DBInspector.isSchemaSnapshotEnabled()),
-					DataCleanupPreupgradeProcess.dependsOn()
-				).build());
-
-		cleanUp();
-
-		Assert.assertTrue(snapshotEnabledDuringUpgrade[0]);
-		Assert.assertFalse(DBInspector.isSchemaSnapshotEnabled());
-
-		ReflectionTestUtil.setFieldValue(
-			this, "_dataCleanupPreupgradeProcessesMap",
-			HashMapBuilder.
-				<DataCleanupPreupgradeProcess,
-				 List<DataCleanupPreupgradeProcess>>put(
-					_createDataCleanupPreupgradeProcess(
-						() -> {
-							throw new Exception(_EXCEPTION_MESSAGE);
-						}),
-					DataCleanupPreupgradeProcess.dependsOn()
-				).build());
-
-		try {
-			cleanUp();
-
-			Assert.fail();
-		}
-		catch (Exception exception) {
-			Assert.assertTrue(
-				exception instanceof DataCleanupPreupgradeException);
-		}
-
-		Assert.assertFalse(DBInspector.isSchemaSnapshotEnabled());
 	}
 
 	@Test

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -104,9 +104,7 @@ public class DataCleanupPreupgradeProcessSuiteTest
 	}
 
 	@Test
-	public void testCleanUpActivatesSchemaSnapshotDuringProcess()
-		throws Exception {
-
+	public void testCleanUp() throws Exception {
 		boolean[] snapshotEnabledDuringUpgrade = {false};
 
 		ReflectionTestUtil.setFieldValue(
@@ -129,10 +127,7 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		Assert.assertFalse(
 			(boolean)ReflectionTestUtil.getFieldValue(
 				DBInspector.class, "_schemaSnapshotEnabled"));
-	}
 
-	@Test
-	public void testCleanUpClearsSchemaSnapshotOnFailure() throws Exception {
 		ReflectionTestUtil.setFieldValue(
 			this, "_dataCleanupPreupgradeProcessesMap",
 			HashMapBuilder.

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ReleaseConstants;
@@ -100,6 +101,63 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		ReflectionTestUtil.setFieldValue(
 			this, "_dataCleanupPreupgradeProcessesMap",
 			_originalDataCleanupPreupgradeProcessesMap);
+	}
+
+	@Test
+	public void testCleanUpActivatesSchemaSnapshotDuringProcess()
+		throws Exception {
+
+		boolean[] snapshotEnabledDuringUpgrade = {false};
+
+		ReflectionTestUtil.setFieldValue(
+			this, "_dataCleanupPreupgradeProcessesMap",
+			HashMapBuilder.
+				<DataCleanupPreupgradeProcess,
+				 List<DataCleanupPreupgradeProcess>>put(
+					_createDataCleanupPreupgradeProcess(
+						() ->
+							snapshotEnabledDuringUpgrade[0] =
+								ReflectionTestUtil.getFieldValue(
+									DBInspector.class,
+									"_schemaSnapshotEnabled")),
+					DataCleanupPreupgradeProcess.dependsOn()
+				).build());
+
+		cleanUp();
+
+		Assert.assertTrue(snapshotEnabledDuringUpgrade[0]);
+		Assert.assertFalse(
+			(boolean)ReflectionTestUtil.getFieldValue(
+				DBInspector.class, "_schemaSnapshotEnabled"));
+	}
+
+	@Test
+	public void testCleanUpClearsSchemaSnapshotOnFailure() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			this, "_dataCleanupPreupgradeProcessesMap",
+			HashMapBuilder.
+				<DataCleanupPreupgradeProcess,
+				 List<DataCleanupPreupgradeProcess>>put(
+					_createDataCleanupPreupgradeProcess(
+						() -> {
+							throw new Exception(_EXCEPTION_MESSAGE);
+						}),
+					DataCleanupPreupgradeProcess.dependsOn()
+				).build());
+
+		try {
+			cleanUp();
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception instanceof DataCleanupPreupgradeException);
+		}
+
+		Assert.assertFalse(
+			(boolean)ReflectionTestUtil.getFieldValue(
+				DBInspector.class, "_schemaSnapshotEnabled"));
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -7,9 +7,7 @@ package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.portal.db.index.PrimaryKeyUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
-import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
@@ -42,7 +40,7 @@ public class DataCleanupPreupgradeProcessSuite {
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			DBInspector.beginSchemaSnapshot();
+			DataCleanupPreupgradeProcessUtil.enableCache();
 
 			try {
 				List<DataCleanupPreupgradeProcess>
@@ -72,9 +70,7 @@ public class DataCleanupPreupgradeProcessSuite {
 				}
 			}
 			finally {
-				DataCleanupPreupgradeProcessUtil.clearCache();
-				DBInspector.clearSchemaSnapshot();
-				DBResourceUtil.clearLiferayTableNamesCache();
+				DataCleanupPreupgradeProcessUtil.disableCache();
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -7,7 +7,9 @@ package com.liferay.portal.upgrade.data.cleanup;
 
 import com.liferay.portal.db.index.PrimaryKeyUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
@@ -40,29 +42,39 @@ public class DataCleanupPreupgradeProcessSuite {
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses =
-				getSortedDataCleanupPreupgradeProcesses();
+			DBInspector.beginSchemaSnapshot();
 
-			for (DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess :
-					dataCleanupPreupgradeProcesses) {
+			try {
+				List<DataCleanupPreupgradeProcess>
+					dataCleanupPreupgradeProcesses =
+						getSortedDataCleanupPreupgradeProcesses();
 
-				Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
+				for (DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess :
+						dataCleanupPreupgradeProcesses) {
 
-				if (ArrayUtil.contains(
-						PropsValues.
-							UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
-						clazz.getName())) {
+					Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
 
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							"Skipping blacklisted data cleanup process: " +
-								clazz.getName());
+					if (ArrayUtil.contains(
+							PropsValues.
+								UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
+							clazz.getName())) {
+
+						if (_log.isInfoEnabled()) {
+							_log.info(
+								"Skipping blacklisted data cleanup process: " +
+									clazz.getName());
+						}
+
+						continue;
 					}
 
-					continue;
+					dataCleanupPreupgradeProcess.upgrade();
 				}
-
-				dataCleanupPreupgradeProcess.upgrade();
+			}
+			finally {
+				DataCleanupPreupgradeProcessUtil.clearCache();
+				DBInspector.clearSchemaSnapshot();
+				DBResourceUtil.clearLiferayTableNamesCache();
 			}
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
@@ -23,6 +23,8 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -32,9 +34,24 @@ import org.osgi.framework.BundleContext;
  */
 public class DataCleanupPreupgradeProcessUtil {
 
+	public static void clearCache() {
+		_primaryKeyColumnNameCache.clear();
+		_tableNameCache.clear();
+	}
+
 	public static String getPrimaryKeyColumnName(
 			Connection connection, DBInspector dbInspector, String tableName)
 		throws Exception {
+
+		String primaryKeyColumnName = _primaryKeyColumnNameCache.get(tableName);
+
+		if (primaryKeyColumnName != null) {
+			if (primaryKeyColumnName == _NOT_FOUND) {
+				return null;
+			}
+
+			return primaryKeyColumnName;
+		}
 
 		DB db = DBManagerUtil.getDB();
 
@@ -45,15 +62,43 @@ public class DataCleanupPreupgradeProcessUtil {
 			dbInspector.normalizeName("ctCollectionId"));
 
 		if (primaryKeyColumnNames.size() != 1) {
+			_primaryKeyColumnNameCache.putIfAbsent(tableName, _NOT_FOUND);
+
 			return null;
 		}
 
-		return primaryKeyColumnNames.get(0);
+		primaryKeyColumnName = primaryKeyColumnNames.get(0);
+
+		_primaryKeyColumnNameCache.putIfAbsent(tableName, primaryKeyColumnName);
+
+		return primaryKeyColumnName;
 	}
 
 	public static String getTableName(
 			Connection connection, DBInspector dbInspector,
 			String fullyQualifiedName)
+		throws Exception {
+
+		String tableName = _tableNameCache.get(fullyQualifiedName);
+
+		if (tableName != null) {
+			if (tableName == _NOT_FOUND) {
+				return null;
+			}
+
+			return tableName;
+		}
+
+		tableName = _computeTableName(connection, fullyQualifiedName);
+
+		_tableNameCache.putIfAbsent(
+			fullyQualifiedName, (tableName != null) ? tableName : _NOT_FOUND);
+
+		return tableName;
+	}
+
+	private static String _computeTableName(
+			Connection connection, String fullyQualifiedName)
 		throws Exception {
 
 		if (StringUtil.startsWith(
@@ -86,15 +131,15 @@ public class DataCleanupPreupgradeProcessUtil {
 				ImplementationClassName implementationClassName =
 					clazz.getAnnotation(ImplementationClassName.class);
 
-				if (implementationClassName == null) {
-					return null;
+				if (implementationClassName != null) {
+					clazz = bundle.loadClass(implementationClassName.value());
+
+					Field field = clazz.getField("TABLE_NAME");
+
+					return (String)field.get(null);
 				}
 
-				clazz = bundle.loadClass(implementationClassName.value());
-
-				Field field = clazz.getField("TABLE_NAME");
-
-				return (String)field.get(null);
+				return null;
 			}
 			catch (ClassNotFoundException classNotFoundException) {
 				if (_log.isDebugEnabled()) {
@@ -106,7 +151,14 @@ public class DataCleanupPreupgradeProcessUtil {
 		return null;
 	}
 
+	private static final String _NOT_FOUND = new String("");
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		DataCleanupPreupgradeProcessUtil.class);
+
+	private static final Map<String, String> _primaryKeyColumnNameCache =
+		new ConcurrentHashMap<>();
+	private static final Map<String, String> _tableNameCache =
+		new ConcurrentHashMap<>();
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
@@ -43,14 +43,17 @@ public class DataCleanupPreupgradeProcessUtil {
 			Connection connection, DBInspector dbInspector, String tableName)
 		throws Exception {
 
-		String primaryKeyColumnName = _primaryKeyColumnNameCache.get(tableName);
+		if (DBInspector.isSchemaSnapshotEnabled()) {
+			String primaryKeyColumnName = _primaryKeyColumnNameCache.get(
+				tableName);
 
-		if (primaryKeyColumnName != null) {
-			if (primaryKeyColumnName.isEmpty()) {
-				return null;
+			if (primaryKeyColumnName != null) {
+				if (primaryKeyColumnName.isEmpty()) {
+					return null;
+				}
+
+				return primaryKeyColumnName;
 			}
-
-			return primaryKeyColumnName;
 		}
 
 		DB db = DBManagerUtil.getDB();
@@ -62,14 +65,19 @@ public class DataCleanupPreupgradeProcessUtil {
 			dbInspector.normalizeName("ctCollectionId"));
 
 		if (primaryKeyColumnNames.size() != 1) {
-			_primaryKeyColumnNameCache.putIfAbsent(tableName, _NOT_FOUND);
+			if (DBInspector.isSchemaSnapshotEnabled()) {
+				_primaryKeyColumnNameCache.putIfAbsent(tableName, _NOT_FOUND);
+			}
 
 			return null;
 		}
 
-		primaryKeyColumnName = primaryKeyColumnNames.get(0);
+		String primaryKeyColumnName = primaryKeyColumnNames.get(0);
 
-		_primaryKeyColumnNameCache.putIfAbsent(tableName, primaryKeyColumnName);
+		if (DBInspector.isSchemaSnapshotEnabled()) {
+			_primaryKeyColumnNameCache.putIfAbsent(
+				tableName, primaryKeyColumnName);
+		}
 
 		return primaryKeyColumnName;
 	}
@@ -79,20 +87,25 @@ public class DataCleanupPreupgradeProcessUtil {
 			String fullyQualifiedName)
 		throws Exception {
 
-		String tableName = _tableNameCache.get(fullyQualifiedName);
+		if (DBInspector.isSchemaSnapshotEnabled()) {
+			String tableName = _tableNameCache.get(fullyQualifiedName);
 
-		if (tableName != null) {
-			if (tableName.isEmpty()) {
-				return null;
+			if (tableName != null) {
+				if (tableName.isEmpty()) {
+					return null;
+				}
+
+				return tableName;
 			}
-
-			return tableName;
 		}
 
-		tableName = _computeTableName(connection, fullyQualifiedName);
+		String tableName = _computeTableName(connection, fullyQualifiedName);
 
-		_tableNameCache.putIfAbsent(
-			fullyQualifiedName, (tableName != null) ? tableName : _NOT_FOUND);
+		if (DBInspector.isSchemaSnapshotEnabled()) {
+			_tableNameCache.putIfAbsent(
+				fullyQualifiedName,
+				(tableName != null) ? tableName : _NOT_FOUND);
+		}
 
 		return tableName;
 	}

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
@@ -46,7 +46,7 @@ public class DataCleanupPreupgradeProcessUtil {
 		String primaryKeyColumnName = _primaryKeyColumnNameCache.get(tableName);
 
 		if (primaryKeyColumnName != null) {
-			if (primaryKeyColumnName == _NOT_FOUND) {
+			if (primaryKeyColumnName.isEmpty()) {
 				return null;
 			}
 
@@ -82,7 +82,7 @@ public class DataCleanupPreupgradeProcessUtil {
 		String tableName = _tableNameCache.get(fullyQualifiedName);
 
 		if (tableName != null) {
-			if (tableName == _NOT_FOUND) {
+			if (tableName.isEmpty()) {
 				return null;
 			}
 
@@ -151,7 +151,7 @@ public class DataCleanupPreupgradeProcessUtil {
 		return null;
 	}
 
-	private static final String _NOT_FOUND = new String("");
+	private static final String _NOT_FOUND = "";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DataCleanupPreupgradeProcessUtil.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
@@ -131,15 +131,15 @@ public class DataCleanupPreupgradeProcessUtil {
 				ImplementationClassName implementationClassName =
 					clazz.getAnnotation(ImplementationClassName.class);
 
-				if (implementationClassName != null) {
-					clazz = bundle.loadClass(implementationClassName.value());
-
-					Field field = clazz.getField("TABLE_NAME");
-
-					return (String)field.get(null);
+				if (implementationClassName == null) {
+					return null;
 				}
 
-				return null;
+				clazz = bundle.loadClass(implementationClassName.value());
+
+				Field field = clazz.getField("TABLE_NAME");
+
+				return (String)field.get(null);
 			}
 			catch (ClassNotFoundException classNotFoundException) {
 				if (_log.isDebugEnabled()) {

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
@@ -34,16 +35,28 @@ import org.osgi.framework.BundleContext;
  */
 public class DataCleanupPreupgradeProcessUtil {
 
-	public static void clearCache() {
+	public static void disableCache() {
+		_cacheEnabled = false;
+
 		_primaryKeyColumnNameCache.clear();
 		_tableNameCache.clear();
+
+		DBInspector.disableCache();
+		DBResourceUtil.disableCache();
+	}
+
+	public static void enableCache() {
+		_cacheEnabled = true;
+
+		DBInspector.enableCache();
+		DBResourceUtil.enableCache();
 	}
 
 	public static String getPrimaryKeyColumnName(
 			Connection connection, DBInspector dbInspector, String tableName)
 		throws Exception {
 
-		if (DBInspector.isSchemaSnapshotEnabled()) {
+		if (_cacheEnabled) {
 			String primaryKeyColumnName = _primaryKeyColumnNameCache.get(
 				tableName);
 
@@ -65,7 +78,7 @@ public class DataCleanupPreupgradeProcessUtil {
 			dbInspector.normalizeName("ctCollectionId"));
 
 		if (primaryKeyColumnNames.size() != 1) {
-			if (DBInspector.isSchemaSnapshotEnabled()) {
+			if (_cacheEnabled) {
 				_primaryKeyColumnNameCache.putIfAbsent(tableName, _NOT_FOUND);
 			}
 
@@ -74,7 +87,7 @@ public class DataCleanupPreupgradeProcessUtil {
 
 		String primaryKeyColumnName = primaryKeyColumnNames.get(0);
 
-		if (DBInspector.isSchemaSnapshotEnabled()) {
+		if (_cacheEnabled) {
 			_primaryKeyColumnNameCache.putIfAbsent(
 				tableName, primaryKeyColumnName);
 		}
@@ -87,7 +100,7 @@ public class DataCleanupPreupgradeProcessUtil {
 			String fullyQualifiedName)
 		throws Exception {
 
-		if (DBInspector.isSchemaSnapshotEnabled()) {
+		if (_cacheEnabled) {
 			String tableName = _tableNameCache.get(fullyQualifiedName);
 
 			if (tableName != null) {
@@ -101,7 +114,7 @@ public class DataCleanupPreupgradeProcessUtil {
 
 		String tableName = _computeTableName(connection, fullyQualifiedName);
 
-		if (DBInspector.isSchemaSnapshotEnabled()) {
+		if (_cacheEnabled) {
 			_tableNameCache.putIfAbsent(
 				fullyQualifiedName,
 				(tableName != null) ? tableName : _NOT_FOUND);
@@ -169,6 +182,7 @@ public class DataCleanupPreupgradeProcessUtil {
 	private static final Log _log = LogFactoryUtil.getLog(
 		DataCleanupPreupgradeProcessUtil.class);
 
+	private static volatile boolean _cacheEnabled;
 	private static final Map<String, String> _primaryKeyColumnNameCache =
 		new ConcurrentHashMap<>();
 	private static final Map<String, String> _tableNameCache =

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessUtil.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.upgrade.data.cleanup;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.annotation.ImplementationClassName;
 import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.dao.db.DBInspector;
@@ -25,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.osgi.framework.Bundle;
@@ -100,8 +103,13 @@ public class DataCleanupPreupgradeProcessUtil {
 			String fullyQualifiedName)
 		throws Exception {
 
+		String cacheKey = StringBundler.concat(
+			Objects.toString(dbInspector.getCatalog(), StringPool.BLANK), ".",
+			Objects.toString(dbInspector.getSchema(), StringPool.BLANK), ".",
+			fullyQualifiedName);
+
 		if (_cacheEnabled) {
-			String tableName = _tableNameCache.get(fullyQualifiedName);
+			String tableName = _tableNameCache.get(cacheKey);
 
 			if (tableName != null) {
 				if (tableName.isEmpty()) {
@@ -116,8 +124,7 @@ public class DataCleanupPreupgradeProcessUtil {
 
 		if (_cacheEnabled) {
 			_tableNameCache.putIfAbsent(
-				fullyQualifiedName,
-				(tableName != null) ? tableName : _NOT_FOUND);
+				cacheKey, (tableName != null) ? tableName : _NOT_FOUND);
 		}
 
 		return tableName;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -39,19 +39,15 @@ import java.util.regex.Pattern;
  */
 public class DBInspector {
 
-	public static void beginSchemaSnapshot() {
-		_schemaSnapshotEnabled = true;
-	}
-
-	public static void clearSchemaSnapshot() {
-		_schemaSnapshotEnabled = false;
+	public static void disableCache() {
+		_cacheEnabled = false;
 
 		_columnTypeCache.clear();
 		_tableNamesCache.clear();
 	}
 
-	public static boolean isSchemaSnapshotEnabled() {
-		return _schemaSnapshotEnabled;
+	public static void enableCache() {
+		_cacheEnabled = true;
 	}
 
 	public DBInspector(Connection connection) {
@@ -82,7 +78,7 @@ public class DBInspector {
 	public List<String> getTableNames(String tableNamePattern)
 		throws SQLException {
 
-		if (_schemaSnapshotEnabled && (tableNamePattern == null)) {
+		if (_cacheEnabled && (tableNamePattern == null)) {
 			String cacheKey = _getSchemaCacheKey();
 
 			Set<String> tableNames = _tableNamesCache.get(cacheKey);
@@ -91,16 +87,14 @@ public class DBInspector {
 				return new ArrayList<>(tableNames);
 			}
 
-			List<String> names = _getNames(null, "TABLE");
-
-			Set<String> tableNamesSnapshot = new TreeSet<>(
+			Set<String> schemaTableNames = new TreeSet<>(
 				String.CASE_INSENSITIVE_ORDER);
 
-			tableNamesSnapshot.addAll(names);
+			schemaTableNames.addAll(_getNames(null, "TABLE"));
 
-			_tableNamesCache.putIfAbsent(cacheKey, tableNamesSnapshot);
+			_tableNamesCache.putIfAbsent(cacheKey, schemaTableNames);
 
-			return new ArrayList<>(tableNamesSnapshot);
+			return new ArrayList<>(schemaTableNames);
 		}
 
 		return _getNames(tableNamePattern, "TABLE");
@@ -119,8 +113,8 @@ public class DBInspector {
 			return false;
 		}
 
-		if (_schemaSnapshotEnabled) {
-			if (_getColumnType(tableName, columnName) != _NO_COLUMN) {
+		if (_cacheEnabled) {
+			if (_getColumnType(tableName, columnName) != _COLUMN_TYPE_NONE) {
 				return true;
 			}
 
@@ -277,7 +271,7 @@ public class DBInspector {
 	}
 
 	public boolean hasTable(String tableName) throws Exception {
-		if (_schemaSnapshotEnabled) {
+		if (_cacheEnabled) {
 			String cacheKey = _getSchemaCacheKey();
 
 			Set<String> tableNames = _tableNamesCache.get(cacheKey);
@@ -348,7 +342,7 @@ public class DBInspector {
 			return false;
 		}
 
-		if (_schemaSnapshotEnabled) {
+		if (_cacheEnabled) {
 			return _isNumericType(_getColumnType(tableName, columnName));
 		}
 
@@ -511,7 +505,7 @@ public class DBInspector {
 			return columnType;
 		}
 
-		columnType = _NO_COLUMN;
+		columnType = _COLUMN_TYPE_NONE;
 
 		try (ResultSet resultSet = _getColumnsResultSet(
 				normalizedTableName, normalizedColumnName)) {
@@ -546,9 +540,8 @@ public class DBInspector {
 	}
 
 	private String _getSchemaCacheKey() throws SQLException {
-		return StringBundler.concat(
-			Objects.toString(getCatalog(), StringPool.BLANK), ".",
-			Objects.toString(getSchema(), StringPool.BLANK));
+		return Objects.toString(getCatalog(), StringPool.BLANK) + "." +
+			Objects.toString(getSchema(), StringPool.BLANK);
 	}
 
 	private boolean _hasElement(String elementName, String elementType)
@@ -595,10 +588,11 @@ public class DBInspector {
 		return false;
 	}
 
-	private static final int _NO_COLUMN = Integer.MIN_VALUE;
+	private static final int _COLUMN_TYPE_NONE = Integer.MIN_VALUE;
 
 	private static final Log _log = LogFactoryUtil.getLog(DBInspector.class);
 
+	private static volatile boolean _cacheEnabled;
 	private static final Pattern _columnDefaultClausePattern = Pattern.compile(
 		".*DEFAULT ((?:'[^']+')|(?:\\S+)) NOT NULL", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnSizePattern = Pattern.compile(
@@ -612,7 +606,6 @@ public class DBInspector {
 			"company", "release_", "servicecomponent", "virtualhost"));
 	private static final Set<String> _partitionedControlTableNames =
 		new HashSet<>(Arrays.asList("classname_", "counter", "resourceaction"));
-	private static volatile boolean _schemaSnapshotEnabled;
 	private static final Map<String, Set<String>> _tableNamesCache =
 		new ConcurrentHashMap<>();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
@@ -91,7 +92,12 @@ public class DBInspector {
 
 			List<String> names = _getNames(null, "TABLE");
 
-			_tableNamesCache.putIfAbsent(catalog, new HashSet<>(names));
+			Set<String> tableNamesSnapshot = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			tableNamesSnapshot.addAll(names);
+
+			_tableNamesCache.putIfAbsent(catalog, tableNamesSnapshot);
 
 			return names;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -82,9 +82,11 @@ public class DBInspector {
 		throws SQLException {
 
 		if (_schemaSnapshotEnabled && (tableNamePattern == null)) {
-			String catalog = StringUtil.defaultString(getCatalog());
+			String cacheKey = StringBundler.concat(
+				StringUtil.defaultString(getCatalog()), ".",
+				StringUtil.defaultString(getSchema()));
 
-			Set<String> tableNames = _tableNamesCache.get(catalog);
+			Set<String> tableNames = _tableNamesCache.get(cacheKey);
 
 			if (tableNames != null) {
 				return new ArrayList<>(tableNames);
@@ -97,7 +99,7 @@ public class DBInspector {
 
 			tableNamesSnapshot.addAll(names);
 
-			_tableNamesCache.putIfAbsent(catalog, tableNamesSnapshot);
+			_tableNamesCache.putIfAbsent(cacheKey, tableNamesSnapshot);
 
 			return names;
 		}
@@ -128,7 +130,8 @@ public class DBInspector {
 
 			String cacheKey = StringBundler.concat(
 				StringUtil.defaultString(getCatalog()), ".",
-				normalizedTableName, ".", normalizedColumnName);
+				StringUtil.defaultString(getSchema()), ".", normalizedTableName,
+				".", normalizedColumnName);
 
 			Boolean cached = _columnExistsCache.get(cacheKey);
 
@@ -300,14 +303,16 @@ public class DBInspector {
 
 	public boolean hasTable(String tableName) throws Exception {
 		if (_schemaSnapshotEnabled) {
-			String catalog = StringUtil.defaultString(getCatalog());
+			String cacheKey = StringBundler.concat(
+				StringUtil.defaultString(getCatalog()), ".",
+				StringUtil.defaultString(getSchema()));
 
-			Set<String> tableNames = _tableNamesCache.get(catalog);
+			Set<String> tableNames = _tableNamesCache.get(cacheKey);
 
 			if (tableNames == null) {
 				getTableNames(null);
 
-				tableNames = _tableNamesCache.get(catalog);
+				tableNames = _tableNamesCache.get(cacheKey);
 			}
 
 			if (tableNames != null) {
@@ -380,7 +385,8 @@ public class DBInspector {
 
 			String cacheKey = StringBundler.concat(
 				StringUtil.defaultString(getCatalog()), ".",
-				normalizedTableName, ".", normalizedColumnName);
+				StringUtil.defaultString(getSchema()), ".", normalizedTableName,
+				".", normalizedColumnName);
 
 			Boolean cached = _columnNumericCache.get(cacheKey);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -46,8 +46,7 @@ public class DBInspector {
 	public static void clearSchemaSnapshot() {
 		_schemaSnapshotEnabled = false;
 
-		_columnExistsCache.clear();
-		_columnNumericCache.clear();
+		_columnTypeCache.clear();
 		_tableNamesCache.clear();
 	}
 
@@ -123,35 +122,11 @@ public class DBInspector {
 		}
 
 		if (_schemaSnapshotEnabled) {
-			DatabaseMetaData databaseMetaData = _connection.getMetaData();
-
-			String normalizedColumnName = normalizeName(
-				columnName, databaseMetaData);
-			String normalizedTableName = normalizeName(
-				tableName, databaseMetaData);
-
-			String cacheKey = StringBundler.concat(
-				Objects.toString(getCatalog(), StringPool.BLANK), ".",
-				Objects.toString(getSchema(), StringPool.BLANK), ".",
-				normalizedTableName, ".", normalizedColumnName);
-
-			Boolean cached = _columnExistsCache.get(cacheKey);
-
-			if (cached != null) {
-				return cached;
+			if (_getColumnType(tableName, columnName) != _NO_COLUMN) {
+				return true;
 			}
 
-			boolean exists = false;
-
-			try (ResultSet resultSet = _getColumnsResultSet(
-					normalizedTableName, normalizedColumnName)) {
-
-				exists = resultSet.next();
-			}
-
-			_columnExistsCache.put(cacheKey, exists);
-
-			return exists;
+			return false;
 		}
 
 		try (ResultSet resultSet = _getColumnsResultSet(
@@ -378,37 +353,7 @@ public class DBInspector {
 		}
 
 		if (_schemaSnapshotEnabled) {
-			DatabaseMetaData databaseMetaData = _connection.getMetaData();
-
-			String normalizedColumnName = normalizeName(
-				columnName, databaseMetaData);
-			String normalizedTableName = normalizeName(
-				tableName, databaseMetaData);
-
-			String cacheKey = StringBundler.concat(
-				Objects.toString(getCatalog(), StringPool.BLANK), ".",
-				Objects.toString(getSchema(), StringPool.BLANK), ".",
-				normalizedTableName, ".", normalizedColumnName);
-
-			Boolean cached = _columnNumericCache.get(cacheKey);
-
-			if (cached != null) {
-				return cached;
-			}
-
-			boolean numeric = false;
-
-			try (ResultSet resultSet = _getColumnsResultSet(
-					normalizedTableName, normalizedColumnName)) {
-
-				if (resultSet.next()) {
-					numeric = _isNumericType(resultSet.getInt("DATA_TYPE"));
-				}
-			}
-
-			_columnNumericCache.put(cacheKey, numeric);
-
-			return numeric;
+			return _isNumericType(_getColumnType(tableName, columnName));
 		}
 
 		try (ResultSet resultSet = _getColumnsResultSet(
@@ -551,6 +496,41 @@ public class DBInspector {
 			normalizeName(tableName, databaseMetaData), columnName);
 	}
 
+	private int _getColumnType(String tableName, String columnName)
+		throws Exception {
+
+		DatabaseMetaData databaseMetaData = _connection.getMetaData();
+
+		String normalizedColumnName = normalizeName(
+			columnName, databaseMetaData);
+		String normalizedTableName = normalizeName(tableName, databaseMetaData);
+
+		String cacheKey = StringBundler.concat(
+			Objects.toString(getCatalog(), StringPool.BLANK), ".",
+			Objects.toString(getSchema(), StringPool.BLANK), ".",
+			normalizedTableName, ".", normalizedColumnName);
+
+		Integer columnType = _columnTypeCache.get(cacheKey);
+
+		if (columnType != null) {
+			return columnType;
+		}
+
+		columnType = _NO_COLUMN;
+
+		try (ResultSet resultSet = _getColumnsResultSet(
+				normalizedTableName, normalizedColumnName)) {
+
+			if (resultSet.next()) {
+				columnType = resultSet.getInt("DATA_TYPE");
+			}
+		}
+
+		_columnTypeCache.put(cacheKey, columnType);
+
+		return columnType;
+	}
+
 	private List<String> _getNames(String namePattern, String elementType)
 		throws SQLException {
 
@@ -614,16 +594,16 @@ public class DBInspector {
 		return false;
 	}
 
+	private static final int _NO_COLUMN = Integer.MIN_VALUE;
+
 	private static final Log _log = LogFactoryUtil.getLog(DBInspector.class);
 
 	private static final Pattern _columnDefaultClausePattern = Pattern.compile(
 		".*DEFAULT ((?:'[^']+')|(?:\\S+)) NOT NULL", Pattern.CASE_INSENSITIVE);
-	private static final Map<String, Boolean> _columnExistsCache =
-		new ConcurrentHashMap<>();
-	private static final Map<String, Boolean> _columnNumericCache =
-		new ConcurrentHashMap<>();
 	private static final Pattern _columnSizePattern = Pattern.compile(
 		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
+	private static final Map<String, Integer> _columnTypeCache =
+		new ConcurrentHashMap<>();
 	private static final Pattern _columnTypePattern = Pattern.compile(
 		"(^\\w+)", Pattern.CASE_INSENSITIVE);
 	private static final Set<String> _controlTableNames = new HashSet<>(

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -83,9 +83,7 @@ public class DBInspector {
 		throws SQLException {
 
 		if (_schemaSnapshotEnabled && (tableNamePattern == null)) {
-			String cacheKey = StringBundler.concat(
-				Objects.toString(getCatalog(), StringPool.BLANK), ".",
-				Objects.toString(getSchema(), StringPool.BLANK));
+			String cacheKey = _getSchemaCacheKey();
 
 			Set<String> tableNames = _tableNamesCache.get(cacheKey);
 
@@ -280,9 +278,7 @@ public class DBInspector {
 
 	public boolean hasTable(String tableName) throws Exception {
 		if (_schemaSnapshotEnabled) {
-			String cacheKey = StringBundler.concat(
-				Objects.toString(getCatalog(), StringPool.BLANK), ".",
-				Objects.toString(getSchema(), StringPool.BLANK));
+			String cacheKey = _getSchemaCacheKey();
 
 			Set<String> tableNames = _tableNamesCache.get(cacheKey);
 
@@ -506,9 +502,8 @@ public class DBInspector {
 		String normalizedTableName = normalizeName(tableName, databaseMetaData);
 
 		String cacheKey = StringBundler.concat(
-			Objects.toString(getCatalog(), StringPool.BLANK), ".",
-			Objects.toString(getSchema(), StringPool.BLANK), ".",
-			normalizedTableName, ".", normalizedColumnName);
+			_getSchemaCacheKey(), ".", normalizedTableName, ".",
+			normalizedColumnName);
 
 		Integer columnType = _columnTypeCache.get(cacheKey);
 
@@ -548,6 +543,12 @@ public class DBInspector {
 		}
 
 		return names;
+	}
+
+	private String _getSchemaCacheKey() throws SQLException {
+		return StringBundler.concat(
+			Objects.toString(getCatalog(), StringPool.BLANK), ".",
+			Objects.toString(getSchema(), StringPool.BLANK));
 	}
 
 	private boolean _hasElement(String elementName, String elementType)

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,6 +35,17 @@ import java.util.regex.Pattern;
  * @author Adolfo Pérez
  */
 public class DBInspector {
+
+	public static void beginSchemaSnapshot() {
+		_schemaSnapshotEnabled = true;
+	}
+
+	public static void clearSchemaSnapshot() {
+		_columnExistsCache.clear();
+		_columnNumericCache.clear();
+		_tableNamesCache.clear();
+		_schemaSnapshotEnabled = false;
+	}
 
 	public DBInspector(Connection connection) {
 		_connection = connection;
@@ -63,6 +75,22 @@ public class DBInspector {
 	public List<String> getTableNames(String tableNamePattern)
 		throws SQLException {
 
+		if (_schemaSnapshotEnabled && (tableNamePattern == null)) {
+			String catalog = StringUtil.defaultString(getCatalog());
+
+			Set<String> tableNames = _tableNamesCache.get(catalog);
+
+			if (tableNames != null) {
+				return new ArrayList<>(tableNames);
+			}
+
+			List<String> names = _getNames(null, "TABLE");
+
+			_tableNamesCache.putIfAbsent(catalog, new HashSet<>(names));
+
+			return names;
+		}
+
 		return _getNames(tableNamePattern, "TABLE");
 	}
 
@@ -77,6 +105,37 @@ public class DBInspector {
 
 		if ((columnName == null) || (tableName == null)) {
 			return false;
+		}
+
+		if (_schemaSnapshotEnabled) {
+			DatabaseMetaData databaseMetaData = _connection.getMetaData();
+
+			String normalizedColumnName = normalizeName(
+				columnName, databaseMetaData);
+			String normalizedTableName = normalizeName(
+				tableName, databaseMetaData);
+
+			String cacheKey = StringBundler.concat(
+				StringUtil.defaultString(getCatalog()), ".",
+				normalizedTableName, ".", normalizedColumnName);
+
+			Boolean cached = _columnExistsCache.get(cacheKey);
+
+			if (cached != null) {
+				return cached;
+			}
+
+			boolean exists = false;
+
+			try (ResultSet resultSet = _getColumnsResultSet(
+					normalizedTableName, normalizedColumnName)) {
+
+				exists = resultSet.next();
+			}
+
+			_columnExistsCache.put(cacheKey, exists);
+
+			return exists;
 		}
 
 		try (ResultSet resultSet = _getColumnsResultSet(
@@ -229,6 +288,15 @@ public class DBInspector {
 	}
 
 	public boolean hasTable(String tableName) throws Exception {
+		if (_schemaSnapshotEnabled) {
+			Set<String> tableNames = _tableNamesCache.get(
+				StringUtil.defaultString(getCatalog()));
+
+			if (tableNames != null) {
+				return tableNames.contains(normalizeName(tableName));
+			}
+		}
+
 		return _hasElement(tableName, "TABLE");
 	}
 
@@ -284,6 +352,39 @@ public class DBInspector {
 			return false;
 		}
 
+		if (_schemaSnapshotEnabled) {
+			DatabaseMetaData databaseMetaData = _connection.getMetaData();
+
+			String normalizedColumnName = normalizeName(
+				columnName, databaseMetaData);
+			String normalizedTableName = normalizeName(
+				tableName, databaseMetaData);
+
+			String cacheKey = StringBundler.concat(
+				StringUtil.defaultString(getCatalog()), ".",
+				normalizedTableName, ".", normalizedColumnName);
+
+			Boolean cached = _columnNumericCache.get(cacheKey);
+
+			if (cached != null) {
+				return cached;
+			}
+
+			boolean numeric = false;
+
+			try (ResultSet resultSet = _getColumnsResultSet(
+					normalizedTableName, normalizedColumnName)) {
+
+				if (resultSet.next()) {
+					numeric = _isNumericType(resultSet.getInt("DATA_TYPE"));
+				}
+			}
+
+			_columnNumericCache.put(cacheKey, numeric);
+
+			return numeric;
+		}
+
 		try (ResultSet resultSet = _getColumnsResultSet(
 				tableName, columnName)) {
 
@@ -291,19 +392,7 @@ public class DBInspector {
 				return false;
 			}
 
-			int columnType = resultSet.getInt("DATA_TYPE");
-
-			if ((columnType == Types.BIGINT) || (columnType == Types.DECIMAL) ||
-				(columnType == Types.DOUBLE) || (columnType == Types.FLOAT) ||
-				(columnType == Types.INTEGER) ||
-				(columnType == Types.NUMERIC) || (columnType == Types.REAL) ||
-				(columnType == Types.SMALLINT) ||
-				(columnType == Types.TINYINT)) {
-
-				return true;
-			}
-
-			return false;
+			return _isNumericType(resultSet.getInt("DATA_TYPE"));
 		}
 	}
 
@@ -486,10 +575,27 @@ public class DBInspector {
 		return !typeName.endsWith("not null");
 	}
 
+	private boolean _isNumericType(int columnType) {
+		if ((columnType == Types.BIGINT) || (columnType == Types.DECIMAL) ||
+			(columnType == Types.DOUBLE) || (columnType == Types.FLOAT) ||
+			(columnType == Types.INTEGER) || (columnType == Types.NUMERIC) ||
+			(columnType == Types.REAL) || (columnType == Types.SMALLINT) ||
+			(columnType == Types.TINYINT)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(DBInspector.class);
 
 	private static final Pattern _columnDefaultClausePattern = Pattern.compile(
 		".*DEFAULT ((?:'[^']+')|(?:\\S+)) NOT NULL", Pattern.CASE_INSENSITIVE);
+	private static final ConcurrentHashMap<String, Boolean> _columnExistsCache =
+		new ConcurrentHashMap<>();
+	private static final ConcurrentHashMap<String, Boolean>
+		_columnNumericCache = new ConcurrentHashMap<>();
 	private static final Pattern _columnSizePattern = Pattern.compile(
 		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnTypePattern = Pattern.compile(
@@ -499,6 +605,9 @@ public class DBInspector {
 			"company", "release_", "servicecomponent", "virtualhost"));
 	private static final Set<String> _partitionedControlTableNames =
 		new HashSet<>(Arrays.asList("classname_", "counter", "resourceaction"));
+	private static volatile boolean _schemaSnapshotEnabled;
+	private static final ConcurrentHashMap<String, Set<String>>
+		_tableNamesCache = new ConcurrentHashMap<>();
 
 	private final Connection _connection;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
@@ -84,8 +85,8 @@ public class DBInspector {
 
 		if (_schemaSnapshotEnabled && (tableNamePattern == null)) {
 			String cacheKey = StringBundler.concat(
-				StringUtil.defaultString(getCatalog()), ".",
-				StringUtil.defaultString(getSchema()));
+				Objects.toString(getCatalog(), StringPool.BLANK), ".",
+				Objects.toString(getSchema(), StringPool.BLANK));
 
 			Set<String> tableNames = _tableNamesCache.get(cacheKey);
 
@@ -102,7 +103,7 @@ public class DBInspector {
 
 			_tableNamesCache.putIfAbsent(cacheKey, tableNamesSnapshot);
 
-			return names;
+			return new ArrayList<>(tableNamesSnapshot);
 		}
 
 		return _getNames(tableNamePattern, "TABLE");
@@ -130,9 +131,9 @@ public class DBInspector {
 				tableName, databaseMetaData);
 
 			String cacheKey = StringBundler.concat(
-				StringUtil.defaultString(getCatalog()), ".",
-				StringUtil.defaultString(getSchema()), ".", normalizedTableName,
-				".", normalizedColumnName);
+				Objects.toString(getCatalog(), StringPool.BLANK), ".",
+				Objects.toString(getSchema(), StringPool.BLANK), ".",
+				normalizedTableName, ".", normalizedColumnName);
 
 			Boolean cached = _columnExistsCache.get(cacheKey);
 
@@ -305,8 +306,8 @@ public class DBInspector {
 	public boolean hasTable(String tableName) throws Exception {
 		if (_schemaSnapshotEnabled) {
 			String cacheKey = StringBundler.concat(
-				StringUtil.defaultString(getCatalog()), ".",
-				StringUtil.defaultString(getSchema()));
+				Objects.toString(getCatalog(), StringPool.BLANK), ".",
+				Objects.toString(getSchema(), StringPool.BLANK));
 
 			Set<String> tableNames = _tableNamesCache.get(cacheKey);
 
@@ -385,9 +386,9 @@ public class DBInspector {
 				tableName, databaseMetaData);
 
 			String cacheKey = StringBundler.concat(
-				StringUtil.defaultString(getCatalog()), ".",
-				StringUtil.defaultString(getSchema()), ".", normalizedTableName,
-				".", normalizedColumnName);
+				Objects.toString(getCatalog(), StringPool.BLANK), ".",
+				Objects.toString(getSchema(), StringPool.BLANK), ".",
+				normalizedTableName, ".", normalizedColumnName);
 
 			Boolean cached = _columnNumericCache.get(cacheKey);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
@@ -45,6 +46,10 @@ public class DBInspector {
 		_columnNumericCache.clear();
 		_tableNamesCache.clear();
 		_schemaSnapshotEnabled = false;
+	}
+
+	public static boolean isSchemaSnapshotEnabled() {
+		return _schemaSnapshotEnabled;
 	}
 
 	public DBInspector(Connection connection) {
@@ -289,8 +294,15 @@ public class DBInspector {
 
 	public boolean hasTable(String tableName) throws Exception {
 		if (_schemaSnapshotEnabled) {
-			Set<String> tableNames = _tableNamesCache.get(
-				StringUtil.defaultString(getCatalog()));
+			String catalog = StringUtil.defaultString(getCatalog());
+
+			Set<String> tableNames = _tableNamesCache.get(catalog);
+
+			if (tableNames == null) {
+				getTableNames(null);
+
+				tableNames = _tableNamesCache.get(catalog);
+			}
 
 			if (tableNames != null) {
 				return tableNames.contains(normalizeName(tableName));
@@ -592,10 +604,10 @@ public class DBInspector {
 
 	private static final Pattern _columnDefaultClausePattern = Pattern.compile(
 		".*DEFAULT ((?:'[^']+')|(?:\\S+)) NOT NULL", Pattern.CASE_INSENSITIVE);
-	private static final ConcurrentHashMap<String, Boolean> _columnExistsCache =
+	private static final Map<String, Boolean> _columnExistsCache =
 		new ConcurrentHashMap<>();
-	private static final ConcurrentHashMap<String, Boolean>
-		_columnNumericCache = new ConcurrentHashMap<>();
+	private static final Map<String, Boolean> _columnNumericCache =
+		new ConcurrentHashMap<>();
 	private static final Pattern _columnSizePattern = Pattern.compile(
 		"^\\w+(?:\\((\\d+)\\))?.*", Pattern.CASE_INSENSITIVE);
 	private static final Pattern _columnTypePattern = Pattern.compile(
@@ -606,8 +618,8 @@ public class DBInspector {
 	private static final Set<String> _partitionedControlTableNames =
 		new HashSet<>(Arrays.asList("classname_", "counter", "resourceaction"));
 	private static volatile boolean _schemaSnapshotEnabled;
-	private static final ConcurrentHashMap<String, Set<String>>
-		_tableNamesCache = new ConcurrentHashMap<>();
+	private static final Map<String, Set<String>> _tableNamesCache =
+		new ConcurrentHashMap<>();
 
 	private final Connection _connection;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector.java
@@ -43,10 +43,11 @@ public class DBInspector {
 	}
 
 	public static void clearSchemaSnapshot() {
+		_schemaSnapshotEnabled = false;
+
 		_columnExistsCache.clear();
 		_columnNumericCache.clear();
 		_tableNamesCache.clear();
-		_schemaSnapshotEnabled = false;
 	}
 
 	public static boolean isSchemaSnapshotEnabled() {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/packageinfo
@@ -1,1 +1,1 @@
-version 22.1.0
+version 22.2.0

--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -11,7 +11,6 @@ import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -50,16 +49,22 @@ import org.osgi.framework.BundleContext;
  */
 public class DBResourceUtil {
 
-	public static void clearLiferayTableNamesCache() {
+	public static void disableCache() {
+		_cacheEnabled = false;
+
 		_liferayTableNames = null;
 
 		_moduleTableNamesDCLSingleton.destroy(null);
 	}
 
+	public static void enableCache() {
+		_cacheEnabled = true;
+	}
+
 	public static Set<String> getLiferayTableNames(Connection connection)
 		throws Exception {
 
-		if (DBInspector.isSchemaSnapshotEnabled()) {
+		if (_cacheEnabled) {
 			Set<String> liferayTableNames = _liferayTableNames;
 
 			if (liferayTableNames == null) {
@@ -94,7 +99,7 @@ public class DBResourceUtil {
 	}
 
 	public static Set<String> getModuleTableNames() {
-		if (DBInspector.isSchemaSnapshotEnabled()) {
+		if (_cacheEnabled) {
 			Set<String> tableNames = new TreeSet<>(
 				String.CASE_INSENSITIVE_ORDER);
 
@@ -426,6 +431,7 @@ public class DBResourceUtil {
 
 	private static final Log _log = LogFactoryUtil.getLog(DBResourceUtil.class);
 
+	private static volatile boolean _cacheEnabled;
 	private static final Pattern _composedPrimaryKeyPattern = Pattern.compile(
 		"create table\\s+(\\w+)\\s*\\((?:[^;]*?)?primary key\\s*\\(([^)]+)\\)",
 		Pattern.DOTALL);

--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -52,7 +52,8 @@ public class DBResourceUtil {
 
 	public static void clearLiferayTableNamesCache() {
 		_liferayTableNames = null;
-		_moduleTableNames = null;
+
+		_moduleTableNamesDCLSingleton.destroy(null);
 	}
 
 	public static Set<String> getLiferayTableNames(Connection connection)
@@ -94,24 +95,12 @@ public class DBResourceUtil {
 
 	public static Set<String> getModuleTableNames() {
 		if (DBInspector.isSchemaSnapshotEnabled()) {
-			Set<String> moduleTableNames = _moduleTableNames;
-
-			if (moduleTableNames == null) {
-				synchronized (DBResourceUtil.class) {
-					moduleTableNames = _moduleTableNames;
-
-					if (moduleTableNames == null) {
-						moduleTableNames = _buildModuleTableNames();
-
-						_moduleTableNames = moduleTableNames;
-					}
-				}
-			}
-
 			Set<String> tableNames = new TreeSet<>(
 				String.CASE_INSENSITIVE_ORDER);
 
-			tableNames.addAll(moduleTableNames);
+			tableNames.addAll(
+				_moduleTableNamesDCLSingleton.getSingleton(
+					DBResourceUtil::_buildModuleTableNames));
 
 			return tableNames;
 		}
@@ -176,24 +165,11 @@ public class DBResourceUtil {
 	}
 
 	public static Set<String> getPortalTableNames() {
-		Set<String> portalTableNames = _portalTableNames;
-
-		if (portalTableNames == null) {
-			synchronized (DBResourceUtil.class) {
-				portalTableNames = _portalTableNames;
-
-				if (portalTableNames == null) {
-					portalTableNames = parseCreateTableSQL(
-						getPortalTablesSQL());
-
-					_portalTableNames = portalTableNames;
-				}
-			}
-		}
-
 		Set<String> tableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
-		tableNames.addAll(portalTableNames);
+		tableNames.addAll(
+			_portalTableNamesDCLSingleton.getSingleton(
+				() -> parseCreateTableSQL(getPortalTablesSQL())));
 
 		return tableNames;
 	}
@@ -460,8 +436,10 @@ public class DBResourceUtil {
 			"(?:\\s+\\w+)*\\s+primary key\\b",
 		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 	private static volatile Set<String> _liferayTableNames;
-	private static volatile Set<String> _moduleTableNames;
-	private static volatile Set<String> _portalTableNames;
+	private static final DCLSingleton<Set<String>>
+		_moduleTableNamesDCLSingleton = new DCLSingleton<>();
+	private static final DCLSingleton<Set<String>>
+		_portalTableNamesDCLSingleton = new DCLSingleton<>();
 	private static final DCLSingleton<ServiceTrackerList<DBResourceProvider>>
 		_serviceTrackerListDCLSingleton = new DCLSingleton<>();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -49,20 +49,37 @@ import org.osgi.framework.BundleContext;
  */
 public class DBResourceUtil {
 
+	public static void clearLiferayTableNamesCache() {
+		_liferayTableNames = null;
+		_moduleTableNames = null;
+	}
+
 	public static Set<String> getLiferayTableNames(Connection connection)
 		throws Exception {
 
-		Set<String> liferayTableNames = new TreeSet<>(
-			String.CASE_INSENSITIVE_ORDER);
+		if (_liferayTableNames != null) {
+			return _liferayTableNames;
+		}
 
-		liferayTableNames.addAll(getModuleTableNames());
-		liferayTableNames.addAll(getPortalTableNames());
-		liferayTableNames.addAll(
-			getServiceComponentModuleTableNames(connection));
-		liferayTableNames.addAll(
-			getServiceComponentPortalTableNames(connection));
+		synchronized (DBResourceUtil.class) {
+			if (_liferayTableNames != null) {
+				return _liferayTableNames;
+			}
 
-		return liferayTableNames;
+			Set<String> liferayTableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			liferayTableNames.addAll(getModuleTableNames());
+			liferayTableNames.addAll(getPortalTableNames());
+			liferayTableNames.addAll(
+				getServiceComponentModuleTableNames(connection));
+			liferayTableNames.addAll(
+				getServiceComponentPortalTableNames(connection));
+
+			_liferayTableNames = liferayTableNames;
+
+			return _liferayTableNames;
+		}
 	}
 
 	public static String getModuleIndexesSQL(Bundle bundle) {
@@ -74,29 +91,42 @@ public class DBResourceUtil {
 	}
 
 	public static Set<String> getModuleTableNames() {
-		Set<String> tableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			String symbolicName = bundle.getSymbolicName();
-
-			if (!symbolicName.startsWith("com.liferay") ||
-				!BundleUtil.isLiferayServiceBundle(bundle)) {
-
-				continue;
-			}
-
-			String tableSQL = getModuleTablesSQL(bundle);
-
-			if (tableSQL == null) {
-				continue;
-			}
-
-			tableNames.addAll(parseCreateTableSQL(tableSQL));
+		if (_moduleTableNames != null) {
+			return _moduleTableNames;
 		}
 
-		return tableNames;
+		synchronized (DBResourceUtil.class) {
+			if (_moduleTableNames != null) {
+				return _moduleTableNames;
+			}
+
+			Set<String> tableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+			for (Bundle bundle : bundleContext.getBundles()) {
+				String symbolicName = bundle.getSymbolicName();
+
+				if (!symbolicName.startsWith("com.liferay") ||
+					!BundleUtil.isLiferayServiceBundle(bundle)) {
+
+					continue;
+				}
+
+				String tableSQL = getModuleTablesSQL(bundle);
+
+				if (tableSQL == null) {
+					continue;
+				}
+
+				tableNames.addAll(parseCreateTableSQL(tableSQL));
+			}
+
+			_moduleTableNames = tableNames;
+
+			return _moduleTableNames;
+		}
 	}
 
 	public static Map<String, String[]> getModuleTablesPrimaryKeyColumnNames(
@@ -160,9 +190,15 @@ public class DBResourceUtil {
 			return _portalTableNames;
 		}
 
-		_portalTableNames = parseCreateTableSQL(getPortalTablesSQL());
+		synchronized (DBResourceUtil.class) {
+			if (_portalTableNames != null) {
+				return _portalTableNames;
+			}
 
-		return _portalTableNames;
+			_portalTableNames = parseCreateTableSQL(getPortalTablesSQL());
+
+			return _portalTableNames;
+		}
 	}
 
 	public static Map<String, String[]> getPortalTablesPrimaryKeyColumnNames() {
@@ -384,6 +420,8 @@ public class DBResourceUtil {
 		"create table\\s+(\\w+)\\s*\\([^;]*?(\\w+)\\s+\\w+(?:\\([^)]*\\))?" +
 			"(?:\\s+\\w+)*\\s+primary key\\b",
 		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+	private static volatile Set<String> _liferayTableNames;
+	private static volatile Set<String> _moduleTableNames;
 	private static volatile Set<String> _portalTableNames;
 	private static final DCLSingleton<ServiceTrackerList<DBResourceProvider>>
 		_serviceTrackerListDCLSingleton = new DCLSingleton<>();

--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -11,6 +11,7 @@ import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -57,29 +58,38 @@ public class DBResourceUtil {
 	public static Set<String> getLiferayTableNames(Connection connection)
 		throws Exception {
 
-		if (_liferayTableNames != null) {
-			return _liferayTableNames;
-		}
-
-		synchronized (DBResourceUtil.class) {
+		if (DBInspector.isSchemaSnapshotEnabled()) {
 			if (_liferayTableNames != null) {
-				return _liferayTableNames;
+				Set<String> tableNames = new TreeSet<>(
+					String.CASE_INSENSITIVE_ORDER);
+
+				tableNames.addAll(_liferayTableNames);
+
+				return tableNames;
 			}
 
-			Set<String> liferayTableNames = new TreeSet<>(
-				String.CASE_INSENSITIVE_ORDER);
+			synchronized (DBResourceUtil.class) {
+				if (_liferayTableNames != null) {
+					Set<String> tableNames = new TreeSet<>(
+						String.CASE_INSENSITIVE_ORDER);
 
-			liferayTableNames.addAll(getModuleTableNames());
-			liferayTableNames.addAll(getPortalTableNames());
-			liferayTableNames.addAll(
-				getServiceComponentModuleTableNames(connection));
-			liferayTableNames.addAll(
-				getServiceComponentPortalTableNames(connection));
+					tableNames.addAll(_liferayTableNames);
 
-			_liferayTableNames = liferayTableNames;
+					return tableNames;
+				}
 
-			return _liferayTableNames;
+				_liferayTableNames = _buildLiferayTableNames(connection);
+
+				Set<String> tableNames = new TreeSet<>(
+					String.CASE_INSENSITIVE_ORDER);
+
+				tableNames.addAll(_liferayTableNames);
+
+				return tableNames;
+			}
 		}
+
+		return _buildLiferayTableNames(connection);
 	}
 
 	public static String getModuleIndexesSQL(Bundle bundle) {
@@ -91,42 +101,38 @@ public class DBResourceUtil {
 	}
 
 	public static Set<String> getModuleTableNames() {
-		if (_moduleTableNames != null) {
-			return _moduleTableNames;
-		}
-
-		synchronized (DBResourceUtil.class) {
+		if (DBInspector.isSchemaSnapshotEnabled()) {
 			if (_moduleTableNames != null) {
-				return _moduleTableNames;
+				Set<String> tableNames = new TreeSet<>(
+					String.CASE_INSENSITIVE_ORDER);
+
+				tableNames.addAll(_moduleTableNames);
+
+				return tableNames;
 			}
 
-			Set<String> tableNames = new TreeSet<>(
-				String.CASE_INSENSITIVE_ORDER);
+			synchronized (DBResourceUtil.class) {
+				if (_moduleTableNames != null) {
+					Set<String> tableNames = new TreeSet<>(
+						String.CASE_INSENSITIVE_ORDER);
 
-			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+					tableNames.addAll(_moduleTableNames);
 
-			for (Bundle bundle : bundleContext.getBundles()) {
-				String symbolicName = bundle.getSymbolicName();
-
-				if (!symbolicName.startsWith("com.liferay") ||
-					!BundleUtil.isLiferayServiceBundle(bundle)) {
-
-					continue;
+					return tableNames;
 				}
 
-				String tableSQL = getModuleTablesSQL(bundle);
+				_moduleTableNames = _buildModuleTableNames();
 
-				if (tableSQL == null) {
-					continue;
-				}
+				Set<String> tableNames = new TreeSet<>(
+					String.CASE_INSENSITIVE_ORDER);
 
-				tableNames.addAll(parseCreateTableSQL(tableSQL));
+				tableNames.addAll(_moduleTableNames);
+
+				return tableNames;
 			}
-
-			_moduleTableNames = tableNames;
-
-			return _moduleTableNames;
 		}
+
+		return _buildModuleTableNames();
 	}
 
 	public static Map<String, String[]> getModuleTablesPrimaryKeyColumnNames(
@@ -187,17 +193,32 @@ public class DBResourceUtil {
 
 	public static Set<String> getPortalTableNames() {
 		if (_portalTableNames != null) {
-			return _portalTableNames;
+			Set<String> tableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			tableNames.addAll(_portalTableNames);
+
+			return tableNames;
 		}
 
 		synchronized (DBResourceUtil.class) {
 			if (_portalTableNames != null) {
-				return _portalTableNames;
+				Set<String> tableNames = new TreeSet<>(
+					String.CASE_INSENSITIVE_ORDER);
+
+				tableNames.addAll(_portalTableNames);
+
+				return tableNames;
 			}
 
 			_portalTableNames = parseCreateTableSQL(getPortalTablesSQL());
 
-			return _portalTableNames;
+			Set<String> tableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			tableNames.addAll(_portalTableNames);
+
+			return tableNames;
 		}
 	}
 
@@ -258,6 +279,48 @@ public class DBResourceUtil {
 
 		while (matcher.find()) {
 			tableNames.add(matcher.group(1));
+		}
+
+		return tableNames;
+	}
+
+	private static Set<String> _buildLiferayTableNames(Connection connection)
+		throws Exception {
+
+		Set<String> liferayTableNames = new TreeSet<>(
+			String.CASE_INSENSITIVE_ORDER);
+
+		liferayTableNames.addAll(getModuleTableNames());
+		liferayTableNames.addAll(getPortalTableNames());
+		liferayTableNames.addAll(
+			getServiceComponentModuleTableNames(connection));
+		liferayTableNames.addAll(
+			getServiceComponentPortalTableNames(connection));
+
+		return liferayTableNames;
+	}
+
+	private static Set<String> _buildModuleTableNames() {
+		Set<String> tableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			String symbolicName = bundle.getSymbolicName();
+
+			if (!symbolicName.startsWith("com.liferay") ||
+				!BundleUtil.isLiferayServiceBundle(bundle)) {
+
+				continue;
+			}
+
+			String tableSQL = getModuleTablesSQL(bundle);
+
+			if (tableSQL == null) {
+				continue;
+			}
+
+			tableNames.addAll(parseCreateTableSQL(tableSQL));
 		}
 
 		return tableNames;

--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -59,34 +59,26 @@ public class DBResourceUtil {
 		throws Exception {
 
 		if (DBInspector.isSchemaSnapshotEnabled()) {
-			if (_liferayTableNames != null) {
-				Set<String> tableNames = new TreeSet<>(
-					String.CASE_INSENSITIVE_ORDER);
+			Set<String> liferayTableNames = _liferayTableNames;
 
-				tableNames.addAll(_liferayTableNames);
+			if (liferayTableNames == null) {
+				synchronized (DBResourceUtil.class) {
+					liferayTableNames = _liferayTableNames;
 
-				return tableNames;
-			}
+					if (liferayTableNames == null) {
+						liferayTableNames = _buildLiferayTableNames(connection);
 
-			synchronized (DBResourceUtil.class) {
-				if (_liferayTableNames != null) {
-					Set<String> tableNames = new TreeSet<>(
-						String.CASE_INSENSITIVE_ORDER);
-
-					tableNames.addAll(_liferayTableNames);
-
-					return tableNames;
+						_liferayTableNames = liferayTableNames;
+					}
 				}
-
-				_liferayTableNames = _buildLiferayTableNames(connection);
-
-				Set<String> tableNames = new TreeSet<>(
-					String.CASE_INSENSITIVE_ORDER);
-
-				tableNames.addAll(_liferayTableNames);
-
-				return tableNames;
 			}
+
+			Set<String> tableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			tableNames.addAll(liferayTableNames);
+
+			return tableNames;
 		}
 
 		return _buildLiferayTableNames(connection);
@@ -102,34 +94,26 @@ public class DBResourceUtil {
 
 	public static Set<String> getModuleTableNames() {
 		if (DBInspector.isSchemaSnapshotEnabled()) {
-			if (_moduleTableNames != null) {
-				Set<String> tableNames = new TreeSet<>(
-					String.CASE_INSENSITIVE_ORDER);
+			Set<String> moduleTableNames = _moduleTableNames;
 
-				tableNames.addAll(_moduleTableNames);
+			if (moduleTableNames == null) {
+				synchronized (DBResourceUtil.class) {
+					moduleTableNames = _moduleTableNames;
 
-				return tableNames;
-			}
+					if (moduleTableNames == null) {
+						moduleTableNames = _buildModuleTableNames();
 
-			synchronized (DBResourceUtil.class) {
-				if (_moduleTableNames != null) {
-					Set<String> tableNames = new TreeSet<>(
-						String.CASE_INSENSITIVE_ORDER);
-
-					tableNames.addAll(_moduleTableNames);
-
-					return tableNames;
+						_moduleTableNames = moduleTableNames;
+					}
 				}
-
-				_moduleTableNames = _buildModuleTableNames();
-
-				Set<String> tableNames = new TreeSet<>(
-					String.CASE_INSENSITIVE_ORDER);
-
-				tableNames.addAll(_moduleTableNames);
-
-				return tableNames;
 			}
+
+			Set<String> tableNames = new TreeSet<>(
+				String.CASE_INSENSITIVE_ORDER);
+
+			tableNames.addAll(moduleTableNames);
+
+			return tableNames;
 		}
 
 		return _buildModuleTableNames();
@@ -192,34 +176,26 @@ public class DBResourceUtil {
 	}
 
 	public static Set<String> getPortalTableNames() {
-		if (_portalTableNames != null) {
-			Set<String> tableNames = new TreeSet<>(
-				String.CASE_INSENSITIVE_ORDER);
+		Set<String> portalTableNames = _portalTableNames;
 
-			tableNames.addAll(_portalTableNames);
+		if (portalTableNames == null) {
+			synchronized (DBResourceUtil.class) {
+				portalTableNames = _portalTableNames;
 
-			return tableNames;
-		}
+				if (portalTableNames == null) {
+					portalTableNames = parseCreateTableSQL(
+						getPortalTablesSQL());
 
-		synchronized (DBResourceUtil.class) {
-			if (_portalTableNames != null) {
-				Set<String> tableNames = new TreeSet<>(
-					String.CASE_INSENSITIVE_ORDER);
-
-				tableNames.addAll(_portalTableNames);
-
-				return tableNames;
+					_portalTableNames = portalTableNames;
+				}
 			}
-
-			_portalTableNames = parseCreateTableSQL(getPortalTablesSQL());
-
-			Set<String> tableNames = new TreeSet<>(
-				String.CASE_INSENSITIVE_ORDER);
-
-			tableNames.addAll(_portalTableNames);
-
-			return tableNames;
 		}
+
+		Set<String> tableNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+
+		tableNames.addAll(portalTableNames);
+
+		return tableNames;
 	}
 
 	public static Map<String, String[]> getPortalTablesPrimaryKeyColumnNames() {

--- a/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/DBResourceUtil.java
@@ -52,8 +52,6 @@ public class DBResourceUtil {
 	public static void disableCache() {
 		_cacheEnabled = false;
 
-		_liferayTableNames = null;
-
 		_moduleTableNamesDCLSingleton.destroy(null);
 	}
 
@@ -64,30 +62,17 @@ public class DBResourceUtil {
 	public static Set<String> getLiferayTableNames(Connection connection)
 		throws Exception {
 
-		if (_cacheEnabled) {
-			Set<String> liferayTableNames = _liferayTableNames;
+		Set<String> liferayTableNames = new TreeSet<>(
+			String.CASE_INSENSITIVE_ORDER);
 
-			if (liferayTableNames == null) {
-				synchronized (DBResourceUtil.class) {
-					liferayTableNames = _liferayTableNames;
+		liferayTableNames.addAll(getModuleTableNames());
+		liferayTableNames.addAll(getPortalTableNames());
+		liferayTableNames.addAll(
+			getServiceComponentModuleTableNames(connection));
+		liferayTableNames.addAll(
+			getServiceComponentPortalTableNames(connection));
 
-					if (liferayTableNames == null) {
-						liferayTableNames = _buildLiferayTableNames(connection);
-
-						_liferayTableNames = liferayTableNames;
-					}
-				}
-			}
-
-			Set<String> tableNames = new TreeSet<>(
-				String.CASE_INSENSITIVE_ORDER);
-
-			tableNames.addAll(liferayTableNames);
-
-			return tableNames;
-		}
-
-		return _buildLiferayTableNames(connection);
+		return liferayTableNames;
 	}
 
 	public static String getModuleIndexesSQL(Bundle bundle) {
@@ -239,22 +224,6 @@ public class DBResourceUtil {
 		}
 
 		return tableNames;
-	}
-
-	private static Set<String> _buildLiferayTableNames(Connection connection)
-		throws Exception {
-
-		Set<String> liferayTableNames = new TreeSet<>(
-			String.CASE_INSENSITIVE_ORDER);
-
-		liferayTableNames.addAll(getModuleTableNames());
-		liferayTableNames.addAll(getPortalTableNames());
-		liferayTableNames.addAll(
-			getServiceComponentModuleTableNames(connection));
-		liferayTableNames.addAll(
-			getServiceComponentPortalTableNames(connection));
-
-		return liferayTableNames;
 	}
 
 	private static Set<String> _buildModuleTableNames() {
@@ -441,7 +410,6 @@ public class DBResourceUtil {
 		"create table\\s+(\\w+)\\s*\\([^;]*?(\\w+)\\s+\\w+(?:\\([^)]*\\))?" +
 			"(?:\\s+\\w+)*\\s+primary key\\b",
 		Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
-	private static volatile Set<String> _liferayTableNames;
 	private static final DCLSingleton<Set<String>>
 		_moduleTableNamesDCLSingleton = new DCLSingleton<>();
 	private static final DCLSingleton<Set<String>>

--- a/portal-kernel/src/com/liferay/portal/kernel/db/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
@@ -57,6 +57,57 @@ public class DBInspectorUnitTest {
 	}
 
 	@Test
+	public void testBeginSchemaSnapshot() throws Exception {
+		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.when(
+			_connection.getCatalog()
+		).thenReturn(
+			_CATALOG_NAME
+		);
+
+		DBInspector dbInspector = new DBInspector(_connection);
+
+		DBInspector.beginSchemaSnapshot();
+
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(1)
+		).getColumns(
+			Mockito.nullable(String.class), Mockito.nullable(String.class),
+			Mockito.anyString(), Mockito.anyString()
+		);
+	}
+
+	@Test
+	public void testClearSchemaSnapshot() throws Exception {
+		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.when(
+			_connection.getCatalog()
+		).thenReturn(
+			_CATALOG_NAME
+		);
+
+		DBInspector dbInspector = new DBInspector(_connection);
+
+		DBInspector.beginSchemaSnapshot();
+		DBInspector.clearSchemaSnapshot();
+
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(2)
+		).getColumns(
+			Mockito.nullable(String.class), Mockito.nullable(String.class),
+			Mockito.anyString(), Mockito.anyString()
+		);
+	}
+
+	@Test
 	public void testHasColumnIsCaseInsensitive() throws Exception {
 		_mockTableWithColumn(_TABLE_NAME, StringUtil.toLowerCase(_COLUMN_NAME));
 
@@ -156,7 +207,7 @@ public class DBInspectorUnitTest {
 	}
 
 	@Test
-	public void testHasTableUsesSnapshotCache() throws Exception {
+	public void testHasTable() throws Exception {
 		Mockito.when(
 			_connection.getCatalog()
 		).thenReturn(
@@ -247,57 +298,6 @@ public class DBInspectorUnitTest {
 		Assert.assertTrue(
 			dbInspector.isObjectTable(companyIds, "l_1_tableName"));
 		Assert.assertTrue(dbInspector.isObjectTable(companyIds, "r_tableName"));
-	}
-
-	@Test
-	public void testSchemaSnapshotBeginEnablesCache() throws Exception {
-		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
-
-		Mockito.when(
-			_connection.getCatalog()
-		).thenReturn(
-			_CATALOG_NAME
-		);
-
-		DBInspector dbInspector = new DBInspector(_connection);
-
-		DBInspector.beginSchemaSnapshot();
-
-		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
-		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
-
-		Mockito.verify(
-			_databaseMetaData, Mockito.times(1)
-		).getColumns(
-			Mockito.nullable(String.class), Mockito.nullable(String.class),
-			Mockito.anyString(), Mockito.anyString()
-		);
-	}
-
-	@Test
-	public void testSchemaSnapshotClearDisablesCache() throws Exception {
-		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
-
-		Mockito.when(
-			_connection.getCatalog()
-		).thenReturn(
-			_CATALOG_NAME
-		);
-
-		DBInspector dbInspector = new DBInspector(_connection);
-
-		DBInspector.beginSchemaSnapshot();
-		DBInspector.clearSchemaSnapshot();
-
-		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
-		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
-
-		Mockito.verify(
-			_databaseMetaData, Mockito.times(2)
-		).getColumns(
-			Mockito.nullable(String.class), Mockito.nullable(String.class),
-			Mockito.anyString(), Mockito.anyString()
-		);
 	}
 
 	private void _mockTableWithColumn(String tableName, String columnName)

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
@@ -15,6 +15,7 @@ import java.sql.ResultSet;
 
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,6 +26,11 @@ import org.mockito.Mockito;
  * @author Mariano Álvaro Sáiz
  */
 public class DBInspectorUnitTest {
+
+	@After
+	public void tearDown() {
+		DBInspector.clearSchemaSnapshot();
+	}
 
 	@Test
 	public void testArgumentMetaDataIsUsedToNormalizeName() throws Exception {
@@ -150,6 +156,64 @@ public class DBInspectorUnitTest {
 	}
 
 	@Test
+	public void testHasTableUsesSnapshotCache() throws Exception {
+		Mockito.when(
+			_connection.getCatalog()
+		).thenReturn(
+			_CATALOG_NAME
+		);
+
+		Mockito.when(
+			_connection.getMetaData()
+		).thenReturn(
+			_databaseMetaData
+		);
+
+		Mockito.when(
+			_databaseMetaData.storesLowerCaseIdentifiers()
+		).thenReturn(
+			true
+		);
+
+		ResultSet tablesResultSet = Mockito.mock(ResultSet.class);
+
+		Mockito.when(
+			tablesResultSet.next()
+		).thenReturn(
+			true, false
+		);
+
+		Mockito.when(
+			tablesResultSet.getString("TABLE_NAME")
+		).thenReturn(
+			_TABLE_NAME
+		);
+
+		Mockito.when(
+			_databaseMetaData.getTables(
+				Mockito.eq(_CATALOG_NAME), Mockito.nullable(String.class),
+				Mockito.isNull(), Mockito.any(String[].class))
+		).thenReturn(
+			tablesResultSet
+		);
+
+		DBInspector dbInspector = new DBInspector(_connection);
+
+		DBInspector.beginSchemaSnapshot();
+
+		dbInspector.getTableNames(null);
+
+		dbInspector.hasTable(_TABLE_NAME);
+		dbInspector.hasTable(_TABLE_NAME);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(1)
+		).getTables(
+			Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
 	public void testIsObjectTable() {
 		DBInspector dbInspector = new DBInspector(_connection);
 
@@ -183,6 +247,57 @@ public class DBInspectorUnitTest {
 		Assert.assertTrue(
 			dbInspector.isObjectTable(companyIds, "l_1_tableName"));
 		Assert.assertTrue(dbInspector.isObjectTable(companyIds, "r_tableName"));
+	}
+
+	@Test
+	public void testSchemaSnapshotBeginEnablesCache() throws Exception {
+		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.when(
+			_connection.getCatalog()
+		).thenReturn(
+			_CATALOG_NAME
+		);
+
+		DBInspector dbInspector = new DBInspector(_connection);
+
+		DBInspector.beginSchemaSnapshot();
+
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(1)
+		).getColumns(
+			Mockito.nullable(String.class), Mockito.nullable(String.class),
+			Mockito.anyString(), Mockito.anyString()
+		);
+	}
+
+	@Test
+	public void testSchemaSnapshotClearDisablesCache() throws Exception {
+		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.when(
+			_connection.getCatalog()
+		).thenReturn(
+			_CATALOG_NAME
+		);
+
+		DBInspector dbInspector = new DBInspector(_connection);
+
+		DBInspector.beginSchemaSnapshot();
+		DBInspector.clearSchemaSnapshot();
+
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(2)
+		).getColumns(
+			Mockito.nullable(String.class), Mockito.nullable(String.class),
+			Mockito.anyString(), Mockito.anyString()
+		);
 	}
 
 	private void _mockTableWithColumn(String tableName, String columnName)
@@ -240,6 +355,8 @@ public class DBInspectorUnitTest {
 
 		_mockTableWithOrWithoutColumn(tableName, columnName, false);
 	}
+
+	private static final String _CATALOG_NAME = "test_catalog";
 
 	private static final String _COLUMN_NAME = "column_name";
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/DBInspectorUnitTest.java
@@ -29,7 +29,7 @@ public class DBInspectorUnitTest {
 
 	@After
 	public void tearDown() {
-		DBInspector.clearSchemaSnapshot();
+		DBInspector.disableCache();
 	}
 
 	@Test
@@ -57,8 +57,8 @@ public class DBInspectorUnitTest {
 	}
 
 	@Test
-	public void testBeginSchemaSnapshot() throws Exception {
-		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
+	public void testDisableCache() throws Exception {
+		_mockTable(_TABLE_NAME, _COLUMN_NAME, true);
 
 		Mockito.when(
 			_connection.getCatalog()
@@ -68,33 +68,9 @@ public class DBInspectorUnitTest {
 
 		DBInspector dbInspector = new DBInspector(_connection);
 
-		DBInspector.beginSchemaSnapshot();
+		DBInspector.enableCache();
 
-		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
-		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
-
-		Mockito.verify(
-			_databaseMetaData, Mockito.times(1)
-		).getColumns(
-			Mockito.nullable(String.class), Mockito.nullable(String.class),
-			Mockito.anyString(), Mockito.anyString()
-		);
-	}
-
-	@Test
-	public void testClearSchemaSnapshot() throws Exception {
-		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
-
-		Mockito.when(
-			_connection.getCatalog()
-		).thenReturn(
-			_CATALOG_NAME
-		);
-
-		DBInspector dbInspector = new DBInspector(_connection);
-
-		DBInspector.beginSchemaSnapshot();
-		DBInspector.clearSchemaSnapshot();
+		DBInspector.disableCache();
 
 		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
 		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
@@ -108,8 +84,33 @@ public class DBInspectorUnitTest {
 	}
 
 	@Test
+	public void testEnableCache() throws Exception {
+		_mockTable(_TABLE_NAME, _COLUMN_NAME, true);
+
+		Mockito.when(
+			_connection.getCatalog()
+		).thenReturn(
+			_CATALOG_NAME
+		);
+
+		DBInspector dbInspector = new DBInspector(_connection);
+
+		DBInspector.enableCache();
+
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+		dbInspector.hasColumn(_TABLE_NAME, _COLUMN_NAME);
+
+		Mockito.verify(
+			_databaseMetaData, Mockito.times(1)
+		).getColumns(
+			Mockito.nullable(String.class), Mockito.nullable(String.class),
+			Mockito.anyString(), Mockito.anyString()
+		);
+	}
+
+	@Test
 	public void testHasColumnIsCaseInsensitive() throws Exception {
-		_mockTableWithColumn(_TABLE_NAME, StringUtil.toLowerCase(_COLUMN_NAME));
+		_mockTable(_TABLE_NAME, StringUtil.toLowerCase(_COLUMN_NAME), true);
 
 		DBInspector dbInspector = new DBInspector(_connection);
 
@@ -122,7 +123,7 @@ public class DBInspectorUnitTest {
 	public void testHasColumnReturnsFalseWithoutExistingColumn()
 		throws Exception {
 
-		_mockTableWithoutColumn(_TABLE_NAME, _COLUMN_NAME);
+		_mockTable(_TABLE_NAME, _COLUMN_NAME, false);
 
 		DBInspector dbInspector = new DBInspector(_connection);
 
@@ -131,7 +132,7 @@ public class DBInspectorUnitTest {
 
 	@Test
 	public void testHasColumnReturnsTrueWithExistingColumn() throws Exception {
-		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
+		_mockTable(_TABLE_NAME, _COLUMN_NAME, true);
 
 		DBInspector dbInspector = new DBInspector(_connection);
 
@@ -140,7 +141,7 @@ public class DBInspectorUnitTest {
 
 	@Test
 	public void testHasColumnSkipsQueryWithExistingColumn() throws Exception {
-		_mockTableWithColumn(_TABLE_NAME, _COLUMN_NAME);
+		_mockTable(_TABLE_NAME, _COLUMN_NAME, true);
 
 		DBInspector dbInspector = new DBInspector(_connection);
 
@@ -153,8 +154,6 @@ public class DBInspectorUnitTest {
 
 	@Test
 	public void testHasIndexIsCaseInsensitive() throws Exception {
-		String indexName = "IX_40A51197";
-
 		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
 				Mockito.mockStatic(DBManagerUtil.class)) {
 
@@ -191,6 +190,8 @@ public class DBInspectorUnitTest {
 			).thenReturn(
 				true, false
 			);
+
+			String indexName = "IX_40A51197";
 
 			Mockito.when(
 				_resultSet.getString("index_name")
@@ -250,7 +251,7 @@ public class DBInspectorUnitTest {
 
 		DBInspector dbInspector = new DBInspector(_connection);
 
-		DBInspector.beginSchemaSnapshot();
+		DBInspector.enableCache();
 
 		dbInspector.getTableNames(null);
 
@@ -266,8 +267,6 @@ public class DBInspectorUnitTest {
 
 	@Test
 	public void testIsObjectTable() {
-		DBInspector dbInspector = new DBInspector(_connection);
-
 		try (MockedStatic<PortalInstancePool> portalInstancePoolMockedStatic =
 				Mockito.mockStatic(PortalInstancePool.class)) {
 
@@ -276,6 +275,8 @@ public class DBInspectorUnitTest {
 			).thenReturn(
 				new long[] {1L}
 			);
+
+			DBInspector dbInspector = new DBInspector(_connection);
 
 			Assert.assertTrue(dbInspector.isObjectTable("L_1_tableName"));
 			Assert.assertTrue(dbInspector.isObjectTable("l_1_tableName"));
@@ -300,13 +301,7 @@ public class DBInspectorUnitTest {
 		Assert.assertTrue(dbInspector.isObjectTable(companyIds, "r_tableName"));
 	}
 
-	private void _mockTableWithColumn(String tableName, String columnName)
-		throws Exception {
-
-		_mockTableWithOrWithoutColumn(tableName, columnName, true);
-	}
-
-	private void _mockTableWithOrWithoutColumn(
+	private void _mockTable(
 			String tableName, String columnName, boolean hasColumn)
 		throws Exception {
 
@@ -348,12 +343,6 @@ public class DBInspectorUnitTest {
 		).thenReturn(
 			hasColumn
 		);
-	}
-
-	private void _mockTableWithoutColumn(String tableName, String columnName)
-		throws Exception {
-
-		_mockTableWithOrWithoutColumn(tableName, columnName, false);
 	}
 
 	private static final String _CATALOG_NAME = "test_catalog";


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93236

## What Is Being Fixed

During the data cleanup pre-upgrade phase, `DBInspector.hasTable()`, `hasColumn()`, `isNumeric()`, and `getTableNames()` each issue a live `INFORMATION_SCHEMA` query per call. On schemas with 600+ tables this produces roughly 14,400 redundant metadata round-trips per cleanup run, adding significant time to the pre-upgrade phase.

## How It Is Being Fixed

`DBInspector` gains an opt-in cache lifecycle — `enableCache()` / `disableCache()` — mirroring the toggle `PortalInstancePool` already exposes. While enabled, table names (a case-insensitive set) and per-column data types are cached, so `hasTable`, `hasColumn`, and `isNumeric` resolve from one snapshot instead of querying the dictionary repeatedly. The absent-column sentinel is named `_COLUMN_TYPE_NONE`, mirroring the existing `DB.SQL_SIZE_NONE` idiom. Cache keys include the catalog and schema so they stay correct under database partitioning.

`DataCleanupPreupgradeProcessUtil` owns the lifecycle for the cleanup run: it enables the cache once before the cleanup loop and, in a `finally`, disables it — clearing its own primary-key and table-name caches along with the `DBInspector` and `DBResourceUtil` caches through a single coordinated call. `DBResourceUtil` follows the same `enableCache`/`disableCache` pattern with its own flag.

The `packageinfo` version bumps for the changed kernel packages are isolated in a separate semantic-versioning commit.

Unit tests cover the cache enable/disable behavior and cache-hit/miss counts; integration coverage exercises the cleanup suite.

## PR Check

**pr-check: PASS** — tested on `ee2143514a8b60bca208771c46b065f346b91c18`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Java Unit Tests | PASS |

Full Portal Build and Cross-Module Compile passed on #3672 (`7ed62c5`); the only change since is the private `_NO_COLUMN` → `_COLUMN_TYPE_NONE` rename (behavior- and build-inert), re-validated here via Source Format + Java Unit Tests.

<!-- pr-check {"result": "success", "sha": "ee2143514a8b60bca208771c46b065f346b91c18"} -->
