### PR TITLE
LPD-92495 Avoid switching CompanyThreadLocal from a secondary partition

### DIFF
--- a/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
+++ b/modules/apps/feature-flag/feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl.java
@@ -14,7 +14,6 @@ import com.liferay.osgi.service.tracker.collections.EagerServiceTrackerCustomize
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.function.UnsafeConsumer;
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -30,7 +29,6 @@ import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiService;
 import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiServiceUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -38,6 +36,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
@@ -135,6 +134,17 @@ public class FeatureFlagsBagProviderImpl
 
 		_initSystemFeatureFlags(false);
 
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			FeatureFlagsBag featureFlagsBag = getOrCreateFeatureFlagsBag(
+				CompanyConstants.SYSTEM);
+
+			for (FeatureFlag featureFlag :
+					featureFlagsBag.getFeatureFlags(null)) {
+
+				featureFlag.isEnabled();
+			}
+		}
+
 		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
 			bundleContext, FeatureFlagListener.class, null,
 			(serviceReference, emitter) -> {
@@ -191,19 +201,7 @@ public class FeatureFlagsBagProviderImpl
 			}
 		}
 
-		if (companyId == CompanyThreadLocal.getCompanyId()) {
-			_populateFeatureFlagsMap(
-				companyId, featureFlags, systemFeatureFlags);
-		}
-		else {
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						companyId)) {
-
-				_populateFeatureFlagsMap(
-					companyId, featureFlags, systemFeatureFlags);
-			}
-		}
+		_populateFeatureFlagsMap(companyId, featureFlags, systemFeatureFlags);
 
 		return new FeatureFlagsBag(
 			companyId, Collections.unmodifiableMap(featureFlags));

--- a/modules/apps/feature-flag/source-formatter-suppressions.xml
+++ b/modules/apps/feature-flag/source-formatter-suppressions.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0"?>
-
-<suppressions>
-	<source-check>
-		<suppress checks="JavaCompanyThreadLocalCheck" files="feature-flag-web/src/main/java/com/liferay/feature/flag/web/internal/feature/flag/FeatureFlagsBagProviderImpl\.java" />
-	</source-check>
-</suppressions>

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -556,15 +556,14 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
-	public void testIncrementSystemCounter() throws Exception {
-		long count = DBPartitionUtil.incrementSystemCounter();
+	public void testIncrementCounter() throws Exception {
+		long count = DBPartitionUtil.incrementCounter();
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					COMPANY_IDS[0])) {
 
-			Assert.assertEquals(
-				count + 1, DBPartitionUtil.incrementSystemCounter());
+			Assert.assertEquals(count + 1, DBPartitionUtil.incrementCounter());
 
 			Assert.assertEquals(
 				Long.valueOf(COMPANY_IDS[0]),

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest.java
@@ -556,6 +556,23 @@ public class DBPartitionUtilTest extends BaseDBPartitionTestCase {
 	}
 
 	@Test
+	public void testIncrementSystemCounter() throws Exception {
+		long count = DBPartitionUtil.incrementSystemCounter();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					COMPANY_IDS[0])) {
+
+			Assert.assertEquals(
+				count + 1, DBPartitionUtil.incrementSystemCounter());
+
+			Assert.assertEquals(
+				Long.valueOf(COMPANY_IDS[0]),
+				CompanyThreadLocal.getCompanyId());
+		}
+	}
+
+	@Test
 	@TestInfo("LPS-137423")
 	public void testRemoveDBPartition() throws Exception {
 		addDBPartitions();

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.db.partition.util;
 
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
@@ -324,6 +325,19 @@ public class DBPartitionUtil {
 		}
 
 		return true;
+	}
+
+	public static long incrementSystemCounter() {
+		if (!PropsValues.DATABASE_PARTITION_ENABLED) {
+			return CounterLocalServiceUtil.increment();
+		}
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					CompanyConstants.SYSTEM)) {
+
+			return CounterLocalServiceUtil.increment();
+		}
 	}
 
 	public static boolean removeDBPartition(long companyId)

--- a/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
+++ b/portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil.java
@@ -327,7 +327,7 @@ public class DBPartitionUtil {
 		return true;
 	}
 
