### PR TITLE
LPD-95477 Honor case-sensitive column identifiers in upgrade SQL

### DIFF
--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v2_2_1/AssetDisplayLayoutFriendlyURLPrivateLayoutUpgradeProcess.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v2_2_1/AssetDisplayLayoutFriendlyURLPrivateLayoutUpgradeProcess.java
@@ -69,7 +69,7 @@ public class AssetDisplayLayoutFriendlyURLPrivateLayoutUpgradeProcess
 					"LayoutFriendlyURL.privateLayout = ?"));
 			PreparedStatement preparedStatement2 = connection.prepareStatement(
 				StringBundler.concat(
-					"select LayoutFriendlyURL.layoutFriendlyURLid from ",
+					"select LayoutFriendlyURL.layoutFriendlyURLId from ",
 					"LayoutFriendlyURL where LayoutFriendlyURL.groupId = ? ",
 					"and LayoutFriendlyURL.privateLayout = ? and ",
 					"LayoutFriendlyURL.friendlyURL = ? and ",

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v1_11_0/CPAttachmentFileEntryGroupUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v1_11_0/CPAttachmentFileEntryGroupUpgradeProcess.java
@@ -102,7 +102,7 @@ public class CPAttachmentFileEntryGroupUpgradeProcess extends UpgradeProcess {
 		try (Statement s = connection.createStatement();
 
 			ResultSet resultSet = s.executeQuery(
-				"select groupId from CPDefinition where cpDefinitionId = " +
+				"select groupId from CPDefinition where CPDefinitionId = " +
 					cpDefinitionId)) {
 
 			if (resultSet.next()) {

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v1_3_0/CProductUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v1_3_0/CProductUpgradeProcess.java
@@ -46,7 +46,7 @@ public class CProductUpgradeProcess extends UpgradeProcess {
 				ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 
 			ResultSet resultSet = s.executeQuery(
-				"select cpDefinitionId, groupId, companyId, userId, userName " +
+				"select CPDefinitionId, groupId, companyId, userId, userName " +
 					"from CPDefinition")) {
 
 			while (resultSet.next()) {

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v1_6_0/CommerceCatalogUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/upgrade/v1_6_0/CommerceCatalogUpgradeProcess.java
@@ -149,7 +149,7 @@ public class CommerceCatalogUpgradeProcess extends UpgradeProcess {
 					ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
 
 				ResultSet cpDefinitionsResultSet = s2.executeQuery(
-					"select distinct cpDefinitionId from CPDefinition where " +
+					"select distinct CPDefinitionId from CPDefinition where " +
 						"groupId = " + catalogGroup.getGroupId());
 
 				while (cpDefinitionsResultSet.next()) {

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v5_22_0/test/CPSpecificationOptionUpgradeProcessTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v5_22_0/test/CPSpecificationOptionUpgradeProcessTest.java
@@ -90,7 +90,7 @@ public class CPSpecificationOptionUpgradeProcessTest {
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
 				"select count(*) as count from CPSOListTypeDefinitionRel " +
-					"where cpSpecificationOptionId = ?")) {
+					"where CPSpecificationOptionId = ?")) {
 
 			preparedStatement.setLong(1, cpSpecificationOptionId);
 

--- a/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v6_2_0/test/CPDefinitionLocalizationUpgradeProcessTest.java
+++ b/modules/apps/commerce/commerce-product-test/src/testIntegration/java/com/liferay/commerce/product/internal/upgrade/v6_2_0/test/CPDefinitionLocalizationUpgradeProcessTest.java
@@ -76,8 +76,8 @@ public class CPDefinitionLocalizationUpgradeProcessTest {
 			PreparedStatement preparedStatement =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,
-					"update CPDefinitionLocalization set cProductId = null " +
-						"where cpDefinitionId = ?")) {
+					"update CPDefinitionLocalization set CProductId = null " +
+						"where CPDefinitionId = ?")) {
 
 			preparedStatement.setLong(1, cpDefinition.getCPDefinitionId());
 			preparedStatement.executeUpdate();
@@ -88,8 +88,8 @@ public class CPDefinitionLocalizationUpgradeProcessTest {
 		try (Connection connection = DataAccess.getConnection();
 
 			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select cProductId from CPDefinitionLocalization where " +
-					"cpDefinitionId = ?")) {
+				"select CProductId from CPDefinitionLocalization where " +
+					"CPDefinitionId = ?")) {
 
 			preparedStatement.setLong(1, cpDefinition.getCPDefinitionId());
 

--- a/modules/apps/commerce/commerce-product-type-virtual-service/src/main/java/com/liferay/commerce/product/type/virtual/internal/upgrade/v3_0_0/CPDefinitionVirtualSettingUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-service/src/main/java/com/liferay/commerce/product/type/virtual/internal/upgrade/v3_0_0/CPDefinitionVirtualSettingUpgradeProcess.java
@@ -23,7 +23,7 @@ public class CPDefinitionVirtualSettingUpgradeProcess extends UpgradeProcess {
 				"= ?";
 
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select groupId, cpDefinitionId from CPDefinition");
+				"select groupId, CPDefinitionId from CPDefinition");
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection, updateCPDefinitionVirtualSettingGroupId);
@@ -41,7 +41,7 @@ public class CPDefinitionVirtualSettingUpgradeProcess extends UpgradeProcess {
 		}
 
 		try (PreparedStatement preparedStatement3 = connection.prepareStatement(
-				"select groupId, cpInstanceId from CPInstance");
+				"select groupId, CPInstanceId from CPInstance");
 			PreparedStatement preparedStatement4 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection, updateCPDefinitionVirtualSettingGroupId);

--- a/modules/apps/commerce/commerce-product-type-virtual-service/src/main/java/com/liferay/commerce/product/type/virtual/internal/upgrade/v3_0_1/CPDefinitionVirtualSettingUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-product-type-virtual-service/src/main/java/com/liferay/commerce/product/type/virtual/internal/upgrade/v3_0_1/CPDefinitionVirtualSettingUpgradeProcess.java
@@ -23,7 +23,7 @@ public class CPDefinitionVirtualSettingUpgradeProcess extends UpgradeProcess {
 				"= ?";
 
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select groupId, cpDefinitionId from CPDefinition");
+				"select groupId, CPDefinitionId from CPDefinition");
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection, updateCPDefinitionVirtualSettingGroupId);
@@ -41,7 +41,7 @@ public class CPDefinitionVirtualSettingUpgradeProcess extends UpgradeProcess {
 		}
 
 		try (PreparedStatement preparedStatement3 = connection.prepareStatement(
-				"select groupId, cpInstanceId from CPInstance");
+				"select groupId, CPInstanceId from CPInstance");
 			PreparedStatement preparedStatement4 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection, updateCPDefinitionVirtualSettingGroupId);

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceSubscriptionEntryUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v2_1_0/CommerceSubscriptionEntryUpgradeProcess.java
@@ -46,7 +46,7 @@ public class CommerceSubscriptionEntryUpgradeProcess extends UpgradeProcess {
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"update CommerceSubscriptionEntry set CProductId = ?," +
-					"CPInstanceUUID = ? where CPInstanceId = ?");
+					"CPInstanceUuid = ? where CPInstanceId = ?");
 
 			Statement s = connection.createStatement();
 
@@ -86,7 +86,7 @@ public class CommerceSubscriptionEntryUpgradeProcess extends UpgradeProcess {
 	protected UpgradeStep[] getPreUpgradeSteps() {
 		return new UpgradeStep[] {
 			UpgradeProcessFactory.addColumns(
-				"CommerceSubscriptionEntry", "CPInstanceUUID VARCHAR(75)",
+				"CommerceSubscriptionEntry", "CPInstanceUuid VARCHAR(75)",
 				"CProductId LONG")
 		};
 	}

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v5_0_1/CommercePermissionUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v5_0_1/CommercePermissionUpgradeProcess.java
@@ -49,7 +49,7 @@ public class CommercePermissionUpgradeProcess extends UpgradeProcess {
 
 			ResultSet resultSet = statement.executeQuery(
 				StringBundler.concat(
-					"select ResourcePermissionId from ResourcePermission ",
+					"select resourcePermissionId from ResourcePermission ",
 					"where name in ('90', '", _PORTLET_NAME_COMMERCE_DISCOUNT,
 					"', '", _PORTLET_NAME_COMMERCE_PRICE_LIST, "')"))) {
 

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v8_8_0/CommercePermissionUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v8_8_0/CommercePermissionUpgradeProcess.java
@@ -36,7 +36,7 @@ public class CommercePermissionUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		try (Statement statement = connection.createStatement()) {
 			ResultSet resultSet = statement.executeQuery(
-				"select ResourcePermissionId from ResourcePermission where " +
+				"select resourcePermissionId from ResourcePermission where " +
 					"name = 'com.liferay.commerce.account' and scope = 1");
 
 			while (resultSet.next()) {

--- a/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v9_1_0/CommercePermissionUpgradeProcess.java
+++ b/modules/apps/commerce/commerce-service/src/main/java/com/liferay/commerce/internal/upgrade/v9_1_0/CommercePermissionUpgradeProcess.java
@@ -35,7 +35,7 @@ public class CommercePermissionUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		try (Statement statement = connection.createStatement()) {
 			ResultSet resultSet = statement.executeQuery(
-				"select ResourcePermissionId from ResourcePermission where " +
+				"select resourcePermissionId from ResourcePermission where " +
 					"name = 'com.liferay.commerce.account' and scope = 1");
 
 			while (resultSet.next()) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_2/DDMStructureUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_10_2/DDMStructureUpgradeProcess.java
@@ -369,8 +369,8 @@ public class DDMStructureUpgradeProcess extends UpgradeProcess {
 						"select DDMStructure.structureId, ",
 						"DDMStructureVersion.definition from DDMStructure ",
 						"inner join DDMStructureVersion on ",
-						"DDMStructure.structureid = ",
-						"DDMStructureVersion.structureid where ",
+						"DDMStructure.structureId = ",
+						"DDMStructureVersion.structureId where ",
 						"DDMStructure.version = DDMStructureVersion.version ",
 						"and DDMStructure.classNameId = ?"));
 			PreparedStatement updatePreparedStatement =

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_8_0/DDMStructureUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v3_8_0/DDMStructureUpgradeProcess.java
@@ -108,8 +108,8 @@ public class DDMStructureUpgradeProcess extends UpgradeProcess {
 
 		sb.append("select DDMStructure.structureId, ");
 		sb.append("DDMStructureVersion.definition from DDMStructure inner ");
-		sb.append("join DDMStructureVersion on DDMStructure.structureid = ");
-		sb.append("DDMStructureVersion.structureid where ");
+		sb.append("join DDMStructureVersion on DDMStructure.structureId = ");
+		sb.append("DDMStructureVersion.structureId where ");
 		sb.append("DDMStructure.version = DDMStructureVersion.version and ");
 		sb.append("DDMStructure.classNameId = ? and DDMStructure.structureId ");
 		sb.append("in (");

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_4_4/DDMStructureUpgradeProcess.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/upgrade/v5_4_4/DDMStructureUpgradeProcess.java
@@ -59,8 +59,8 @@ public class DDMStructureUpgradeProcess extends UpgradeProcess {
 						"inner join DDMStructureVersion on ",
 						"DDMStructure.ctCollectionId = ",
 						"DDMStructureVersion.ctCollectionId and ",
-						"DDMStructure.structureid = ",
-						"DDMStructureVersion.structureid where ",
+						"DDMStructure.structureId = ",
+						"DDMStructureVersion.structureId where ",
 						"DDMStructure.version = DDMStructureVersion.version ",
 						"and DDMStructure.classNameId = ?"));
 			PreparedStatement updatePreparedStatement =

--- a/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/upgrade/v3_0_0/LayoutSEOEntryCustomMetaTagUpgradeProcess.java
+++ b/modules/apps/layout/layout-seo-service/src/main/java/com/liferay/layout/seo/internal/upgrade/v3_0_0/LayoutSEOEntryCustomMetaTagUpgradeProcess.java
@@ -60,8 +60,8 @@ public class LayoutSEOEntryCustomMetaTagUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
 				"select ctCollectionId, layoutSEOEntryId, groupId, " +
-					"companyId, ddmStorageId from LayoutSEOEntry where " +
-						"ddmStorageId > 0 order by ddmStorageId");
+					"companyId, DDMStorageId from LayoutSEOEntry where " +
+						"DDMStorageId > 0 order by DDMStorageId");
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_2/LayoutUpgradeProcess.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_2/LayoutUpgradeProcess.java
@@ -35,23 +35,23 @@ public class LayoutUpgradeProcess extends UpgradeProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement preparedStatement1 = connection.prepareStatement(
 				StringBundler.concat(
-					"select groupId, plid, friendlyUrl from Layout where ",
+					"select groupId, plid, friendlyURL from Layout where ",
 					"privateLayout = ? and (plid IN (select plid from ",
 					"LayoutPageTemplateEntry where type_ = ?) OR (classPK IN (",
 					"select plid from LayoutPageTemplateEntry where type_ = ?",
 					") and classNameId = ?))"));
 			PreparedStatement preparedStatement2 = connection.prepareStatement(
 				"select plid from Layout where privateLayout = ? and groupId " +
-					"= ? and friendlyUrl = ? and plid != ?");
+					"= ? and friendlyURL = ? and plid != ?");
 			PreparedStatement preparedStatement3 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
-					"update Layout set uuid_ = ?, friendlyUrl = ? where plid " +
+					"update Layout set uuid_ = ?, friendlyURL = ? where plid " +
 						"= ?");
 			PreparedStatement preparedStatement4 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
-					"update LayoutFriendlyURL set friendlyUrl = ? where plid " +
+					"update LayoutFriendlyURL set friendlyURL = ? where plid " +
 						"= ?");
 			PreparedStatement preparedStatement5 =
 				AutoBatchPreparedStatementUtil.autoBatch(

--- a/modules/apps/license-manager/license-manager-web/src/main/java/com/liferay/license/manager/web/internal/upgrade/v1_0_1/UpgradePortletId.java
+++ b/modules/apps/license-manager/license-manager-web/src/main/java/com/liferay/license/manager/web/internal/upgrade/v1_0_1/UpgradePortletId.java
@@ -84,7 +84,7 @@ public class UpgradePortletId extends BasePortletIdUpgradeProcess {
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,
 					"delete from ResourcePermission where companyId = ? and " +
-						"name = ? and scope = ? and primkey = ? and roleId = " +
+						"name = ? and scope = ? and primKey = ? and roleId = " +
 							"?")) {
 
 			while (resultSet.next()) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/registry/ObjectServiceUpgradeStepRegistrator.java
@@ -236,7 +236,7 @@ public class ObjectServiceUpgradeStepRegistrator
 		registry.register(
 			"3.23.0", "3.23.1",
 			UpgradeProcessFactory.runSQL(
-				"update ObjectField set indexed = [$TRUE$], indexedAsKeyWord " +
+				"update ObjectField set indexed = [$TRUE$], indexedAsKeyword " +
 					"= [$TRUE$] where indexed = [$FALSE$] and name = 'id' " +
 						"and system_ = [$TRUE$]"));
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v3_22_0/ObjectFieldUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v3_22_0/ObjectFieldUpgradeProcess.java
@@ -48,7 +48,7 @@ public class ObjectFieldUpgradeProcess extends UpgradeProcess {
 						"createDate, modifiedDate, externalReferenceCode, ",
 						"listTypeDefinitionId, objectDefinitionId, ",
 						"businessType, dbColumnName, dbTableName, dbType, ",
-						"defaultValue, indexed, indexedAsKeyWord, ",
+						"defaultValue, indexed, indexedAsKeyword, ",
 						"indexedLanguageId, label, name, relationshipType, ",
 						"required, state_, system_) values (?, ?, ?, ?, ?, ?, ",
 						"?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ",

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_0/QuartzUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_0/QuartzUpgradeProcess.java
@@ -26,8 +26,8 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 	private void _updateJobDetails() {
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement preparedStatement = connection.prepareStatement(
-				"update QUARTZ_JOB_DETAILS set job_class_name = ? where " +
-					"job_class_name = ?")) {
+				"update QUARTZ_JOB_DETAILS set JOB_CLASS_NAME = ? where " +
+					"JOB_CLASS_NAME = ?")) {
 
 			preparedStatement.setString(
 				1,

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/QuartzUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_1/QuartzUpgradeProcess.java
@@ -44,8 +44,9 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 		Map<String, Long> companyIds = new HashMap<>();
 
 		try (PreparedStatement preparedStatement = connection.prepareStatement(
-				"select job_name, job_data from QUARTZ_JOB_DETAILS where " +
-					"job_name not like '%@%'");
+				"select JOB_NAME, JOB_DATA from QUARTZ_JOB_DETAILS where " +
+					"JOB_NAME not like '%@%'");
+
 
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 
@@ -59,13 +60,13 @@ public class QuartzUpgradeProcess extends UpgradeProcess {
 		}
 
 		_updateTables(
-			companyIds, "job_name",
+			companyIds, "JOB_NAME",
 			new String[] {
 				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_JOB_DETAILS", "QUARTZ_TRIGGERS"
 			});
 
 		_updateTables(
-			companyIds, "trigger_name",
+			companyIds, "TRIGGER_NAME",
 			new String[] {
 				"QUARTZ_BLOB_TRIGGERS", "QUARTZ_CRON_TRIGGERS",
 				"QUARTZ_FIRED_TRIGGERS", "QUARTZ_SIMPLE_TRIGGERS",

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v3_2_0/SegmentsExperienceUpgradeProcess.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v3_2_0/SegmentsExperienceUpgradeProcess.java
@@ -229,8 +229,8 @@ public class SegmentsExperienceUpgradeProcess extends UpgradeProcess {
 		}
 
 		sb.append("segmentsExperienceId = ? and ");
-		sb.append("LayoutPageTemplateStructureId in (select ");
-		sb.append("LayoutPageTemplateStructureId from ");
+		sb.append("layoutPageTemplateStructureId in (select ");
+		sb.append("layoutPageTemplateStructureId from ");
 		sb.append("LayoutPageTemplateStructure where ");
 		sb.append(columnName);
 		sb.append(" = ?)");

--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v3_0_0/SiteNavigationMenuItemUpgradeProcess.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v3_0_0/SiteNavigationMenuItemUpgradeProcess.java
@@ -154,7 +154,7 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 			String sql = StringBundler.concat(
 				"select CProduct.externalReferenceCode from CProduct inner ",
 				"join CPDefinition on CProduct.CProductId = CPDefinition.",
-				"CProductId where CPDefinition.cpDefinitionId = ",
+				"CProductId where CPDefinition.CPDefinitionId = ",
 				GetterUtil.getLong(
 					typeSettingsUnicodeProperties.getProperty("classPK")));
 

--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v4_0_0/SiteNavigationMenuItemUpgradeProcess.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v4_0_0/SiteNavigationMenuItemUpgradeProcess.java
@@ -90,7 +90,7 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 			String sql = StringBundler.concat(
 				"select CProduct.externalReferenceCode from CProduct inner ",
 				"join CPDefinition on CProduct.CProductId = CPDefinition.",
-				"CProductId where CPDefinition.cpDefinitionId = ",
+				"CProductId where CPDefinition.CPDefinitionId = ",
 				GetterUtil.getLong(
 					typeSettingsUnicodeProperties.getProperty("classPK")));
 

--- a/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v5_0_0/SiteNavigationMenuItemUpgradeProcess.java
+++ b/modules/apps/site-navigation/site-navigation-service/src/main/java/com/liferay/site/navigation/internal/upgrade/v5_0_0/SiteNavigationMenuItemUpgradeProcess.java
@@ -195,7 +195,7 @@ public class SiteNavigationMenuItemUpgradeProcess extends UpgradeProcess {
 				String sql = StringBundler.concat(
 					"select CProduct.groupId from CProduct inner join ",
 					"CPDefinition on CProduct.CProductId = CPDefinition.",
-					"CProductId where CPDefinition.cpDefinitionId = ",
+					"CProductId where CPDefinition.CPDefinitionId = ",
 					GetterUtil.getLong(
 						typeSettingsUnicodeProperties.getProperty("classPK")));
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -98,10 +98,10 @@ public class UpgradeGroup extends UpgradeProcess {
 				SQLTransformer.transform(
 					StringBundler.concat(
 						"select Group_.companyId as companyId, ",
-						"User_.languageid as companyDefaultLanguageId, ",
+						"User_.languageId as companyDefaultLanguageId, ",
 						"groupId, name, typeSettings from Group_ left join ",
 						"User_ on Group_.companyId = User_.companyId where ",
-						"User_.defaultuser = [$TRUE$] and site = [$TRUE$] and ",
+						"User_.defaultUser = [$TRUE$] and site = [$TRUE$] and ",
 						"friendlyURL != '/global'")));
 
 			ResultSet resultSet = preparedStatement1.executeQuery();


### PR DESCRIPTION
Honor case-sensitive column identifiers in database upgrade SQL so that upgrades succeed on Microsoft SQL Server instances configured with a binary/case-sensitive collation (e.g. `Latin1_General_BIN2`).

- Jira: [LPD-95477](https://liferay.atlassian.net/browse/LPD-95477) — *Information is lost after upgrade due to case-sensitive collation with MSSQL Server*
- Original report: [PTR-8578](https://liferay.atlassian.net/browse/PTR-8578)

## Context

A clean Liferay install defaults MSSQL to `SQL_Latin1_General_CP1_CI_AS` (case-**insensitive**), so column identifiers whose casing does not exactly match the schema still resolve. Client environments using `Latin1_General_BIN2` (binary, strictly case-**sensitive**) treat differently-cased identifiers as distinct columns, so several `*UpgradeProcess` classes fail with:

```
com.microsoft.sqlserver.jdbc.SQLServerException: Invalid column name 'structureid'.
```

For example, `DDMStructureUpgradeProcess` selects `DDMStructure.structureId` but joins/filters on `DDMStructure.structureid`. The upgrade aborts, and data is lost.

## What changed

Corrected column identifiers in the SQL strings of 27 upgrade-process / upgrade-test classes to match the canonical column names declared in each entity's `*Table.java` / `tables.sql`. Examples:

- `DDMStructure.structureid` → `DDMStructure.structureId`
- `indexedAsKeyWord` → `indexedAsKeyword` (ObjectField)
- `job_name`, `job_data`, `job_class_name`, `trigger_name` → `JOB_NAME`, `JOB_DATA`, `JOB_CLASS_NAME`, `TRIGGER_NAME` (Quartz)
- `CPInstanceUUID` → `CPInstanceUuid`, `cProductId` → `CProductId`, `cpDefinitionId` → `CPDefinitionId` (Commerce)
- `ddmStorageId` → `DDMStorageId` (LayoutSEOEntry)
- `LayoutPageTemplateStructureId` → `layoutPageTemplateStructureId` (Segments)
- `friendlyUrl` → `friendlyURL`, `primkey` → `primKey`, `User_.languageid` → `User_.languageId`, etc.

No behavioral change on case-insensitive collations; these are pure identifier-casing corrections. `ResultSet.get*(String)` label lookups were left as-is (case-insensitive per the JDBC spec) and table names were left unchanged.

## How to test

End-to-end (matches the customer scenario):

1. Start MSSQL with a binary collation, e.g. `docker run -e "ACCEPT_EULA=Y" -e "MSSQL_SA_PASSWORD=Liferay#123" -e "MSSQL_COLLATION=Latin1_General_BIN2" -p 1433:1433 -d mcr.microsoft.com/mssql/server:2022-latest`.
2. Create the `lportal` DB (inherits `Latin1_General_BIN2`); confirm with `SELECT DATABASEPROPERTYEX('lportal','Collation')`.
3. Boot an older Liferay (e.g. 7.0) against it so the tables are created/populated; add at least one DDM/Web Content structure.
4. Stop it, deploy the target version, and run the upgrade (Database Upgrade Tool or `upgrade.database.auto.run=true`).
5. **Before:** fails with `Invalid column name 'structureid'` (and similar). **After:** upgrade completes, no data lost.

Faster inner loop: the upgrade-process integration tests in this change (e.g. `CPDefinitionLocalizationUpgradeProcessTest`, `CPSpecificationOptionUpgradeProcessTest`) reproduce the failure when run against a `BIN2` MSSQL test DB and pass with this change.


[LPD-95477]: https://liferay.atlassian.net/browse/LPD-95477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PTR-8578]: https://liferay.atlassian.net/browse/PTR-8578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