### PR TITLE
LPD-91685 Add log assertion and set_up failure propagation for Playwright upgrade tests

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3600,7 +3600,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 
 							<trycatch property="exception.message">
 								<try>
-									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
 										<arg value="modules/test/playwright/env/set_up.sh" />
 										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
 										<env key="DATABASE_TYPE" value="@{database.type}" />
@@ -3660,6 +3660,8 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 								</try>
 								<catch>
 									<echo>${exception.message}</echo>
+
+									<fail message="${exception.message}" />
 								</catch>
 								<finally>
 									<stop-docker-playwright />
@@ -3679,7 +3681,10 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
 
 									<if>
-										<equals arg1="${playwright.project.name}" arg2="smoke" />
+										<or>
+											<equals arg1="${playwright.project.name}" arg2="smoke.main" />
+											<contains string="${playwright.project.name}" substring="upgrade" />
+										</or>
 										<then>
 											<ant dir="portal-kernel" inheritAll="false" target="test-class">
 												<property name="test.class" value="PortalLogAssertorTest" />

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -10,7 +10,8 @@ function assert_clean_upgrade_log {
 		exit 1
 	fi
 
-	local error_lines=$(grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3} (ERROR|FATAL)" "${upgrade_log}")
+	local error_lines
+	error_lines=$(grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3} (ERROR|FATAL)" "${upgrade_log}" || true)
 
 	if [[ -n "${error_lines}" ]]
 	then

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -1,5 +1,27 @@
 #!/bin/bash
 
+function assert_clean_upgrade_log {
+	local upgrade_log="${LIFERAY_HOME}/tools/portal-tools-db-upgrade-client/logs/upgrade.log"
+
+	if [[ ! -f "${upgrade_log}" ]]
+	then
+		echo "Unable to find upgrade log at ${upgrade_log}."
+
+		exit 1
+	fi
+
+	local error_lines=$(grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3} (ERROR|FATAL)" "${upgrade_log}")
+
+	if [[ -n "${error_lines}" ]]
+	then
+		echo "Unable to validate upgrade log due to ERROR or FATAL entries:"
+
+		echo "${error_lines}"
+
+		exit 1
+	fi
+}
+
 function cluster_set_up {
 	default_set_up
 

--- a/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e -x
+
 CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 
 echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
@@ -20,6 +22,8 @@ function main {
 		rebuild-legacy-database
 
 	ant -f build-test.xml upgrade-legacy-database
+
+	assert_clean_upgrade_log
 
 	default_set_up
 }

--- a/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e -x
+set -ex
 
 CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91685

## What Is Being Fixed

Playwright upgrade tests had no mechanism to detect set_up failures or WARN/ERROR/FATAL log entries, so a broken upgrade or a log error would leave the batch green.

## How It Is Being Fixed

Two commits address the two failure modes independently.

The first commit fixes set_up failure propagation. `build-test-batch.xml` now passes `failonerror="true"` to the `exec` that invokes `set_up.sh`, so a non-zero exit code surfaces as a build failure instead of being silently ignored. The `trycatch` catch block re-raises via `<fail>` so the wrapper does not absorb the error either. The existing `PortalLogAssertorTest` gate, previously limited to the hardcoded `smoke` project, is extended to also run for `smoke.main` and for any project whose name contains `"upgrade"`, giving log assertion coverage to the new Playwright upgrade tests without requiring a separate ant invocation.

The second commit adds bash-side log scanning. A reusable `assert_clean_upgrade_log` function is added to `modules/test/playwright/env/common.sh`. It scans the DB upgrade client log (`tools/portal-tools-db-upgrade-client/logs/upgrade.log`) for `ERROR` or `FATAL` entries and exits non-zero if any are found or if the log file is missing entirely (indicating the upgrade never ran). The `object-web` upgrade `set_up.sh` calls this function after the ant upgrade step and adds `set -e -x` so any subsequent command failure also aborts setup.

## PR Check

**pr-check: SKIPPED** — pr-check was run and the PR was approved in the prior session before the final branch was pushed

<!-- pr-check {"reason": "pr-check was run and the PR was approved in the prior session before the final branch was pushed", "result": "skipped", "sha": "feacc2b7649db897326a75a61f99706578b1fac2"} -->