-	public static long incrementSystemCounter() {
+	public static long incrementCounter() {
 		if (!PropsValues.DATABASE_PARTITION_ENABLED) {
 			return CounterLocalServiceUtil.increment();
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
 import com.liferay.portal.kernel.exception.AvailableLocaleException;
@@ -18,7 +19,6 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.VirtualHost;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.persistence.CompanyPersistence;
 import com.liferay.portal.kernel.service.persistence.GroupPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutSetPersistence;
@@ -208,8 +208,7 @@ public class VirtualHostLocalServiceImpl
 			}
 
 			if (virtualHost == null) {
-				long virtualHostId =
-					CompanyThreadLocal.incrementSystemCounter();
+				long virtualHostId = DBPartitionUtil.incrementSystemCounter();
 
 				virtualHost = virtualHostPersistence.create(virtualHostId);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -208,7 +208,7 @@ public class VirtualHostLocalServiceImpl
 			}
 
 			if (virtualHost == null) {
-				long virtualHostId = DBPartitionUtil.incrementSystemCounter();
+				long virtualHostId = DBPartitionUtil.incrementCounter();
 
 				virtualHost = virtualHostPersistence.create(virtualHostId);
 

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.service.impl;
 
-import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.dao.orm.EntityCacheUtil;
@@ -16,7 +15,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.VirtualHost;
@@ -210,14 +208,8 @@ public class VirtualHostLocalServiceImpl
 			}
 
 			if (virtualHost == null) {
-				long virtualHostId = 0;
-
-				try (SafeCloseable safeCloseable =
-						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							CompanyConstants.SYSTEM)) {
-
-					virtualHostId = counterLocalService.increment();
-				}
+				long virtualHostId =
+					CompanyThreadLocal.incrementSystemCounter();
 
 				virtualHost = virtualHostPersistence.create(virtualHostId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.kernel.security.auth;
 
-import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
@@ -105,19 +104,6 @@ public class CompanyThreadLocal {
 		}
 
 		return companyId;
-	}
-
-	public static long incrementSystemCounter() {
-		long originalCompanyId = getCompanyId();
-
-		_companyId.set(CompanyConstants.SYSTEM);
-
-		try {
-			return CounterLocalServiceUtil.increment();
-		}
-		finally {
-			_companyId.set(originalCompanyId);
-		}
 	}
 
 	public static boolean isInitializingPortalInstance() {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.security.auth;
 
+import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
@@ -104,6 +105,19 @@ public class CompanyThreadLocal {
 		}
 
 		return companyId;
+	}
+
+	public static long incrementSystemCounter() {
+		long originalCompanyId = getCompanyId();
+
+		_companyId.set(CompanyConstants.SYSTEM);
+
+		try {
+			return CounterLocalServiceUtil.increment();
+		}
+		finally {
+			_companyId.set(originalCompanyId);
+		}
 	}
 
 	public static boolean isInitializingPortalInstance() {

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -87,7 +87,6 @@
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/internal/increment/BufferedIncreasableEntry\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/security/permission/PermissionCacheUtil\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
-		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/servlet/filters/portal/instances/PortalInstancesFilter\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-impl/src/com/liferay/portal/util/PortalInstances\.java" />
 		<suppress checks="JavaCompanyThreadLocalCheck" files="portal-kernel/src/com/liferay/portal/kernel/cache/transactional/TransactionalPortalCacheUtil\.java" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92495

## What Is Being Fixed

LPD-51068 forbids calling `CompanyThreadLocal.setCompanyIdWithSafeCloseable` from a secondary partition when database partitioning is enabled. Two sites still did it for a legitimate reason — accessing default-partition data from a secondary-partition thread — and were suppressed by the SF rule from LPD-81801: `VirtualHostLocalServiceImpl` needs a globally unique ID from the shared `Counter_` table during a secondary-partition write, and `FeatureFlagsBagProviderImpl` read the SYSTEM-scoped feature flags (the `companyId = 0` rows) when building any company's flag bag.

## How It Is Being Fixed

For the virtual host counter, the increment is moved behind a new `DBPartitionUtil.incrementCounter()` helper. Routing the increment to the default partition's shared `Counter_` table is a database partitioning concern, so the helper lives on `DBPartitionUtil` — which is already a sanctioned `JavaCompanyThreadLocalCheck` exception and already uses `setCompanyIdWithSafeCloseable` as its idiom. It switches to the SYSTEM context only when partitioning is enabled and otherwise increments directly, so `CompanyThreadLocal` gains no dependency on the counter service and no new public kernel API.

For the feature flags, the `setCompanyIdWithSafeCloseable(SYSTEM)` switch is removed from `_createFeatureFlagsBag`, and the SYSTEM feature flags are instead loaded once at `activate()` in the default-partition context, gated on `DATABASE_PARTITION_ENABLED`. `PreferenceAwareFeatureFlag` caches its enabled state on first read, so warming the SYSTEM bag in the default context means later reads from any partition return the cached value with no switch. The pre-warm runs before the eager `FeatureFlagListener` tracker opens. Both SF suppressions are removed now that neither class switches `CompanyThreadLocal` from a secondary partition.

## PR Check

**pr-check: PASS** — tested on `26f2159310d36483cac2ab68b30bfedb938657a8`

| Validation | Result |
| --- | --- |
| Service Builder | SKIPPED (body-only change, cannot drift) |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS (covered by Full Portal Build) |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS (covered by Full Portal Build) |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "26f2159310d36483cac2ab68b30bfedb938657a8"} -->
