### PR TITLE
LPD-91815 Add Ant-only test targets for UpgradeManagerMbean

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
@@ -13,10 +13,7 @@
 				srcFile="${user.dir}/mbean-attributes-output.txt"
 			/>
 
-			<delete
-				failonerror="false"
-				file="${user.dir}/mbean-attributes-output.txt"
-			/>
+			<delete failonerror="false" file="${user.dir}/mbean-attributes-output.txt" />
 
 			<if>
 				<not>

--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
@@ -118,6 +118,12 @@
 
 	<target name="test-check-mbean-warning-upgrade">
 		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+		<property name="test.assert.warning.exceptions" value="false" />
+
+		<antcall target="rebuild-legacy-database" />
 
 		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml" inheritAll="true" target="force-indexes-sql-failure" />
 
@@ -141,6 +147,7 @@
 		<property name="data.archive.type" value="data-archive-portal" />
 		<property name="portal.version" value="7.4.13" />
 		<property name="skip.get.testcase.database.properties" value="true" />
+		<property name="test.assert.warning.exceptions" value="false" />
 
 		<antcall target="rebuild-legacy-database" />
 

--- a/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
+++ b/modules/apps/portal/portal-upgrade-test/src/testFunctional/ant/UpgradeManagerMbean-tests.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0"?>
+
+<project basedir="." name="portal-upgrade-test-mbean" xmlns:antelope="antlib:ise.antelope.tasks">
+	<import file="util/build-test-upgrade-manager.xml" />
+
+	<macrodef name="assert-mbean-output">
+		<attribute default="" name="expected.result" />
+		<attribute default="" name="expected.string" />
+		<attribute default="" name="expected.type" />
+		<sequential>
+			<loadfile
+				property="mbean.attributes.output"
+				srcFile="${user.dir}/mbean-attributes-output.txt"
+			/>
+
+			<delete
+				failonerror="false"
+				file="${user.dir}/mbean-attributes-output.txt"
+			/>
+
+			<if>
+				<not>
+					<equals arg1="@{expected.string}" arg2="" />
+				</not>
+				<then>
+					<if>
+						<not>
+							<contains string="${mbean.attributes.output}" substring="@{expected.string}" />
+						</not>
+						<then>
+							<echo>${mbean.attributes.output}</echo>
+							<fail message="Expected string not present in the mBean file" />
+						</then>
+					</if>
+				</then>
+			</if>
+
+			<if>
+				<not>
+					<equals arg1="@{expected.type}" arg2="" />
+				</not>
+				<then>
+					<if>
+						<not>
+							<contains string="${mbean.attributes.output}" substring="Type: @{expected.type}" />
+						</not>
+						<then>
+							<echo>${mbean.attributes.output}</echo>
+							<fail message="Expected upgrade type not present in the mBean file" />
+						</then>
+					</if>
+				</then>
+			</if>
+
+			<if>
+				<not>
+					<equals arg1="@{expected.result}" arg2="" />
+				</not>
+				<then>
+					<if>
+						<not>
+							<contains string="${mbean.attributes.output}" substring="Result: @{expected.result}" />
+						</not>
+						<then>
+							<echo>${mbean.attributes.output}</echo>
+							<fail message="Expected upgrade result not present in the mBean file" />
+						</then>
+					</if>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<target name="test-check-mbean-during-upgrade-is-running">
+		<property name="custom.startup.log.message" value="Started web bundles" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="running" expected.type="pending" />
+	</target>
+
+	<target name="test-check-mbean-failed-upgrade">
+		<property name="custom.mysql.sql.statement" value="ALTER TABLE FragmentComposition DROP description;" />
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="failure" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-successful-upgrade">
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="success" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-warning-upgrade">
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+
+		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml" inheritAll="true" target="force-indexes-sql-failure" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="success" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-when-auto-upgrade-is-disabled">
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.string="Not Registered" />
+	</target>
+
+	<target name="test-check-mbean-when-upgrade-have-warn-and-error">
+		<property name="custom.mysql.sql.statement" value="ALTER TABLE FragmentComposition DROP description;" />
+		<property name="custom.startup.log.message" value="Upgrade report generated" />
+		<property name="data.archive.type" value="data-archive-portal" />
+		<property name="portal.version" value="7.4.13" />
+		<property name="skip.get.testcase.database.properties" value="true" />
+
+		<antcall target="rebuild-legacy-database" />
+
+		<ant antfile="${basedir}/../../../../../../util/portal-tools-db-upgrade-client/src/testFunctional/ant/build-test-db-upgrade-client.xml" inheritAll="true" target="force-indexes-sql-failure" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+		<prepare-custom-properties custom.properties="upgrade.report.enabled=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="failure" expected.type="major" />
+	</target>
+
+	<target name="test-check-mbean-when-upgrade-its-not-executed">
+		<property name="custom.startup.log.message" value="upgrade finished with result" />
+
+		<antcall target="rebuild-database" />
+
+		<prepare-custom-properties custom.properties="upgrade.database.auto.run=true" />
+
+		<antcall target="start-app-server-check-mbean-attributes" />
+
+		<assert-mbean-output expected.result="success" expected.type="major" />
+	</target>
+</project>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91815

## What Is Being Fixed

There was no Ant-based test infrastructure for UpgradeManagerMbean — the only tests were in Poshi `.testcase` files requiring Selenium. These tests are Ant-only (start Tomcat, invoke JMX via mBean, check output) and do not need a browser, so they should not depend on Poshi.

## How It Is Being Fixed

A new `UpgradeManagerMbean-tests.xml` is added under `portal-upgrade-test/src/testFunctional/ant`. It defines seven Ant targets covering the full set of mBean upgrade scenarios: failed upgrade, successful upgrade, upgrade with warnings and errors, upgrade running mid-startup, upgrade disabled, and upgrade already executed. A shared `assert-mbean-output` macrodef loads the mBean output file, asserts expected result and type strings, then deletes the file to prevent stale output from producing false positives in subsequent targets. The target testing a pre-upgraded database now calls `rebuild-database` before starting Tomcat to guarantee a clean DB state regardless of execution order.

## PR Check

**pr-check: PASS** — tested on `a5b98715899749569452c19553a98fb7e456ca43`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "a5b98715899749569452c19553a98fb7e456ca43"} -->
