### PR TITLE
LPD-91341 Batch commit transactions during concurrent DB upgrade

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.dao.db.IndexMetadata;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -567,24 +568,27 @@ public class BaseDBProcessTest extends BaseDBProcess {
 
 	@Test
 	public void testProcessConcurrentlyWithBatch() throws Exception {
-		_validateProcessConcurrently(
-			threadIds -> processConcurrently(
-				"select id from " + _TABLE_NAME,
-				"update " + _TABLE_NAME + " set typeInteger = ? where id = ?",
-				resultSet -> new Object[] {resultSet.getInt("id")},
-				(values, preparedStatement) -> {
-					Thread currentThread = Thread.currentThread();
+		_validateProcessConcurrently(this::_processConcurrentlyWithBatch);
+	}
 
-					threadIds.add(currentThread.getId());
+	@Test
+	public void testProcessConcurrentlyWithBatchWhenDatabasePartitionEnabled()
+		throws Exception {
 
-					int value = (int)values[0];
+		_populateTable();
 
-					preparedStatement.setInt(1, value);
-					preparedStatement.setInt(2, value);
+		Set<Long> threadIds = Collections.synchronizedSet(new HashSet<>());
 
-					preparedStatement.addBatch();
-				},
-				null));
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"DATABASE_PARTITION_ENABLED", true)) {
+
+			_processConcurrentlyWithBatch(threadIds);
+		}
+
+		Assert.assertTrue(threadIds.size() > 1);
+
+		_validateTableContent();
 	}
 
 	@Test
@@ -627,6 +631,28 @@ public class BaseDBProcessTest extends BaseDBProcess {
 					"insert into ", _TABLE_NAME, " (id, notNilColumn) values (",
 					i, ", '1')"));
 		}
+	}
+
+	private void _processConcurrentlyWithBatch(Set<Long> threadIds)
+		throws Exception {
+
+		processConcurrently(
+			"select id from " + _TABLE_NAME,
+			"update " + _TABLE_NAME + " set typeInteger = ? where id = ?",
+			resultSet -> new Object[] {resultSet.getInt("id")},
+			(values, preparedStatement) -> {
+				Thread currentThread = Thread.currentThread();
+
+				threadIds.add(currentThread.getId());
+
+				int value = (int)values[0];
+
+				preparedStatement.setInt(1, value);
+				preparedStatement.setInt(2, value);
+
+				preparedStatement.addBatch();
+			},
+			null);
 	}
 
 	private void _validateIndex(String[] columnNames) throws Exception {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -973,6 +973,18 @@ public abstract class BaseDBProcess implements DBProcess {
 				return;
 			}
 
+			if (_log.isWarnEnabled() && !_connection.getAutoCommit()) {
+				Class<?> clazz = BaseDBProcess.this.getClass();
+
+				Thread currentThread = Thread.currentThread();
+
+				_log.warn(
+					StringBundler.concat(
+						"Worker connection arrived with autoCommit=false in ",
+						clazz.getName(), " on thread ", currentThread.getName(),
+						"; healing on the next flush"));
+			}
+
 			try {
 				_connection.setAutoCommit(false);
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -605,12 +605,13 @@ public abstract class BaseDBProcess implements DBProcess {
 		catch (SQLException sqlException) {
 			_log.error(sqlException);
 		}
-
-		try {
-			connection.setAutoCommit(true);
-		}
-		catch (SQLException sqlException) {
-			_log.error(sqlException);
+		finally {
+			try {
+				connection.setAutoCommit(true);
+			}
+			catch (SQLException sqlException) {
+				_log.error(sqlException);
+			}
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -915,9 +915,9 @@ public abstract class BaseDBProcess implements DBProcess {
 
 			String methodName = method.getName();
 
-			boolean isAddBatch = methodName.equals("addBatch");
+			boolean addBatch = methodName.equals("addBatch");
 
-			if (isAddBatch && !_transaction) {
+			if (addBatch && !_transaction) {
 				_startTransaction();
 			}
 
@@ -930,14 +930,12 @@ public abstract class BaseDBProcess implements DBProcess {
 				throw invocationTargetException.getCause();
 			}
 
-			if (isAddBatch) {
+			if (addBatch) {
 				if (++_count >= PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
 					_finishTransaction(true);
 				}
 			}
-			else if (_transaction &&
-					 methodName.equals("executeBatch")) {
-
+			else if (_transaction && methodName.equals("executeBatch")) {
 				_finishTransaction(true);
 			}
 
@@ -971,10 +969,6 @@ public abstract class BaseDBProcess implements DBProcess {
 		}
 
 		private void _startTransaction() throws SQLException {
-			if (!_connection.getAutoCommit()) {
-				return;
-			}
-
 			if (!_transactionalConnections.add(_connection)) {
 				return;
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -928,18 +928,18 @@ public abstract class BaseDBProcess implements DBProcess {
 				result = method.invoke(_preparedStatement, args);
 			}
 			catch (InvocationTargetException invocationTargetException) {
-				Throwable causeThrowable = invocationTargetException.getCause();
+				Throwable throwable = invocationTargetException.getCause();
 
 				if (_transaction) {
 					try {
 						_finishTransaction(false);
 					}
 					catch (SQLException sqlException) {
-						causeThrowable.addSuppressed(sqlException);
+						throwable.addSuppressed(sqlException);
 					}
 				}
 
-				throw causeThrowable;
+				throw throwable;
 			}
 
 			if (addBatch) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -649,8 +649,7 @@ public abstract class BaseDBProcess implements DBProcess {
 						return preparedStatement;
 					}
 
-					Connection workerConnection = connectionsMap.get(
-						Thread.currentThread());
+					Connection workerConnection = connectionsMap.get(k);
 
 					if (workerConnection == null) {
 						return preparedStatement;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -577,46 +577,6 @@ public abstract class BaseDBProcess implements DBProcess {
 		}
 	}
 
-	private Connection _enableTransactionForCurrentThread()
-		throws SQLException {
-
-		Map<Thread, Connection> connectionsMap = _connectionsMaps.get(
-			PropsValues.DATABASE_PARTITION_ENABLED ?
-				CompanyThreadLocal.getCompanyId() : CompanyConstants.SYSTEM);
-
-		if (connectionsMap == null) {
-			return null;
-		}
-
-		Connection workerConnection = connectionsMap.get(
-			Thread.currentThread());
-
-		if (workerConnection == null) {
-			return null;
-		}
-
-		boolean previousAutoCommit = workerConnection.getAutoCommit();
-
-		if (!previousAutoCommit) {
-			return null;
-		}
-
-		if (!_transactionalConnections.add(workerConnection)) {
-			return null;
-		}
-
-		try {
-			workerConnection.setAutoCommit(false);
-		}
-		catch (SQLException sqlException) {
-			_transactionalConnections.remove(workerConnection);
-
-			throw sqlException;
-		}
-
-		return workerConnection;
-	}
-
 	private void _finishAndCloseConnection(Connection connection) {
 		if (_transactionalConnections.remove(connection)) {
 			if (_log.isWarnEnabled()) {
@@ -678,8 +638,18 @@ public abstract class BaseDBProcess implements DBProcess {
 						AutoBatchPreparedStatementUtil.autoBatch(
 							connection, updateSQL);
 
-					Connection workerConnection =
-						_enableTransactionForCurrentThread();
+					Map<Thread, Connection> connectionsMap =
+						_connectionsMaps.get(
+							PropsValues.DATABASE_PARTITION_ENABLED ?
+								CompanyThreadLocal.getCompanyId() :
+									CompanyConstants.SYSTEM);
+
+					if (connectionsMap == null) {
+						return preparedStatement;
+					}
+
+					Connection workerConnection = connectionsMap.get(
+						Thread.currentThread());
 
 					if (workerConnection == null) {
 						return preparedStatement;
@@ -689,7 +659,7 @@ public abstract class BaseDBProcess implements DBProcess {
 						ClassLoader.getSystemClassLoader(),
 						new Class<?>[] {PreparedStatement.class},
 						new BatchCommitInvocationHandler(
-							workerConnection, preparedStatement));
+							workerConnection, _transactionalConnections, preparedStatement));
 				}
 				catch (SQLException sqlException) {
 					throw new RuntimeException(sqlException);
@@ -946,6 +916,12 @@ public abstract class BaseDBProcess implements DBProcess {
 
 			String methodName = method.getName();
 
+			boolean isAddBatch = methodName.equals("addBatch");
+
+			if (isAddBatch && !_transaction) {
+				_startTransaction();
+			}
+
 			Object result;
 
 			try {
@@ -955,32 +931,74 @@ public abstract class BaseDBProcess implements DBProcess {
 				throw invocationTargetException.getCause();
 			}
 
-			if (methodName.equals("addBatch")) {
+			if (isAddBatch) {
 				if (++_count >= PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
-					_count = 0;
-
-					_connection.commit();
+					_finishTransaction(true);
 				}
 			}
-			else if (methodName.equals("executeBatch") && (_count > 0)) {
-				_count = 0;
+			else if (methodName.equals("executeBatch") &&
+					 _transaction) {
 
-				_connection.commit();
+				_finishTransaction(true);
 			}
 
 			return result;
 		}
 
 		private BatchCommitInvocationHandler(
-			Connection connection, PreparedStatement preparedStatement) {
+			Connection connection, Set<Connection> ownedConnections,
+			PreparedStatement preparedStatement) {
 
 			_connection = connection;
+			_transactionalConnections = ownedConnections;
 			_preparedStatement = preparedStatement;
 		}
 
+		private void _finishTransaction(boolean commit) throws SQLException {
+			_count = 0;
+			_transaction = false;
+
+			_transactionalConnections.remove(_connection);
+
+			try {
+				if (commit) {
+					_connection.commit();
+				}
+				else {
+					_connection.rollback();
+				}
+			}
+			finally {
+				_connection.setAutoCommit(true);
+			}
+		}
+
+		private void _startTransaction() throws SQLException {
+			if (!_connection.getAutoCommit()) {
+				return;
+			}
+
+			if (!_transactionalConnections.add(_connection)) {
+				return;
+			}
+
+			try {
+				_connection.setAutoCommit(false);
+			}
+			catch (SQLException sqlException) {
+				_transactionalConnections.remove(_connection);
+
+				throw sqlException;
+			}
+
+			_transaction = true;
+		}
+
+		private final Set<Connection> _transactionalConnections;
 		private final Connection _connection;
 		private int _count;
 		private final PreparedStatement _preparedStatement;
+		private boolean _transaction;
 
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import java.sql.Connection;
@@ -545,19 +546,14 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		Collection<Connection> connections = connectionsMap.values();
 
-		try {
-			Iterator<Connection> iterator = connections.iterator();
+		Iterator<Connection> iterator = connections.iterator();
 
-			while (iterator.hasNext()) {
-				Connection connection = iterator.next();
+		while (iterator.hasNext()) {
+			Connection connection = iterator.next();
 
-				iterator.remove();
+			iterator.remove();
 
-				connection.close();
-			}
-		}
-		catch (SQLException sqlException) {
-			_log.error(sqlException);
+			_finishAndCloseConnection(connection);
 		}
 	}
 
@@ -568,23 +564,105 @@ public abstract class BaseDBProcess implements DBProcess {
 			return;
 		}
 
+		for (Map.Entry<Thread, Connection> entry : connectionsMap.entrySet()) {
+			if (entry.getKey() == thread) {
+				Connection connection = entry.getValue();
+
+				connectionsMap.remove(entry.getKey());
+
+				_finishAndCloseConnection(connection);
+
+				return;
+			}
+		}
+	}
+
+	private Connection _enableTransactionForCurrentThread()
+		throws SQLException {
+
+		Map<Thread, Connection> connectionsMap = _connectionsMaps.get(
+			PropsValues.DATABASE_PARTITION_ENABLED ?
+				CompanyThreadLocal.getCompanyId() : CompanyConstants.SYSTEM);
+
+		if (connectionsMap == null) {
+			return null;
+		}
+
+		Connection workerConnection = connectionsMap.get(
+			Thread.currentThread());
+
+		if (workerConnection == null) {
+			return null;
+		}
+
+		boolean previousAutoCommit = workerConnection.getAutoCommit();
+
+		if (!previousAutoCommit) {
+			return null;
+		}
+
+		if (!_transactionalConnections.add(workerConnection)) {
+			return null;
+		}
+
 		try {
-			for (Map.Entry<Thread, Connection> entry :
-					connectionsMap.entrySet()) {
+			workerConnection.setAutoCommit(false);
+		}
+		catch (SQLException sqlException) {
+			_transactionalConnections.remove(workerConnection);
 
-				if (entry.getKey() == thread) {
-					Connection connection = entry.getValue();
+			throw sqlException;
+		}
 
-					connectionsMap.remove(entry.getKey());
+		return workerConnection;
+	}
 
-					connection.close();
+	private void _finishAndCloseConnection(Connection connection) {
+		if (_transactionalConnections.remove(connection)) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Closing a connection with an uncommitted autocommit " +
+						"override; rolling back defensively");
+			}
 
-					return;
-				}
+			_finishTransactionalConnection(connection, false);
+		}
+
+		DataAccess.cleanUp(connection);
+	}
+
+	private void _finishTransactionalConnection(
+		Connection connection, boolean commit) {
+
+		try {
+			if (commit) {
+				connection.commit();
+			}
+			else {
+				connection.rollback();
 			}
 		}
 		catch (SQLException sqlException) {
 			_log.error(sqlException);
+		}
+
+		try {
+			connection.setAutoCommit(true);
+		}
+		catch (SQLException sqlException) {
+			_log.error(sqlException);
+		}
+	}
+
+	private void _finishTransactionalConnections(boolean commit) {
+		Iterator<Connection> iterator = _transactionalConnections.iterator();
+
+		while (iterator.hasNext()) {
+			Connection connection = iterator.next();
+
+			iterator.remove();
+
+			_finishTransactionalConnection(connection, commit);
 		}
 	}
 
@@ -596,8 +674,22 @@ public abstract class BaseDBProcess implements DBProcess {
 			Thread.currentThread(),
 			k -> {
 				try {
-					return AutoBatchPreparedStatementUtil.autoBatch(
-						connection, updateSQL);
+					PreparedStatement preparedStatement =
+						AutoBatchPreparedStatementUtil.autoBatch(
+							connection, updateSQL);
+
+					Connection workerConnection =
+						_enableTransactionForCurrentThread();
+
+					if (workerConnection == null) {
+						return preparedStatement;
+					}
+
+					return (PreparedStatement)ProxyUtil.newProxyInstance(
+						ClassLoader.getSystemClassLoader(),
+						new Class<?>[] {PreparedStatement.class},
+						new BatchCommitInvocationHandler(
+							workerConnection, preparedStatement));
 				}
 				catch (SQLException sqlException) {
 					throw new RuntimeException(sqlException);
@@ -799,6 +891,8 @@ public abstract class BaseDBProcess implements DBProcess {
 				Throwable throwable = throwableCollector.getThrowable();
 
 				if (throwable != null) {
+					_finishTransactionalConnections(false);
+
 					if (exceptionMessage != null) {
 						throw new Exception(exceptionMessage, throwable);
 					}
@@ -814,8 +908,12 @@ public abstract class BaseDBProcess implements DBProcess {
 
 						preparedStatement.close();
 					}
+
+					_finishTransactionalConnections(true);
 				}
 				catch (Exception exception) {
+					_finishTransactionalConnections(false);
+
 					_log.error(exceptionMessage, exception);
 
 					throw exception;
@@ -836,6 +934,55 @@ public abstract class BaseDBProcess implements DBProcess {
 
 	private final Map<Long, Map<Thread, Connection>> _connectionsMaps =
 		new ConcurrentHashMap<>();
+	private final Set<Connection> _transactionalConnections =
+		ConcurrentHashMap.newKeySet();
+
+	private static class BatchCommitInvocationHandler
+		implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws Throwable {
+
+			String methodName = method.getName();
+
+			Object result;
+
+			try {
+				result = method.invoke(_preparedStatement, args);
+			}
+			catch (InvocationTargetException invocationTargetException) {
+				throw invocationTargetException.getCause();
+			}
+
+			if (methodName.equals("addBatch")) {
+				if (++_count >= PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
+					_count = 0;
+
+					_connection.commit();
+				}
+			}
+			else if (methodName.equals("executeBatch") && (_count > 0)) {
+				_count = 0;
+
+				_connection.commit();
+			}
+
+			return result;
+		}
+
+		private BatchCommitInvocationHandler(
+			Connection connection, PreparedStatement preparedStatement) {
+
+			_connection = connection;
+			_preparedStatement = preparedStatement;
+		}
+
+		private final Connection _connection;
+		private int _count;
+		private final PreparedStatement _preparedStatement;
+
+	}
 
 	private class ConnectionThreadProxyInvocationHandler
 		implements InvocationHandler {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -985,19 +985,19 @@ public abstract class BaseDBProcess implements DBProcess {
 				return;
 			}
 
-			if (_log.isWarnEnabled() && !_connection.getAutoCommit()) {
-				Class<?> clazz = BaseDBProcess.this.getClass();
-
-				Thread currentThread = Thread.currentThread();
-
-				_log.warn(
-					StringBundler.concat(
-						"Worker connection arrived with autoCommit=false in ",
-						clazz.getName(), " on thread ", currentThread.getName(),
-						"; healing on the next flush"));
-			}
-
 			try {
+				if (_log.isWarnEnabled() && !_connection.getAutoCommit()) {
+					Class<?> clazz = BaseDBProcess.this.getClass();
+
+					Thread currentThread = Thread.currentThread();
+
+					_log.warn(
+						StringBundler.concat(
+							"Worker connection for ", clazz.getName(),
+							" arrived with autocommit disabled on thread ",
+							currentThread.getName()));
+				}
+
 				_connection.setAutoCommit(false);
 			}
 			catch (SQLException sqlException) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -659,7 +659,7 @@ public abstract class BaseDBProcess implements DBProcess {
 						ClassLoader.getSystemClassLoader(),
 						new Class<?>[] {PreparedStatement.class},
 						new BatchCommitInvocationHandler(
-							workerConnection, _transactionalConnections, preparedStatement));
+							workerConnection, preparedStatement));
 				}
 				catch (SQLException sqlException) {
 					throw new RuntimeException(sqlException);
@@ -907,8 +907,7 @@ public abstract class BaseDBProcess implements DBProcess {
 	private final Set<Connection> _transactionalConnections =
 		ConcurrentHashMap.newKeySet();
 
-	private static class BatchCommitInvocationHandler
-		implements InvocationHandler {
+	private class BatchCommitInvocationHandler implements InvocationHandler {
 
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args)
@@ -936,8 +935,8 @@ public abstract class BaseDBProcess implements DBProcess {
 					_finishTransaction(true);
 				}
 			}
-			else if (methodName.equals("executeBatch") &&
-					 _transaction) {
+			else if (_transaction &&
+					 methodName.equals("executeBatch")) {
 
 				_finishTransaction(true);
 			}
@@ -946,11 +945,9 @@ public abstract class BaseDBProcess implements DBProcess {
 		}
 
 		private BatchCommitInvocationHandler(
-			Connection connection, Set<Connection> ownedConnections,
-			PreparedStatement preparedStatement) {
+			Connection connection, PreparedStatement preparedStatement) {
 
 			_connection = connection;
-			_transactionalConnections = ownedConnections;
 			_preparedStatement = preparedStatement;
 		}
 
@@ -994,7 +991,6 @@ public abstract class BaseDBProcess implements DBProcess {
 			_transaction = true;
 		}
 
-		private final Set<Connection> _transactionalConnections;
 		private final Connection _connection;
 		private int _count;
 		private final PreparedStatement _preparedStatement;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -927,7 +927,18 @@ public abstract class BaseDBProcess implements DBProcess {
 				result = method.invoke(_preparedStatement, args);
 			}
 			catch (InvocationTargetException invocationTargetException) {
-				throw invocationTargetException.getCause();
+				Throwable causeThrowable = invocationTargetException.getCause();
+
+				if (_transaction) {
+					try {
+						_finishTransaction(false);
+					}
+					catch (SQLException sqlException) {
+						causeThrowable.addSuppressed(sqlException);
+					}
+				}
+
+				throw causeThrowable;
 			}
 
 			if (addBatch) {


### PR DESCRIPTION
Review notes on top of Mariano's implementation. Four commits added after the original 7:

- **Ensure setAutoCommit(true) runs in finally after commit or rollback** — `_finishTransactionalConnection` had two sequential try/catch blocks; if `commit()`/`rollback()` threw, `setAutoCommit(true)` was silently skipped, leaving the connection in a non-autocommit state.

- **Guard _transactionalConnections enrollment against getAutoCommit failure** — `_startTransaction` enrolled the connection in `_transactionalConnections` before calling `getAutoCommit()` for the warn check. If `getAutoCommit()` threw (broken connection), the connection was orphaned in the set with autoCommit still true, and cleanup would call `rollback()` on it — which some JDBC drivers reject in autoCommit mode. Moved the warn check inside the existing try/catch so the `remove()` on failure covers all SQLException paths.

- **Rename causeThrowable to throwable** — source formatter VariableNameCheck requirement for Throwable-typed variables.

- **Use computeIfAbsent key k instead of Thread.currentThread() in lambda** — the lambda parameter `k` is already `Thread.currentThread()` at invocation time; using it directly avoids the redundant call.

Two open questions for Mariano:

- **C1** — `invoke()` dispatches via `methodName.equals("addBatch")` / `"executeBatch"` (string comparison). `AutoBatchPreparedStatementUtil.BatchInvocationHandler` uses a cached `Method` field. Deliberate choice or worth aligning?

- **C2** — Partial-commit semantics: batches committed at flush boundaries before a failure are permanent (only the in-flight batch rolls back). Accepted tradeoff, or was all-or-nothing the intent?