### PR TITLE
LPD-95490 Fix unique-index collision in testUpgradeDLFileEntrySpecificCounterFilters

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
@@ -255,9 +255,9 @@ public class CounterDataCleanupPreupgradeProcessTest
 		long fileEntryId2 = CounterLocalServiceUtil.increment();
 		long fileEntryId3 = CounterLocalServiceUtil.increment();
 
-		long groupId1 = RandomTestUtil.nextLong();
-		long groupId2 = RandomTestUtil.nextLong();
-		long groupId3 = RandomTestUtil.nextLong();
+		long groupId1 = CounterLocalServiceUtil.increment();
+		long groupId2 = CounterLocalServiceUtil.increment();
+		long groupId3 = CounterLocalServiceUtil.increment();
 
 		long name =
 			CounterLocalServiceUtil.getCurrentId(DLFileEntry.class.getName()) +

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
@@ -254,6 +254,11 @@ public class CounterDataCleanupPreupgradeProcessTest
 		long fileEntryId1 = CounterLocalServiceUtil.increment();
 		long fileEntryId2 = CounterLocalServiceUtil.increment();
 		long fileEntryId3 = CounterLocalServiceUtil.increment();
+
+		long groupId1 = RandomTestUtil.nextLong();
+		long groupId2 = RandomTestUtil.nextLong();
+		long groupId3 = RandomTestUtil.nextLong();
+
 		long name =
 			CounterLocalServiceUtil.getCurrentId(DLFileEntry.class.getName()) +
 				100;
@@ -266,19 +271,16 @@ public class CounterDataCleanupPreupgradeProcessTest
 			(UnsafeRunnable<Exception>)() -> {
 				runSQL(
 					StringBundler.concat(
-						"insert into DLFileEntry (mvccVersion, ",
-						"ctCollectionId, fileEntryId, name) values (0, 0,",
-						fileEntryId1, ", '", name, "')"));
+						_INSERT_DL_FILE_ENTRY_SQL, fileEntryId1, ", ", groupId1,
+						", '", name, "')"));
 				runSQL(
 					StringBundler.concat(
-						"insert into DLFileEntry (mvccVersion, ",
-						"ctCollectionId, fileEntryId, name) values (0, 0,",
-						fileEntryId2, ", 'non-numeric')"));
+						_INSERT_DL_FILE_ENTRY_SQL, fileEntryId2, ", ", groupId2,
+						", 'non-numeric')"));
 				runSQL(
 					StringBundler.concat(
-						"insert into DLFileEntry (mvccVersion, ",
-						"ctCollectionId, fileEntryId, name) values (0, 0,",
-						fileEntryId3, ", '99999999999999999999')"));
+						_INSERT_DL_FILE_ENTRY_SQL, fileEntryId3, ", ", groupId3,
+						", '99999999999999999999')"));
 			},
 			(UnsafeConsumer<List<String>, Exception>)messages -> {
 				Assert.assertEquals(messages.toString(), 1, messages.size());
@@ -465,6 +467,10 @@ public class CounterDataCleanupPreupgradeProcessTest
 			postUnsafeRunnable.run();
 		}
 	}
+
+	private static final String _INSERT_DL_FILE_ENTRY_SQL =
+		"insert into DLFileEntry (mvccVersion, ctCollectionId, fileEntryId, " +
+			"groupId, name) values (0, 0, ";
 
 	private static final String _TABLE_NAME = "TestTable";
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95490

## What Is Being Fixed

`testUpgradeDLFileEntrySpecificCounterFilters` was failing on SQL Server, Oracle, and DB2 with a unique-constraint violation on IX_273362A5 (`groupId`, `externalReferenceCode`, `ctCollectionId`). The test inserted three `DLFileEntry` rows without a `groupId`, so all three produced the identical `(0, NULL, 0)` tuple. SQL Server, Oracle, and DB2 treat `NULL=NULL` in unique indexes, unlike MySQL and PostgreSQL, so the second and third inserts collided with the first.

## How It Is Being Fixed

Each of the three inserted rows is given a distinct `groupId` from `CounterLocalServiceUtil.increment()`, which is guaranteed unique per the database counter table. Because `groupId` is the leading column of every unique index on `DLFileEntry`, distinct leading values make every tuple unique across all five indexes at once. The repeated INSERT SQL prefix is extracted to `_INSERT_DL_FILE_ENTRY_SQL` (used three times, meeting the extraction threshold).

## PR Check

**pr-check: PASS** — tested on `3862662816cc81e67ee964b6218f29ad353f3217`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |