### PR TITLE
LPD-91814 Add DB partition Playwright tests and CI batch macrodefs

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -1954,6 +1954,179 @@ app.server.type=@{app.server.type}]]></echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="run-db-import-postgresql-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="mysql" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="mysql" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Phase 1: start server on MySQL, verify default instance is accessible -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="mysql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase1 --grep "CanImportDatabaseToPostgreSQL"
+									</docker-execute>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="mysql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<antcall inheritall="false" target="stop-app-server" />
+
+									<!-- Start PostgreSQL Docker and rebuild schema -->
+
+									<antcall inheritall="false" target="start-docker-database">
+										<param name="database.type" value="postgresql" />
+									</antcall>
+
+									<antcall inheritall="false" target="rebuild-database">
+										<param name="database.type" value="postgresql" />
+										<param name="skip.delete.liferay.home" value="true" />
+									</antcall>
+
+									<!-- Run db-migration-importer: copy MySQL data to PostgreSQL -->
+
+									<get-database-property property.name="database.host" />
+									<get-database-property property.name="database.password" />
+									<get-database-property property.name="database.username" />
+
+									<ant antfile="modules/util/portal-tools-db-migration-importer-test/src/testFunctional/ant/build-test-db-migration-importer.xml" inheritAll="false" target="import-database">
+										<property name="path" value="${liferay.home}" />
+										<property name="source.jdbc.url" value="${jdbc.default.url}" />
+										<property name="source.password" value="${jdbc.default.password}" />
+										<property name="source.user" value="${jdbc.default.username}" />
+										<property name="target.jdbc.url" value="${database.postgresql.url}" />
+										<property name="target.password" value="${database.postgresql.password}" />
+										<property name="target.user" value="${database.postgresql.username}" />
+									</ant>
+
+									<!-- Switch portal-ext.properties to PostgreSQL -->
+
+									<propertyfile file="${liferay.home}/portal-ext.properties">
+										<entry key="jdbc.default.driver.class.name" value="${database.postgresql.driver}" />
+										<entry key="jdbc.default.password" value="${database.postgresql.password}" />
+										<entry key="jdbc.default.url" value="${database.postgresql.url}" />
+										<entry key="jdbc.default.username" value="${database.postgresql.username}" />
+									</propertyfile>
+
+									<antcall inheritall="false" target="start-app-server-preserve-liferay-home" />
+
+									<!-- Phase 2: verify default instance on PostgreSQL -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="postgresql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase2 --grep "CanImportDatabaseToPostgreSQL"
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="postgresql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<antcall inheritall="false" target="stop-docker-database">
+										<param name="database.type" value="postgresql" />
+									</antcall>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="run-db-migration-container-test">
 		<attribute name="database.type" />
 		<attribute name="database.version" />
@@ -2008,6 +2181,1996 @@ app.server.type=@{app.server.type}]]></echo>
 									<ant dir="portal-kernel" inheritAll="false" target="test-class">
 										<property name="test.class" value="PortalLogAssertorTest" />
 									</ant>
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-cluster-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" stop.app.server="true">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<trycatch property="exception.message">
+								<try>
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.cluster" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.cluster
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.cluster" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-compare-latest-7413-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" rebuild.database="false" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<local name="db.partition.compare.state.file" />
+
+							<property location="modules/test/playwright/test-results/db-partition-state.json" name="db.partition.compare.state.file" />
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Set up the released (7.4.13) bundle — CI must supply test.released.* properties -->
+
+									<antcall inheritAll="false" target="prepare-upgrade-released-bundle-test-environment" />
+
+									<!-- Phase 1: create www.able.com on old released bundle -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-latest-7413" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.compare-latest-7413 --grep "Phase 1"
+									</docker-execute>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-latest-7413" />
+									</exec>
+
+									<!-- Read ableCompanyId so we can name the upgraded partition schema -->
+
+									<local name="phase1.state.json" />
+
+									<loadfile
+										property="phase1.state.json"
+										srcFile="${db.partition.compare.state.file}"
+									/>
+
+									<local name="able.company.id" />
+
+									<propertyregex
+										input="${phase1.state.json}"
+										property="able.company.id"
+										regexp="&quot;ableCompanyId&quot;\s*:\s*([0-9]+)"
+										select="\1"
+									/>
+
+									<!-- Set buildDate to epoch so module indexes regenerate after upgrade -->
+
+									<get-database-property property.name="database.host" />
+									<get-database-property property.name="database.password" />
+									<get-database-property property.name="database.username" />
+
+									<if>
+										<equals arg1="@{database.type}" arg2="mysql" />
+										<then>
+											<exec executable="docker" failonerror="true">
+												<arg value="exec" />
+												<arg value="${database.host}" />
+												<arg value="mysql" />
+												<arg value="--execute=UPDATE lportal.Release_ SET buildDate = '1970-01-01 00:00:00' WHERE releaseId = 1;" />
+												<arg value="--host=127.0.0.1" />
+												<arg value="--password=${database.password}" />
+												<arg value="--user=${database.username}" />
+											</exec>
+										</then>
+										<elseif>
+											<equals arg1="@{database.type}" arg2="postgresql" />
+											<then>
+												<exec executable="docker" failonerror="true">
+													<arg value="exec" />
+													<arg value="${database.host}" />
+													<arg value="/bin/bash" />
+													<arg value="-c" />
+													<arg value="PGPASSWORD=${database.password} psql --command=&quot;UPDATE &quot;&quot;Release_&quot;&quot; SET &quot;&quot;buildDate&quot;&quot; = '1970-01-01 00:00:00' WHERE &quot;&quot;releaseId&quot;&quot; = 1;&quot; --username=${database.username} lportal" />
+												</exec>
+											</then>
+										</elseif>
+									</if>
+
+									<!-- Restore original bundle and run the DB upgrade client -->
+
+									<antcall inheritAll="false" target="prepare-upgrade-original-bundle-test-environment" />
+
+									<antcall inheritAll="false" target="upgrade-legacy-database" />
+
+									<!-- Export upgraded schemas -->
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="upgraded" />
+										<param name="database.schema.name" value="lpartition_${able.company.id}" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="upgraded" />
+										<param name="database.schema.name" value="lportal" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<!-- Rebuild DB and drop upgraded partition -->
+
+									<antcall inheritAll="false" target="rebuild-database">
+										<param name="database.bare.enabled" value="true" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<if>
+										<equals arg1="@{database.type}" arg2="mysql" />
+										<then>
+											<exec executable="docker" failonerror="true">
+												<arg value="exec" />
+												<arg value="${database.host}" />
+												<arg value="mysql" />
+												<arg value="--execute=DROP DATABASE IF EXISTS lpartition_${able.company.id};" />
+												<arg value="--host=127.0.0.1" />
+												<arg value="--password=${database.password}" />
+												<arg value="--user=${database.username}" />
+											</exec>
+										</then>
+										<elseif>
+											<equals arg1="@{database.type}" arg2="postgresql" />
+											<then>
+												<exec executable="docker" failonerror="true">
+													<arg value="exec" />
+													<arg value="${database.host}" />
+													<arg value="/bin/bash" />
+													<arg value="-c" />
+													<arg value="PGPASSWORD=${database.password} psql --command='DROP SCHEMA IF EXISTS lpartition_${able.company.id} CASCADE;' --username=${database.username} lportal" />
+												</exec>
+											</then>
+										</elseif>
+									</if>
+
+									<!-- Phase 3: create www.baker.com on fresh server -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-latest-7413" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.compare-latest-7413 --grep "Phase 3"
+									</docker-execute>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-latest-7413" />
+									</exec>
+
+									<!-- Read bakerCompanyId (phase3 merges it into the same state file) -->
+
+									<local name="final.state.json" />
+
+									<loadfile
+										property="final.state.json"
+										srcFile="${db.partition.compare.state.file}"
+									/>
+
+									<local name="baker.company.id" />
+
+									<propertyregex
+										input="${final.state.json}"
+										property="baker.company.id"
+										regexp="&quot;bakerCompanyId&quot;\s*:\s*([0-9]+)"
+										select="\1"
+									/>
+
+									<!-- Export fresh schemas -->
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="fresh" />
+										<param name="database.schema.name" value="lpartition_${baker.company.id}" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="fresh" />
+										<param name="database.schema.name" value="lportal" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<!-- Compare: baker↔able partition, lportal↔lportal -->
+
+									<antcall inheritAll="false" target="validate-db-upgrade-schemas">
+										<param name="fresh.db.schema" value="lpartition_${baker.company.id}" />
+										<param name="upgraded.db.schema" value="lpartition_${able.company.id}" />
+									</antcall>
+
+									<antcall inheritAll="false" target="validate-db-upgrade-schemas">
+										<param name="fresh.db.schema" value="lportal" />
+										<param name="upgraded.db.schema" value="lportal" />
+									</antcall>
+
+									<!-- Fail if any comparison found differences -->
+
+									<local name="schema.compare.output.partition" />
+
+									<loadfile
+										failonerror="false"
+										property="schema.compare.output.partition"
+										srcFile="${selenium.output.dir.name}/lpartition_${able.company.id}-lpartition_${baker.company.id}-validate-db-schemas.txt"
+									/>
+
+									<fail message="DB partition schema comparison failed for able/baker partitions. See ${selenium.output.dir.name} for details.">
+										<condition>
+											<not>
+												<contains string="${schema.compare.output.partition}" substring="Database schemas match" />
+											</not>
+										</condition>
+									</fail>
+
+									<local name="schema.compare.output.main" />
+
+									<loadfile
+										failonerror="false"
+										property="schema.compare.output.main"
+										srcFile="${selenium.output.dir.name}/lportal-lportal-validate-db-schemas.txt"
+									/>
+
+									<fail message="DB partition schema comparison failed for lportal. See ${selenium.output.dir.name} for details.">
+										<condition>
+											<not>
+												<contains string="${schema.compare.output.main}" substring="Database schemas match" />
+											</not>
+										</condition>
+									</fail>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-latest-7413" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-compare-schemas-7413-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+		<attribute default="data-archive-portal-partition" name="data.archive.type" />
+		<attribute default="7.4.13.u33" name="portal.version" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" rebuild.database="false" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<local name="db.partition.compare.state.file" />
+
+							<property location="modules/test/playwright/test-results/db-partition-state.json" name="db.partition.compare.state.file" />
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Load data archive (7.4.13.u33 with company IDs 44913 and 42638) -->
+
+									<echo append="true" file="portal-impl/src/portal-ext.properties">
+upgrade.database.auto.run=true</echo>
+
+									<antcall target="rebuild-legacy-database">
+										<param name="data.archive.type" value="@{data.archive.type}" />
+										<param name="database.partition.enabled" value="true" />
+										<param name="portal.version" value="@{portal.version}" />
+										<param name="skip.get.testcase.database.properties" value="true" />
+									</antcall>
+
+									<!-- Start upgraded bundle against archived data — auto-upgrade runs -->
+
+									<antcall inheritAll="false" target="start-app-server" />
+
+									<antcall inheritAll="false" target="stop-app-server" />
+
+									<!-- Export upgraded schemas from the 7.4.13 archive (fixed company IDs) -->
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="upgraded" />
+										<param name="database.schema.name" value="lpartition_42638" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="upgraded" />
+										<param name="database.schema.name" value="lpartition_44913" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="upgraded" />
+										<param name="database.schema.name" value="lportal" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<!-- Rebuild main DB and drop the archived partition schemas -->
+
+									<antcall inheritAll="false" target="rebuild-database">
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<get-database-property property.name="database.host" />
+									<get-database-property property.name="database.password" />
+									<get-database-property property.name="database.username" />
+
+									<if>
+										<equals arg1="@{database.type}" arg2="mysql" />
+										<then>
+											<exec executable="docker" failonerror="true">
+												<arg value="exec" />
+												<arg value="${database.host}" />
+												<arg value="mysql" />
+												<arg value="--execute=DROP DATABASE IF EXISTS lpartition_42638; DROP DATABASE IF EXISTS lpartition_44913;" />
+												<arg value="--host=127.0.0.1" />
+												<arg value="--password=${database.password}" />
+												<arg value="--user=${database.username}" />
+											</exec>
+										</then>
+										<elseif>
+											<equals arg1="@{database.type}" arg2="postgresql" />
+											<then>
+												<exec executable="docker" failonerror="true">
+													<arg value="exec" />
+													<arg value="${database.host}" />
+													<arg value="/bin/bash" />
+													<arg value="-c" />
+													<arg value="PGPASSWORD=${database.password} psql --command='DROP SCHEMA IF EXISTS lpartition_42638 CASCADE; DROP SCHEMA IF EXISTS lpartition_44913 CASCADE;' --username=${database.username} lportal" />
+												</exec>
+											</then>
+										</elseif>
+									</if>
+
+									<!-- Phase: create two fresh virtual instances and record their IDs -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-7413" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.compare-7413
+									</docker-execute>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-7413" />
+									</exec>
+
+									<!-- Read fresh company IDs written by the Playwright phase -->
+
+									<local name="compare.state.json" />
+
+									<loadfile
+										property="compare.state.json"
+										srcFile="${db.partition.compare.state.file}"
+									/>
+
+									<local name="able.company.id" />
+
+									<propertyregex
+										input="${compare.state.json}"
+										property="able.company.id"
+										regexp="&quot;ableCompanyId&quot;\s*:\s*([0-9]+)"
+										select="\1"
+									/>
+
+									<local name="baker.company.id" />
+
+									<propertyregex
+										input="${compare.state.json}"
+										property="baker.company.id"
+										regexp="&quot;bakerCompanyId&quot;\s*:\s*([0-9]+)"
+										select="\1"
+									/>
+
+									<!-- Export fresh schemas using the IDs assigned to the new instances -->
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="fresh" />
+										<param name="database.schema.name" value="lpartition_${able.company.id}" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="fresh" />
+										<param name="database.schema.name" value="lpartition_${baker.company.id}" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<antcall inheritAll="false" target="export-database-schema">
+										<param name="database.file.prefix" value="fresh" />
+										<param name="database.schema.name" value="lportal" />
+										<param name="database.type" value="@{database.type}" />
+									</antcall>
+
+									<!-- Compare: fresh vs upgraded (able↔44913, baker↔42638, lportal↔lportal) -->
+
+									<antcall inheritAll="false" target="validate-db-upgrade-schemas">
+										<param name="fresh.db.schema" value="lpartition_${able.company.id}" />
+										<param name="upgraded.db.schema" value="lpartition_44913" />
+									</antcall>
+
+									<antcall inheritAll="false" target="validate-db-upgrade-schemas">
+										<param name="fresh.db.schema" value="lpartition_${baker.company.id}" />
+										<param name="upgraded.db.schema" value="lpartition_42638" />
+									</antcall>
+
+									<antcall inheritAll="false" target="validate-db-upgrade-schemas">
+										<param name="fresh.db.schema" value="lportal" />
+										<param name="upgraded.db.schema" value="lportal" />
+									</antcall>
+
+									<!-- Fail if any comparison found differences -->
+
+									<local name="schema.compare.output" />
+
+									<loadfile
+										failonerror="false"
+										property="schema.compare.output"
+										srcFile="${selenium.output.dir.name}/lpartition_44913-lpartition_${able.company.id}-validate-db-schemas.txt"
+									/>
+
+									<fail message="DB partition schema comparison failed for able/44913. See ${selenium.output.dir.name} for details.">
+										<condition>
+											<not>
+												<contains string="${schema.compare.output}" substring="Database schemas match" />
+											</not>
+										</condition>
+									</fail>
+
+									<local name="schema.compare.output.baker" />
+
+									<loadfile
+										failonerror="false"
+										property="schema.compare.output.baker"
+										srcFile="${selenium.output.dir.name}/lpartition_42638-lpartition_${baker.company.id}-validate-db-schemas.txt"
+									/>
+
+									<fail message="DB partition schema comparison failed for baker/42638. See ${selenium.output.dir.name} for details.">
+										<condition>
+											<not>
+												<contains string="${schema.compare.output.baker}" substring="Database schemas match" />
+											</not>
+										</condition>
+									</fail>
+
+									<local name="schema.compare.output.main" />
+
+									<loadfile
+										failonerror="false"
+										property="schema.compare.output.main"
+										srcFile="${selenium.output.dir.name}/lportal-lportal-validate-db-schemas.txt"
+									/>
+
+									<fail message="DB partition schema comparison failed for lportal. See ${selenium.output.dir.name} for details.">
+										<condition>
+											<not>
+												<contains string="${schema.compare.output.main}" substring="Database schemas match" />
+											</not>
+										</condition>
+									</fail>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.compare-7413" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-import-postgresql-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="mysql" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="mysql" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<local name="db.partition.state.file" />
+
+							<property location="modules/test/playwright/test-results/db-partition-state.json" name="db.partition.state.file" />
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Phase 1: start server on MySQL, create www.able.com partition -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="mysql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase1 --grep "ImportPartitionedDatabaseToPostgreSQL"
+									</docker-execute>
+
+									<!-- Offline bridge: export partition while server is UP -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/export_partition.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="mysql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<antcall inheritall="false" target="stop-app-server" />
+
+									<!-- Start PostgreSQL Docker and rebuild schema -->
+
+									<antcall inheritall="false" target="start-docker-database">
+										<param name="database.type" value="postgresql" />
+									</antcall>
+
+									<antcall inheritall="false" target="rebuild-database">
+										<param name="database.type" value="postgresql" />
+										<param name="skip.delete.liferay.home" value="true" />
+									</antcall>
+
+									<!-- Run db-migration-importer: copy MySQL data to PostgreSQL -->
+
+									<get-database-property property.name="database.host" />
+									<get-database-property property.name="database.password" />
+									<get-database-property property.name="database.username" />
+
+									<ant antfile="modules/util/portal-tools-db-migration-importer-test/src/testFunctional/ant/build-test-db-migration-importer.xml" inheritAll="false" target="import-database">
+										<property name="path" value="${liferay.home}" />
+										<property name="source.jdbc.url" value="${jdbc.default.url}" />
+										<property name="source.password" value="${jdbc.default.password}" />
+										<property name="source.user" value="${jdbc.default.username}" />
+										<property name="target.jdbc.url" value="${database.postgresql.url}" />
+										<property name="target.password" value="${database.postgresql.password}" />
+										<property name="target.user" value="${database.postgresql.username}" />
+									</ant>
+
+									<!-- Switch portal-ext.properties to PostgreSQL -->
+
+									<propertyfile file="${liferay.home}/portal-ext.properties">
+										<entry key="jdbc.default.driver.class.name" value="${database.postgresql.driver}" />
+										<entry key="jdbc.default.password" value="${database.postgresql.password}" />
+										<entry key="jdbc.default.url" value="${database.postgresql.url}" />
+										<entry key="jdbc.default.username" value="${database.postgresql.username}" />
+									</propertyfile>
+
+									<antcall inheritall="false" target="start-app-server-preserve-liferay-home" />
+
+									<!-- Import partition in PostgreSQL context -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/import_partition.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<!-- Phase 2: verify default instance and virtual instance on PostgreSQL -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="postgresql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase2 --grep "ImportPartitionedDatabaseToPostgreSQL"
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="postgresql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<antcall inheritall="false" target="stop-docker-database">
+										<param name="database.type" value="postgresql" />
+									</antcall>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-nonpartitioned-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<!-- Start with DB partitioning disabled (non-partitioned source database) -->
+
+							<propertyfile file="${liferay.home}/portal-ext.properties">
+								<entry key="database.partition.enabled" value="false" />
+							</propertyfile>
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<local name="db.partition.state.file" />
+
+							<property location="modules/test/playwright/test-results/db-partition-state.json" name="db.partition.state.file" />
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Phase 1: start server, add virtual instance, upload DM document -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase1 --grep "ExportNonPartitioned"
+									</docker-execute>
+
+									<!-- Offline bridge: export partition while server is UP -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/export_partition.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<!-- Delete the virtual instance while the server is still UP -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/delete_instance.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<antcall inheritall="false" target="stop-app-server" />
+
+									<!-- Enable DB partitioning for the fresh database -->
+
+									<propertyfile file="${liferay.home}/portal-ext.properties">
+										<entry key="database.partition.enabled" value="true" />
+									</propertyfile>
+
+									<!-- Drop lpartition_{id}: the export created a standalone copy; drop the original -->
+
+									<local name="db.partition.company.id" />
+									<local name="db.partition.state.json" />
+
+									<loadfile
+										property="db.partition.state.json"
+										srcFile="${db.partition.state.file}"
+									/>
+
+									<propertyregex
+										input="${db.partition.state.json}"
+										property="db.partition.company.id"
+										regexp="&quot;partitionCompanyId&quot;:\s*([0-9]+)"
+										select="\1"
+									/>
+
+									<fail message="Failed to parse db.partition.company.id from state file." unless="db.partition.company.id" />
+
+									<get-database-property property.name="database.host" />
+									<get-database-property property.name="database.password" />
+									<get-database-property property.name="database.username" />
+
+									<if>
+										<equals arg1="@{database.type}" arg2="mysql" />
+										<then>
+											<execute>
+												docker exec ${database.host} mysql --host=127.0.0.1 --password=${database.password} --user=${database.username} --execute="DROP SCHEMA IF EXISTS lpartition_${db.partition.company.id};"
+											</execute>
+										</then>
+										<elseif>
+											<equals arg1="@{database.type}" arg2="postgresql" />
+											<then>
+												<execute>
+													docker exec ${database.host} /bin/bash -c "PGPASSWORD=${database.password} psql --command='DROP SCHEMA IF EXISTS lpartition_${db.partition.company.id} CASCADE;' --username=${database.username}"
+												</execute>
+											</then>
+										</elseif>
+									</if>
+
+									<!-- Rebuild main DB with partitioning enabled -->
+
+									<antcall inheritall="false" target="rebuild-database">
+										<param name="database.type" value="@{database.type}" />
+										<param name="skip.delete.liferay.home" value="true" />
+									</antcall>
+
+									<antcall inheritall="false" target="start-app-server-preserve-liferay-home" />
+
+									<!-- Import partition: re-creates company record in the fresh partitioned DB -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/import_partition.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<!-- Phase 2: verify default instance and virtual instance after partition import -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase2 --grep "ExportNonPartitioned"
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<local name="db.partition.state.file" />
+
+							<property location="modules/test/playwright/test-results/db-partition-state.json" name="db.partition.state.file" />
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Phase 1: start server, add virtual instance, upload DM document -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase1 --grep "ExportAndAddDBPartition"
+									</docker-execute>
+
+									<!-- Offline bridge: export partition while server is UP -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/export_partition.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<antcall inheritall="false" target="stop-app-server" />
+
+									<!-- Drop lpartition_{id}: the export created a standalone copy; drop the original -->
+
+									<local name="db.partition.company.id" />
+									<local name="db.partition.state.json" />
+
+									<loadfile
+										property="db.partition.state.json"
+										srcFile="${db.partition.state.file}"
+									/>
+
+									<propertyregex
+										input="${db.partition.state.json}"
+										property="db.partition.company.id"
+										regexp="&quot;partitionCompanyId&quot;:\s*([0-9]+)"
+										select="\1"
+									/>
+
+									<fail message="Failed to parse db.partition.company.id from state file." unless="db.partition.company.id" />
+
+									<get-database-property property.name="database.host" />
+									<get-database-property property.name="database.password" />
+									<get-database-property property.name="database.username" />
+
+									<if>
+										<equals arg1="@{database.type}" arg2="mysql" />
+										<then>
+											<execute>
+												docker exec ${database.host} mysql --host=127.0.0.1 --password=${database.password} --user=${database.username} --execute="DROP SCHEMA IF EXISTS lpartition_${db.partition.company.id};"
+											</execute>
+										</then>
+										<elseif>
+											<equals arg1="@{database.type}" arg2="postgresql" />
+											<then>
+												<execute>
+													docker exec ${database.host} /bin/bash -c "PGPASSWORD=${database.password} psql --command='DROP SCHEMA IF EXISTS lpartition_${db.partition.company.id} CASCADE;' --username=${database.username}"
+												</execute>
+											</then>
+										</elseif>
+									</if>
+
+									<!-- Rebuild main DB (lpartition_{id} already dropped above) -->
+
+									<antcall inheritall="false" target="rebuild-database">
+										<param name="database.type" value="@{database.type}" />
+										<param name="skip.delete.liferay.home" value="true" />
+									</antcall>
+
+									<antcall inheritall="false" target="start-app-server-preserve-liferay-home" />
+
+									<!-- Import partition: re-creates company record in the fresh main DB -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/import_partition.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<!-- Phase 2: verify default instance and virtual instance after partition import -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase2 --grep "ExportAndAddDBPartition"
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-restart-case-insensitive-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="mysql" />
+
+			<!-- Passed to start-docker-database-cmd via get-database-property -->
+
+			<var name="database.mysql.docker.database.options" value="--lower_case_table_names=1" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="mysql" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Phase 1: start server on MySQL (lower_case_table_names=1), create www.able.com partition -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="mysql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase1 --grep "CaseInsensitiveDatabase"
+									</docker-execute>
+
+									<!-- Offline bridge: stop and restart server (preserve data) -->
+
+									<antcall inheritall="false" target="stop-app-server" />
+
+									<antcall inheritall="false" target="start-app-server-preserve-liferay-home" />
+
+									<!-- Phase 2: verify www.able.com is still accessible on case-insensitive DB -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="mysql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase2 --grep "CaseInsensitiveDatabase"
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="mysql" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-restart-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Phase 1: start server, create www.able.com partition -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase1 --grep "AfterRestart —"
+									</docker-execute>
+
+									<!-- Offline bridge: stop and restart server (preserve data) -->
+
+									<antcall inheritall="false" target="stop-app-server" />
+
+									<antcall inheritall="false" target="start-app-server-preserve-liferay-home" />
+
+									<!-- Phase 2: verify www.able.com is still accessible -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase2 --grep "AfterRestart —"
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-scheduler-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" stop.app.server="true">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<trycatch property="exception.message">
+								<try>
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.scheduler" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.scheduler
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.scheduler" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-schema-validator-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" stop.app.server="true">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<trycatch property="exception.message">
+								<try>
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.main" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.main --grep "ExecuteSchemaValidator"
+									</docker-execute>
+
+									<!-- Run schema validator against the partition schemas -->
+
+									<antcall target="validate-db-partition-schemas">
+										<param name="schema.name.prefix" value="lpartition_" />
+									</antcall>
+
+									<!-- Assert validation passed -->
+
+									<local name="db.partition.validate.output" />
+
+									<loadfile
+										property="db.partition.validate.output"
+										srcFile="${liferay.home}/validateoutput.txt"
+									/>
+
+									<local name="db.partition.validation.passed" />
+
+									<condition property="db.partition.validation.passed">
+										<contains string="${db.partition.validate.output}" substring="Validation passed" />
+									</condition>
+
+									<fail message="DB partition schema validation failed. See ${liferay.home}/validateoutput.txt for details." unless="db.partition.validation.passed" />
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.main" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
+								</finally>
+							</trycatch>
+						</test-action>
+					</database-test-run-test>
+				</test-action>
+
+				<test-set-up>
+					<setup-test-environment />
+				</test-set-up>
+			</run-batch-test>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="run-db-partition-upgraded-playwright-test">
+		<attribute default="tomcat" name="app.server.type" />
+		<attribute name="database.type" />
+
+		<sequential>
+			<get-java-jdk-bundle-type test.batch.name="${test.batch.name}" />
+			<get-java-jdk-bundle-version test.batch.name="${test.batch.name}" />
+			<var name="app.server.type" value="@{app.server.type}" />
+			<var name="database.type" value="@{database.type}" />
+
+			<run-batch-test>
+				<test-action>
+					<database-test-run-test database.type="@{database.type}" stop.app.server="false">
+						<test-action>
+							<delete dir="${liferay.home}/work" />
+
+							<antcall inheritAll="false" target="prepare-log4j-ext-xml" />
+
+							<generate-jdbc-properties properties.file="portal-impl/src/portal-ext.properties" />
+
+							<apply-portal-ext-properties />
+
+							<local name="execute.path" />
+							<local name="java.jdk.home" />
+							<local name="java.jdk.opts" />
+
+							<get-java-jdk-home type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+							<get-java-jdk-opts type="${java.jdk.bundle.type}" version="${java.jdk.bundle.version}" />
+
+							<propertyregex
+								input="${env.PATH}"
+								override="true"
+								property="execute.path"
+								regexp="/opt/java/(jdk|openjdk|zulu(-x64)?)[^/]+/bin"
+								replace="${java.jdk.home}/bin"
+							/>
+
+							<local name="db.partition.state.file" />
+
+							<property location="modules/test/playwright/test-results/db-partition-state.json" name="db.partition.state.file" />
+
+							<trycatch property="exception.message">
+								<try>
+
+									<!-- Phase 1: verify existing partitions from data archive, write state with both company IDs -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<start-docker-playwright />
+
+									<gradle-execute dir="${playwright.dir}" task="npmInstall" />
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase1 --grep "ExportAndAddDBPartitionWithUpgradedDB"
+									</docker-execute>
+
+									<!-- Offline bridge: export both partitions while server is UP -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/export_partitions.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase1" />
+									</exec>
+
+									<antcall inheritall="false" target="stop-app-server" />
+
+									<!-- Drop all partition schemas; exports created standalone copies -->
+
+									<get-database-property property.name="database.host" />
+									<get-database-property property.name="database.password" />
+									<get-database-property property.name="database.username" />
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/drop_partitions.sh" />
+										<env key="DATABASE_HOST" value="${database.host}" />
+										<env key="DATABASE_PASSWORD" value="${database.password}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="DATABASE_USERNAME" value="${database.username}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<!-- Rebuild main DB -->
+
+									<antcall inheritall="false" target="rebuild-database">
+										<param name="database.type" value="@{database.type}" />
+										<param name="skip.delete.liferay.home" value="true" />
+									</antcall>
+
+									<antcall inheritall="false" target="start-app-server-preserve-liferay-home" />
+
+									<!-- Import both partitions into the fresh database -->
+
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/tests/db-partition/env/import_partitions.sh" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="STATE_FILE" value="${db.partition.state.file}" />
+									</exec>
+
+									<!-- Phase 2: verify default instance and both virtual instances -->
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+										<arg value="modules/test/playwright/env/set_up.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<docker-execute container="${playwright.docker.host}">
+										cd ${playwright.dir}
+
+										npx playwright test --project=db-partition.phase2 --grep "ExportAndAddDBPartitionWithUpgradedDB"
+									</docker-execute>
+								</try>
+								<catch>
+									<echo>${exception.message}</echo>
+								</catch>
+								<finally>
+									<stop-docker-playwright />
+
+									<exec executable="/bin/bash" timeout="${test.class.playwright.teardown.timeout}">
+										<arg value="modules/test/playwright/env/tear_down.sh" />
+										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
+										<env key="DATABASE_TYPE" value="@{database.type}" />
+										<env key="JAVA_HOME" value="${java.jdk.home}" />
+										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
+										<env key="LIFERAY_HOME" value="${liferay.home}" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
+										<env key="PATH" value="${execute.path}" />
+										<env key="PLAYWRIGHT_PROJECT_NAME" value="db-partition.phase2" />
+									</exec>
+
+									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
+
+									<print-docker-database-logs />
 								</finally>
 							</trycatch>
 						</test-action>
@@ -3671,7 +5834,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 										<env key="JAVA_HOME" value="${java.jdk.home}" />
 										<env key="JAVA_OPTS" value="${java.jdk.opts}" />
 										<env key="LIFERAY_HOME" value="${liferay.home}" />
-										<env key="LIFERAY_PORTAL_URL" value="http://${env.HOSTNAME}:8080" />
+										<env key="LIFERAY_PORTAL_URL" value="http://${env.NODE_NAME}:8080" />
 										<env key="PATH" value="${execute.path}" />
 										<env key="PLAYWRIGHT_PROJECT_NAME" value="${playwright.project.name}" />
 									</exec>
@@ -9760,6 +11923,90 @@ ${output.content}</echo>
 				<setup-test-environment />
 			</test-set-up>
 		</run-batch-test>
+	</target>
+
+	<target name="playwright-js-db-import-postgresql-tomcat101-mysql84">
+		<run-db-import-postgresql-playwright-test />
+	</target>
+
+	<target name="playwright-js-db-partition-cluster-tomcat101-mysql84">
+		<run-db-partition-cluster-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-cluster-tomcat101-postgresql163">
+		<run-db-partition-cluster-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-compare-latest-7413-tomcat101-mysql84">
+		<run-db-partition-compare-latest-7413-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-compare-latest-7413-tomcat101-postgresql163">
+		<run-db-partition-compare-latest-7413-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-compare-schemas-7413-tomcat101-mysql84">
+		<run-db-partition-compare-schemas-7413-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-compare-schemas-7413-tomcat101-postgresql163">
+		<run-db-partition-compare-schemas-7413-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-import-postgresql-tomcat101-mysql84">
+		<run-db-partition-import-postgresql-playwright-test />
+	</target>
+
+	<target name="playwright-js-db-partition-nonpartitioned-tomcat101-mysql84">
+		<run-db-partition-nonpartitioned-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-nonpartitioned-tomcat101-postgresql163">
+		<run-db-partition-nonpartitioned-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-restart-case-insensitive-tomcat101-mysql84">
+		<run-db-partition-restart-case-insensitive-playwright-test />
+	</target>
+
+	<target name="playwright-js-db-partition-restart-tomcat101-mysql84">
+		<run-db-partition-restart-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-restart-tomcat101-postgresql163">
+		<run-db-partition-restart-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-scheduler-tomcat101-mysql84">
+		<run-db-partition-scheduler-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-scheduler-tomcat101-postgresql163">
+		<run-db-partition-scheduler-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-schema-validator-tomcat101-mysql84">
+		<run-db-partition-schema-validator-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-schema-validator-tomcat101-postgresql163">
+		<run-db-partition-schema-validator-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-tomcat101-mysql84">
+		<run-db-partition-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-tomcat101-postgresql163">
+		<run-db-partition-playwright-test database.type="postgresql" />
+	</target>
+
+	<target name="playwright-js-db-partition-upgraded-tomcat101-mysql84">
+		<run-db-partition-upgraded-playwright-test database.type="mysql" />
+	</target>
+
+	<target name="playwright-js-db-partition-upgraded-tomcat101-postgresql163">
+		<run-db-partition-upgraded-playwright-test database.type="postgresql" />
 	</target>
 
 	<target name="playwright-js-smoke-jboss80-postgresql155">

--- a/build-test.xml
+++ b/build-test.xml
@@ -15648,7 +15648,14 @@ cluster.link.bind.addr["cluster-link-udp"]=127.0.0.1</echo>
 					</else>
 				</if>
 
-				<get-testcase-property property.name="database.partition.enabled" />
+				<if>
+					<not>
+						<isset property="skip.get.testcase.database.properties" />
+					</not>
+					<then>
+						<get-testcase-property property.name="database.partition.enabled" />
+					</then>
+				</if>
 
 				<if>
 					<equals arg1="${database.partition.enabled}" arg2="true" />

--- a/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminUserApiHelper.ts
@@ -67,7 +67,7 @@ export type TPostalAddresses = {
 
 export type TPermission = {
 	actionIds: string[];
-	primaryKey: string;
+	primaryKey: number | string;
 	resourceName: string;
 	scope: number;
 };

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesCompanyApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesCompanyApiHelper.ts
@@ -7,7 +7,7 @@ import {liferayConfig} from '../../liferay.config';
 import {ApiHelpers} from '../ApiHelpers';
 
 type Company = {
-	companyId: number;
+	companyId: number | string;
 };
 
 export class JSONWebServicesCompanyApiHelper {

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesCompanyApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesCompanyApiHelper.ts
@@ -7,7 +7,7 @@ import {liferayConfig} from '../../liferay.config';
 import {ApiHelpers} from '../ApiHelpers';
 
 type Company = {
-	companyId: string;
+	companyId: number;
 };
 
 export class JSONWebServicesCompanyApiHelper {

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesGroupApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesGroupApiHelper.ts
@@ -37,10 +37,10 @@ export class JSONWebServicesGroupApiHelper {
 		);
 	}
 
-	async getCompanyGroup(companyId: string): Promise<Group> {
+	async getCompanyGroup(companyId: number | string): Promise<Group> {
 		const urlSearchParams = new URLSearchParams();
 
-		urlSearchParams.append('companyId', companyId);
+		urlSearchParams.append('companyId', String(companyId));
 
 		return this.apiHelpers.post(
 			`${liferayConfig.environment.baseUrl}${this.basePath}/get-company-group`,
@@ -52,10 +52,13 @@ export class JSONWebServicesGroupApiHelper {
 		);
 	}
 
-	async getGroupByKey(companyId: string, groupKey: string): Promise<Group> {
+	async getGroupByKey(
+		companyId: number | string,
+		groupKey: string
+	): Promise<Group> {
 		const urlSearchParams = new URLSearchParams();
 
-		urlSearchParams.append('companyId', companyId);
+		urlSearchParams.append('companyId', String(companyId));
 		urlSearchParams.append('groupKey', groupKey);
 
 		return this.apiHelpers.post(

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutSetPrototypeApiHelper.ts
@@ -48,7 +48,7 @@ export class JSONWebServicesLayoutSetPrototypeApiHelper {
 				'liferay.com'
 			);
 
-		urlSearchParams.append('companyId', company.companyId);
+		urlSearchParams.append('companyId', String(company.companyId));
 
 		return this.apiHelpers.post(
 			`${liferayConfig.environment.baseUrl}${this.basePath}/get-layout-set-prototypes`,

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesResourcePermissionApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesResourcePermissionApiHelper.ts
@@ -75,16 +75,16 @@ export class JSONWebServicesResourcePermissionApiHelper {
 
 	async setIndividualResourcePermissions(
 		actionIds: Array<string>,
-		companyId: string,
-		groupId: string,
+		companyId: number | string,
+		groupId: number | string,
 		name: string,
 		primKey: string,
 		roleId: string
 	) {
 		const urlSearchParams = new URLSearchParams();
 
-		urlSearchParams.append('groupId', groupId);
-		urlSearchParams.append('companyId', companyId);
+		urlSearchParams.append('groupId', String(groupId));
+		urlSearchParams.append('companyId', String(companyId));
 		urlSearchParams.append('name', name);
 		urlSearchParams.append('primKey', primKey);
 		urlSearchParams.append('roleId', roleId);

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -65,6 +65,13 @@ import {config as contactsWebConfig} from './tests/contacts-web/main/config';
 import {config as contentDashboardWebConfig} from './tests/content-dashboard-web/main/config';
 import {config as cookiesBannerWebConfig} from './tests/cookies-banner-web/main/config';
 import {config as dataCleanupConfig} from './tests/data-cleanup/main/config';
+import {config as dbPartitionClusterConfig} from './tests/db-partition/cluster/config';
+import {config as dbPartitionCompare7413Config} from './tests/db-partition/compare-7413/config';
+import {config as dbPartitionCompareLatest7413Config} from './tests/db-partition/compare-latest-7413/config';
+import {config as dbPartitionConfig} from './tests/db-partition/main/config';
+import {config as dbPartitionPhase1Config} from './tests/db-partition/phase1/config';
+import {config as dbPartitionPhase2Config} from './tests/db-partition/phase2/config';
+import {config as dbPartitionSchedulerConfig} from './tests/db-partition/scheduler/config';
 import {config as depotWebConfig} from './tests/depot-web/main/config';
 import {config as designLibraryWebConfig} from './tests/design-library-web/main/config';
 import {config as dispatchWebConfig} from './tests/dispatch-web/main/config';
@@ -294,6 +301,13 @@ export default defineConfig({
 		contentDashboardWebConfig,
 		cookiesBannerWebConfig,
 		customerConfig,
+		dbPartitionClusterConfig,
+		dbPartitionCompare7413Config,
+		dbPartitionCompareLatest7413Config,
+		dbPartitionConfig,
+		dbPartitionPhase1Config,
+		dbPartitionPhase2Config,
+		dbPartitionSchedulerConfig,
 		depotWebConfig,
 		designLibraryWebConfig,
 		dispatchWebConfig,

--- a/modules/test/playwright/tests/db-partition/cluster/config.ts
+++ b/modules/test/playwright/tests/db-partition/cluster/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'db-partition.cluster',
+	testDir: 'tests/db-partition/cluster',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/db-partition/cluster/dbPartitionCluster.spec.ts
+++ b/modules/test/playwright/tests/db-partition/cluster/dbPartitionCluster.spec.ts
@@ -141,12 +141,12 @@ test(
 
 			const serverAdminPage = new ServerAdministrationPage(secondaryPage);
 
-			await serverAdminPage.goto();
-			await serverAdminPage.executeScript(GROOVY_SCRIPT);
+			await expect(async () => {
+				await serverAdminPage.goto();
+				await serverAdminPage.executeScript(GROOVY_SCRIPT);
 
-			await expect(async () =>
-				expect(await serverAdminPage.getScriptOutput()).toContain('1')
-			).toPass({timeout: 30000});
+				expect(await serverAdminPage.getScriptOutput()).toContain('1');
+			}).toPass({timeout: 30000});
 
 			const instance =
 				await apiHelpers.headlessPortalInstance.addVirtualInstance({

--- a/modules/test/playwright/tests/db-partition/cluster/dbPartitionCluster.spec.ts
+++ b/modules/test/playwright/tests/db-partition/cluster/dbPartitionCluster.spec.ts
@@ -1,0 +1,190 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {ServerAdministrationPage} from '../../../pages/server-admin-web/ServerAdministrationPage';
+import {performLoginViaApi} from '../../../utils/performLogin';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+const GROOVY_SCRIPT = `
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
+import java.util.concurrent.atomic.AtomicInteger;
+
+AtomicInteger total = new AtomicInteger();
+
+DBPartitionUtil.forEachCompanyId({companyId -> total.incrementAndGet()});
+
+out.println(total.get());
+`.trim();
+
+test(
+	'canAddCompanyWithCluster',
+	{tag: '@LPD-91814'},
+	async ({apiHelpers, browser}) => {
+		const ableBaseUrl = liferayConfig.environment.baseUrl.replace(
+			'localhost',
+			ABLE_HOST
+		);
+
+		const instance =
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+		try {
+			const instancePage = await browser.newPage({
+				baseURL: ableBaseUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableBaseUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+			}
+		}
+		finally {
+			await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+				instance.id
+			);
+		}
+	}
+);
+
+test(
+	'canAddCompanyWithClusterSecondNode',
+	{tag: '@LPD-91814'},
+	async ({apiHelpers, browser}) => {
+		const secondaryBaseUrl = liferayConfig.environment.baseUrl.replace(
+			'8080',
+			'9080'
+		);
+
+		const ableSecondaryUrl = secondaryBaseUrl.replace(
+			'localhost',
+			ABLE_HOST
+		);
+
+		const instance =
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+		try {
+			const instancePage = await browser.newPage({
+				baseURL: ableSecondaryUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableSecondaryUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+			}
+		}
+		finally {
+			await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+				instance.id
+			);
+		}
+	}
+);
+
+test(
+	'portalInstanceCreationDeletionUpdatesDBPartitionUtilWithCluster',
+	{tag: '@LPD-91814'},
+	async ({apiHelpers, browser}) => {
+		const secondaryBaseUrl = liferayConfig.environment.baseUrl.replace(
+			'8080',
+			'9080'
+		);
+
+		const secondaryPage = await browser.newPage({
+			baseURL: secondaryBaseUrl,
+		});
+
+		let instanceId: number | null = null;
+
+		try {
+			await performLoginViaApi({
+				loginUrl: secondaryBaseUrl,
+				page: secondaryPage,
+				screenName: 'test',
+			});
+
+			const serverAdminPage = new ServerAdministrationPage(secondaryPage);
+
+			await serverAdminPage.goto();
+			await serverAdminPage.executeScript(GROOVY_SCRIPT);
+
+			await expect(async () =>
+				expect(await serverAdminPage.getScriptOutput()).toContain('1')
+			).toPass({timeout: 30000});
+
+			const instance =
+				await apiHelpers.headlessPortalInstance.addVirtualInstance({
+					domain: ABLE_HOST,
+					portalInstanceId: ABLE_HOST,
+					virtualHost: ABLE_HOST,
+				});
+
+			instanceId = instance.id;
+
+			await expect(async () => {
+				await serverAdminPage.goto();
+				await serverAdminPage.executeScript(GROOVY_SCRIPT);
+
+				expect(await serverAdminPage.getScriptOutput()).toContain('2');
+			}).toPass({timeout: 120000});
+
+			await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+				instance.id
+			);
+
+			instanceId = null;
+
+			await expect(async () => {
+				await serverAdminPage.goto();
+				await serverAdminPage.executeScript(GROOVY_SCRIPT);
+
+				expect(await serverAdminPage.getScriptOutput()).toContain('1');
+			}).toPass({timeout: 120000});
+		}
+		finally {
+			await secondaryPage.close();
+
+			if (instanceId !== null) {
+				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+					instanceId
+				);
+			}
+		}
+	}
+);

--- a/modules/test/playwright/tests/db-partition/cluster/env/com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config
+++ b/modules/test/playwright/tests/db-partition/cluster/env/com.liferay.portal.search.elasticsearch8.configuration.ElasticsearchConfiguration.config
@@ -1,0 +1,3 @@
+networkHostAddresses="http://%LIFERAY_DOCKER_NETWORK_NAME%:9201"
+operationMode="REMOTE"
+productionModeEnabled=B"true"

--- a/modules/test/playwright/tests/db-partition/cluster/env/portal-ext.properties
+++ b/modules/test/playwright/tests/db-partition/cluster/env/portal-ext.properties
@@ -1,0 +1,2 @@
+feature.flag.LPD-11342=true
+virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com

--- a/modules/test/playwright/tests/db-partition/cluster/env/set_up.sh
+++ b/modules/test/playwright/tests/db-partition/cluster/env/set_up.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/../../../../env/common.sh
+
+cluster_set_up 1

--- a/modules/test/playwright/tests/db-partition/cluster/env/set_up.sh
+++ b/modules/test/playwright/tests/db-partition/cluster/env/set_up.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/../../../../env/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../../env/common.sh"
 
 cluster_set_up 1

--- a/modules/test/playwright/tests/db-partition/cluster/env/tear_down.sh
+++ b/modules/test/playwright/tests/db-partition/cluster/env/tear_down.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source $(dirname ${BASH_SOURCE[0]})/../../../../env/common.sh
+
+stop_additional_bundles 1

--- a/modules/test/playwright/tests/db-partition/cluster/test.properties
+++ b/modules/test/playwright/tests/db-partition/cluster/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Partitioning

--- a/modules/test/playwright/tests/db-partition/compare-7413/compareSchemas7413.spec.ts
+++ b/modules/test/playwright/tests/db-partition/compare-7413/compareSchemas7413.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+const BAKER_HOST = 'www.baker.com';
+
+test.describe.serial('ComparePartitionedUpgradedAndFreshDBSchemas7413', () => {
+	test(
+		'Create virtual instances for schema comparison',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: BAKER_HOST,
+				portalInstanceId: BAKER_HOST,
+				virtualHost: BAKER_HOST,
+			});
+
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const bakerCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					BAKER_HOST
+				);
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify(
+					{
+						ableCompanyId: ableCompany.companyId,
+						bakerCompanyId: bakerCompany.companyId,
+					},
+					null,
+					2
+				)
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/compare-7413/compareSchemas7413.spec.ts
+++ b/modules/test/playwright/tests/db-partition/compare-7413/compareSchemas7413.spec.ts
@@ -21,27 +21,23 @@ test.describe.serial('ComparePartitionedUpgradedAndFreshDBSchemas7413', () => {
 		'Create virtual instances for schema comparison',
 		{tag: '@LPD-91814'},
 		async ({apiHelpers}) => {
-			await apiHelpers.headlessPortalInstance.addVirtualInstance({
-				domain: ABLE_HOST,
-				portalInstanceId: ABLE_HOST,
-				virtualHost: ABLE_HOST,
-			});
+			await Promise.all([
+				apiHelpers.headlessPortalInstance.addVirtualInstance({
+					domain: ABLE_HOST,
+					portalInstanceId: ABLE_HOST,
+					virtualHost: ABLE_HOST,
+				}),
+				apiHelpers.headlessPortalInstance.addVirtualInstance({
+					domain: BAKER_HOST,
+					portalInstanceId: BAKER_HOST,
+					virtualHost: BAKER_HOST,
+				}),
+			]);
 
-			await apiHelpers.headlessPortalInstance.addVirtualInstance({
-				domain: BAKER_HOST,
-				portalInstanceId: BAKER_HOST,
-				virtualHost: BAKER_HOST,
-			});
-
-			const ableCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
-					ABLE_HOST
-				);
-
-			const bakerCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
-					BAKER_HOST
-				);
+			const [ableCompany, bakerCompany] = await Promise.all([
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(ABLE_HOST),
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(BAKER_HOST),
+			]);
 
 			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
 

--- a/modules/test/playwright/tests/db-partition/compare-7413/config.ts
+++ b/modules/test/playwright/tests/db-partition/compare-7413/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'db-partition.compare-7413',
+	testDir: 'tests/db-partition/compare-7413',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/db-partition/compare-7413/env/portal-ext.properties
+++ b/modules/test/playwright/tests/db-partition/compare-7413/env/portal-ext.properties
@@ -1,0 +1,1 @@
+upgrade.database.auto.run=false

--- a/modules/test/playwright/tests/db-partition/compare-7413/test.properties
+++ b/modules/test/playwright/tests/db-partition/compare-7413/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Partitioning

--- a/modules/test/playwright/tests/db-partition/compare-latest-7413/compareLatest7413Schemas.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/compare-latest-7413/compareLatest7413Schemas.phase1.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+test.describe
+	.serial('CompareLatest7413PartitionedUpgradedAndFreshDBSchemas — Phase 1', () => {
+	test(
+		'Create www.able.com partition on released bundle',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify({ableCompanyId: ableCompany.companyId}, null, 2)
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/compare-latest-7413/compareLatest7413Schemas.phase3.spec.ts
+++ b/modules/test/playwright/tests/db-partition/compare-latest-7413/compareLatest7413Schemas.phase3.spec.ts
@@ -1,0 +1,51 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const BAKER_HOST = 'www.baker.com';
+
+test.describe
+	.serial('CompareLatest7413PartitionedUpgradedAndFreshDBSchemas — Phase 3', () => {
+	test(
+		'Create www.baker.com partition on fresh server',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: BAKER_HOST,
+				portalInstanceId: BAKER_HOST,
+				virtualHost: BAKER_HOST,
+			});
+
+			const bakerCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					BAKER_HOST
+				);
+
+			const existingState = fs.existsSync(STATE_FILE)
+				? JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'))
+				: {};
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify(
+					{
+						...existingState,
+						bakerCompanyId: bakerCompany.companyId,
+					},
+					null,
+					2
+				)
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/compare-latest-7413/config.ts
+++ b/modules/test/playwright/tests/db-partition/compare-latest-7413/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'db-partition.compare-latest-7413',
+	testDir: 'tests/db-partition/compare-latest-7413',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/db-partition/compare-latest-7413/env/portal-ext.properties
+++ b/modules/test/playwright/tests/db-partition/compare-latest-7413/env/portal-ext.properties
@@ -1,0 +1,1 @@
+upgrade.database.auto.run=false

--- a/modules/test/playwright/tests/db-partition/compare-latest-7413/test.properties
+++ b/modules/test/playwright/tests/db-partition/compare-latest-7413/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Partitioning

--- a/modules/test/playwright/tests/db-partition/env/db_partition_common.sh
+++ b/modules/test/playwright/tests/db-partition/env/db_partition_common.sh
@@ -52,7 +52,7 @@ function read_partition_company_id {
 
 	local company_id
 
-	company_id=$(grep -oP '"partitionCompanyId":\s*\K[0-9]+' "${STATE_FILE}")
+	company_id=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${STATE_FILE}', 'utf8')).partitionCompanyId)")
 
 	if [[ -z "${company_id}" ]]
 	then
@@ -81,7 +81,7 @@ function read_partition_company_ids {
 
 	local company_ids
 
-	company_ids=$(grep -oP '"partitionCompanyIds":\s*\[\K[0-9, ]+' "${STATE_FILE}" | grep -oP '[0-9]+')
+	company_ids=$(node -e "console.log(JSON.parse(require('fs').readFileSync('${STATE_FILE}', 'utf8')).partitionCompanyIds.join('\n'))")
 
 	if [[ -z "${company_ids}" ]]
 	then

--- a/modules/test/playwright/tests/db-partition/env/db_partition_common.sh
+++ b/modules/test/playwright/tests/db-partition/env/db_partition_common.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+# Shared helpers for export_partition.sh and import_partition.sh.
+#
+# Required env vars:
+# LIFERAY_HOME — path to the Liferay bundle (e.g. /opt/liferay)
+# STATE_FILE — path to the JSON file written by the Phase 1 Playwright spec
+# (default: modules/test/playwright/test-results/db-partition-state.json)
+
+STATE_FILE=${STATE_FILE:-modules/test/playwright/test-results/db-partition-state.json}
+
+function poll_config_deletion {
+	local config_file=${1}
+	local operation=${2}
+
+	echo "Waiting for Liferay to process the ${operation}..."
+
+	local attempts=0
+	local max_attempts=75
+
+	while [[ -f "${config_file}" ]]
+	do
+		if [[ ${attempts} -ge ${max_attempts} ]]
+		then
+			echo "Unable to ${operation} partition: timed out waiting for ${config_file} to be deleted."
+
+			exit 1
+		fi
+
+		sleep 8
+
+		((attempts++))
+	done
+
+	echo "Partition ${operation} is complete."
+}
+
+function read_partition_company_id {
+	if [[ -z "${LIFERAY_HOME}" ]]
+	then
+		echo "LIFERAY_HOME is not set."
+
+		exit 1
+	fi
+
+	if [[ ! -f "${STATE_FILE}" ]]
+	then
+		echo "State file was not found: ${STATE_FILE}."
+
+		exit 1
+	fi
+
+	local company_id
+
+	company_id=$(grep -oP '"partitionCompanyId":\s*\K[0-9]+' "${STATE_FILE}")
+
+	if [[ -z "${company_id}" ]]
+	then
+		echo "Unable to read partitionCompanyId from ${STATE_FILE}."
+
+		exit 1
+	fi
+
+	echo "${company_id}"
+}
+
+function read_partition_company_ids {
+	if [[ -z "${LIFERAY_HOME}" ]]
+	then
+		echo "LIFERAY_HOME is not set."
+
+		exit 1
+	fi
+
+	if [[ ! -f "${STATE_FILE}" ]]
+	then
+		echo "State file was not found: ${STATE_FILE}."
+
+		exit 1
+	fi
+
+	local company_ids
+
+	company_ids=$(grep -oP '"partitionCompanyIds":\s*\[\K[0-9, ]+' "${STATE_FILE}" | grep -oP '[0-9]+')
+
+	if [[ -z "${company_ids}" ]]
+	then
+		echo "Unable to read partitionCompanyIds from ${STATE_FILE}."
+
+		exit 1
+	fi
+
+	echo "${company_ids}"
+}

--- a/modules/test/playwright/tests/db-partition/env/delete_instance.sh
+++ b/modules/test/playwright/tests/db-partition/env/delete_instance.sh
@@ -36,7 +36,7 @@ function main {
 		exit 1
 	fi
 
-	echo "Virtual instance ${company_id} deleted successfully."
+	echo "Virtual instance ${company_id} was deleted successfully."
 }
 
 main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/delete_instance.sh
+++ b/modules/test/playwright/tests/db-partition/env/delete_instance.sh
@@ -9,9 +9,7 @@
 # LIFERAY_PORTAL_URL — base URL of the portal (default: http://localhost:8080)
 # ADMIN_PASSWORD — admin user password (default: test)
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/db_partition_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/db_partition_common.sh"
 
 LIFERAY_PORTAL_URL=${LIFERAY_PORTAL_URL:-"http://localhost:8080"}
 ADMIN_PASSWORD=${ADMIN_PASSWORD:-"test"}

--- a/modules/test/playwright/tests/db-partition/env/delete_instance.sh
+++ b/modules/test/playwright/tests/db-partition/env/delete_instance.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Deletes the virtual instance via the Liferay headless API.
+# Must be called while the server is running (before shutdown).
+#
+# Required env vars:
+# LIFERAY_HOME — path to the Liferay bundle
+# STATE_FILE — path to the JSON state file written by Phase 1
+# LIFERAY_PORTAL_URL — base URL of the portal (default: http://localhost:8080)
+# ADMIN_PASSWORD — admin user password (default: test)
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/db_partition_common.sh
+
+LIFERAY_PORTAL_URL=${LIFERAY_PORTAL_URL:-"http://localhost:8080"}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-"test"}
+
+function main {
+	local company_id
+	company_id=$(read_partition_company_id) || exit 1
+
+	echo "Deleting virtual instance for company ${company_id}."
+
+	local http_code
+	http_code=$(curl \
+		--output /dev/null \
+		--request DELETE \
+		--silent \
+		--url "${LIFERAY_PORTAL_URL}/headless-portal-instances/v1.0/portal-instances/${company_id}" \
+		--user "test@liferay.com:${ADMIN_PASSWORD}" \
+		--write-out "%{http_code}")
+
+	if [[ "${http_code}" != "204" && "${http_code}" != "200" ]]
+	then
+		echo "Unable to delete virtual instance ${company_id}: HTTP ${http_code}."
+
+		exit 1
+	fi
+
+	echo "Virtual instance ${company_id} deleted successfully."
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/drop_partitions.sh
+++ b/modules/test/playwright/tests/db-partition/env/drop_partitions.sh
@@ -11,9 +11,7 @@
 # LIFERAY_HOME — path to the Liferay bundle
 # STATE_FILE — path to the JSON state file written by the Phase 1 spec
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/db_partition_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/db_partition_common.sh"
 
 function main {
 	local company_ids

--- a/modules/test/playwright/tests/db-partition/env/drop_partitions.sh
+++ b/modules/test/playwright/tests/db-partition/env/drop_partitions.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Drops all partition schemas listed in the partitionCompanyIds array in the
+# state file. Called offline (server must be stopped) between rebuild steps.
+#
+# Required env vars:
+# DATABASE_HOST — Docker container name for the database
+# DATABASE_PASSWORD — database password
+# DATABASE_TYPE — "mysql" or "postgresql"
+# DATABASE_USERNAME — database username
+# LIFERAY_HOME — path to the Liferay bundle
+# STATE_FILE — path to the JSON state file written by the Phase 1 spec
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/db_partition_common.sh
+
+function main {
+	local company_ids
+	company_ids=$(read_partition_company_ids) || exit 1
+
+	while IFS= read -r company_id
+	do
+		echo "Dropping schema lpartition_${company_id}."
+
+		if [[ "${DATABASE_TYPE}" == "mysql" ]]
+		then
+			docker exec "${DATABASE_HOST}" mysql \
+				--execute="DROP SCHEMA IF EXISTS lpartition_${company_id};" \
+				--host=127.0.0.1 \
+				--password="${DATABASE_PASSWORD}" \
+				--user="${DATABASE_USERNAME}"
+		elif [[ "${DATABASE_TYPE}" == "postgresql" ]]
+		then
+			docker exec "${DATABASE_HOST}" /bin/bash -c \
+				"PGPASSWORD=${DATABASE_PASSWORD} psql --command='DROP SCHEMA IF EXISTS lpartition_${company_id} CASCADE;' --username=${DATABASE_USERNAME}"
+		fi
+	done <<< "${company_ids}"
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/export_partition.sh
+++ b/modules/test/playwright/tests/db-partition/env/export_partition.sh
@@ -2,9 +2,7 @@
 
 # Triggers a partition export and waits for Liferay to process it.
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/db_partition_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/db_partition_common.sh"
 
 function main {
 	local partition_company_id

--- a/modules/test/playwright/tests/db-partition/env/export_partition.sh
+++ b/modules/test/playwright/tests/db-partition/env/export_partition.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Triggers a partition export and waits for Liferay to process it.
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/db_partition_common.sh
+
+function main {
+	local partition_company_id
+
+	partition_company_id=$(read_partition_company_id) || exit 1
+
+	echo "Exporting partition for company ${partition_company_id}."
+
+	local config_dir="${LIFERAY_HOME}/osgi/configs"
+	local config_file="${config_dir}/com.liferay.portal.instances.internal.configuration.ExportPortalInstanceConfiguration.config"
+
+	mkdir -p "${config_dir}"
+
+	echo "exportCompanyId=L\"${partition_company_id}\"" > "${config_file}"
+
+	poll_config_deletion "${config_file}" "export"
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/export_partitions.sh
+++ b/modules/test/playwright/tests/db-partition/env/export_partitions.sh
@@ -8,9 +8,7 @@
 # LIFERAY_HOME — path to the Liferay bundle
 # STATE_FILE — path to the JSON state file written by the Phase 1 spec
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/db_partition_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/db_partition_common.sh"
 
 function main {
 	local company_ids

--- a/modules/test/playwright/tests/db-partition/env/export_partitions.sh
+++ b/modules/test/playwright/tests/db-partition/env/export_partitions.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Exports all partitions listed in the partitionCompanyIds array in the state
+# file. Each partition is exported sequentially and waits for completion before
+# starting the next.
+#
+# Required env vars:
+# LIFERAY_HOME — path to the Liferay bundle
+# STATE_FILE — path to the JSON state file written by the Phase 1 spec
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/db_partition_common.sh
+
+function main {
+	local company_ids
+	company_ids=$(read_partition_company_ids) || exit 1
+
+	local config_dir="${LIFERAY_HOME}/osgi/configs"
+
+	mkdir -p "${config_dir}"
+
+	while IFS= read -r company_id
+	do
+		echo "Exporting partition for company ${company_id}."
+
+		local config_file="${config_dir}/com.liferay.portal.instances.internal.configuration.ExportPortalInstanceConfiguration.config"
+
+		echo "exportCompanyId=L\"${company_id}\"" > "${config_file}"
+
+		poll_config_deletion "${config_file}" "export"
+	done <<< "${company_ids}"
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/import_partition.sh
+++ b/modules/test/playwright/tests/db-partition/env/import_partition.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Triggers a partition import and waits for Liferay to process it.
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/db_partition_common.sh
+
+function main {
+	local partition_company_id
+
+	partition_company_id=$(read_partition_company_id) || exit 1
+
+	echo "Importing partition for company ${partition_company_id}."
+
+	local config_dir="${LIFERAY_HOME}/osgi/configs"
+	local config_file="${config_dir}/com.liferay.portal.instances.internal.configuration.ImportPortalInstanceConfiguration.config"
+
+	mkdir -p "${config_dir}"
+
+	echo "importCompanyId=L\"${partition_company_id}\"" > "${config_file}"
+
+	poll_config_deletion "${config_file}" "import"
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/import_partition.sh
+++ b/modules/test/playwright/tests/db-partition/env/import_partition.sh
@@ -2,9 +2,7 @@
 
 # Triggers a partition import and waits for Liferay to process it.
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/db_partition_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/db_partition_common.sh"
 
 function main {
 	local partition_company_id

--- a/modules/test/playwright/tests/db-partition/env/import_partitions.sh
+++ b/modules/test/playwright/tests/db-partition/env/import_partitions.sh
@@ -8,9 +8,7 @@
 # LIFERAY_HOME — path to the Liferay bundle
 # STATE_FILE — path to the JSON state file written by the Phase 1 spec
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/db_partition_common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/db_partition_common.sh"
 
 function main {
 	local company_ids

--- a/modules/test/playwright/tests/db-partition/env/import_partitions.sh
+++ b/modules/test/playwright/tests/db-partition/env/import_partitions.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Imports all partitions listed in the partitionCompanyIds array in the state
+# file. Each partition is imported sequentially and waits for completion before
+# starting the next.
+#
+# Required env vars:
+# LIFERAY_HOME — path to the Liferay bundle
+# STATE_FILE — path to the JSON state file written by the Phase 1 spec
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/db_partition_common.sh
+
+function main {
+	local company_ids
+	company_ids=$(read_partition_company_ids) || exit 1
+
+	local config_dir="${LIFERAY_HOME}/osgi/configs"
+
+	mkdir -p "${config_dir}"
+
+	while IFS= read -r company_id
+	do
+		echo "Importing partition for company ${company_id}."
+
+		local config_file="${config_dir}/com.liferay.portal.instances.internal.configuration.ImportPortalInstanceConfiguration.config"
+
+		echo "importCompanyId=L\"${company_id}\"" > "${config_file}"
+
+		poll_config_deletion "${config_file}" "import"
+	done <<< "${company_ids}"
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/portal-ext.properties
+++ b/modules/test/playwright/tests/db-partition/env/portal-ext.properties
@@ -1,0 +1,2 @@
+feature.flag.LPD-11342=true
+virtual.hosts.valid.hosts=localhost,127.0.0.1,www.able.com,www.baker.com

--- a/modules/test/playwright/tests/db-partition/env/set_up.sh
+++ b/modules/test/playwright/tests/db-partition/env/set_up.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../env/common.sh"
 
 function main {
 	if [[ "${PLAYWRIGHT_PROJECT_NAME}" == "db-partition.phase2" ]]

--- a/modules/test/playwright/tests/db-partition/env/set_up.sh
+++ b/modules/test/playwright/tests/db-partition/env/set_up.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/../../../env/common.sh
+
+function main {
+	if [[ "${PLAYWRIGHT_PROJECT_NAME}" == "db-partition.phase2" ]]
+	then
+		# Server is already running after partition import — handled by the
+		# offline bridge that runs between the two Playwright phases.
+		return 0
+	fi
+
+	default_set_up
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/tear_down.sh
+++ b/modules/test/playwright/tests/db-partition/env/tear_down.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+source ${CURRENT_DIR_NAME}/../../../env/common.sh
+
+function main {
+	if [[ "${PLAYWRIGHT_PROJECT_NAME}" == "db-partition.phase1" ]]
+	then
+		# Server is kept running after phase 1 so the offline bridge can
+		# trigger the partition export before stopping it.
+		return 0
+	fi
+
+	default_tear_down
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/db-partition/env/tear_down.sh
+++ b/modules/test/playwright/tests/db-partition/env/tear_down.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
-
-source ${CURRENT_DIR_NAME}/../../../env/common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../../../env/common.sh"
 
 function main {
 	if [[ "${PLAYWRIGHT_PROJECT_NAME}" == "db-partition.phase1" ]]

--- a/modules/test/playwright/tests/db-partition/main/config.ts
+++ b/modules/test/playwright/tests/db-partition/main/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'db-partition.main',
+	testDir: 'tests/db-partition/main',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/db-partition/main/dbPartition.spec.ts
+++ b/modules/test/playwright/tests/db-partition/main/dbPartition.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {EActions} from '../../../helpers/ServerAdministrationHelper';
+import {liferayConfig} from '../../../liferay.config';
+import {ServerAdministrationPage} from '../../../pages/server-admin-web/ServerAdministrationPage';
+import {SiteSettingsPage} from '../../../pages/users-admin-web/site-admin-web/SiteSettingsPage';
+import {performLoginViaApi} from '../../../utils/performLogin';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+test(
+	'canAddCompanyWithHeadlessAPI',
+	{tag: '@LPD-91814'},
+	async ({apiHelpers, browser}) => {
+		const VIRTUAL_HOST = 'www.baker.com';
+		const VIRTUAL_HOST_BASE_URL = `http://${VIRTUAL_HOST}:${liferayConfig.environment.port}`;
+
+		const instance =
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: VIRTUAL_HOST,
+				portalInstanceId: VIRTUAL_HOST,
+				virtualHost: VIRTUAL_HOST,
+			});
+
+		try {
+			const virtualInstancePage = await browser.newPage({
+				baseURL: VIRTUAL_HOST_BASE_URL,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${VIRTUAL_HOST}`,
+					loginUrl: VIRTUAL_HOST_BASE_URL,
+					page: virtualInstancePage,
+					screenName: 'test',
+				});
+
+				await expect(virtualInstancePage).toHaveURL(
+					new RegExp(VIRTUAL_HOST)
+				);
+			}
+			finally {
+				await virtualInstancePage.close();
+			}
+		}
+		finally {
+			await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+				instance.id
+			);
+		}
+	}
+);
+
+test(
+	'canSetVirtualHostViaPages',
+	{tag: '@LPD-91814'},
+	async ({apiHelpers, browser, page}) => {
+		const ABLE_HOST = 'www.able.com';
+		const BAKER_HOST = 'www.baker.com';
+		const BAKER_BASE_URL = `http://${BAKER_HOST}:${liferayConfig.environment.port}`;
+
+		const instance =
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+		try {
+			const ABLE_BASE_URL = `http://${ABLE_HOST}:${liferayConfig.environment.port}`;
+
+			const virtualPage = await browser.newPage({
+				baseURL: ABLE_BASE_URL,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ABLE_BASE_URL,
+					page: virtualPage,
+					screenName: 'test',
+				});
+
+				const siteSettingsPage = new SiteSettingsPage(virtualPage);
+
+				await siteSettingsPage.setVirtualHost('guest', BAKER_HOST);
+
+				await virtualPage.goto(`${BAKER_BASE_URL}/web/guest/home`);
+
+				await expect(virtualPage).toHaveURL(
+					`${BAKER_BASE_URL}/web/guest/home`
+				);
+			}
+			finally {
+				await virtualPage.close();
+			}
+
+			const serverAdminPage = new ServerAdministrationPage(page);
+
+			await serverAdminPage.goto();
+			await serverAdminPage.executeAction(EActions.CLEAR_DATABASE_CACHE);
+
+			const bakerPage = await browser.newPage({
+				baseURL: BAKER_BASE_URL,
+			});
+
+			try {
+				await bakerPage.goto('/web/guest/home');
+
+				await expect(bakerPage).toHaveURL(
+					`${BAKER_BASE_URL}/web/guest/home`
+				);
+			}
+			finally {
+				await bakerPage.close();
+			}
+		}
+		finally {
+			await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+				instance.id
+			);
+		}
+	}
+);
+
+test('canDeleteCompany', {tag: '@LPD-91814'}, async ({apiHelpers, page}) => {
+	const VIRTUAL_HOST = 'www.able.com';
+
+	const instance = await apiHelpers.headlessPortalInstance.addVirtualInstance(
+		{
+			domain: VIRTUAL_HOST,
+			portalInstanceId: VIRTUAL_HOST,
+			virtualHost: VIRTUAL_HOST,
+		}
+	);
+
+	let deleted = false;
+
+	try {
+		await page.goto(
+			'/~/control_panel/manage?p_p_id=com_liferay_portal_instances_web_portlet_PortalInstancesPortlet'
+		);
+
+		await page
+			.getByRole('row', {name: VIRTUAL_HOST})
+			.getByRole('button', {name: 'Actions'})
+			.click();
+
+		await page.getByRole('menuitem', {name: 'Delete'}).click();
+
+		await page.getByRole('button', {name: 'OK'}).click();
+
+		await expect(
+			page.getByRole('cell', {exact: true, name: VIRTUAL_HOST})
+		).not.toBeVisible();
+
+		deleted = true;
+	}
+	finally {
+		if (!deleted) {
+			await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+				instance.id
+			);
+		}
+	}
+});

--- a/modules/test/playwright/tests/db-partition/main/executeSchemaValidator.spec.ts
+++ b/modules/test/playwright/tests/db-partition/main/executeSchemaValidator.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+const BAKER_HOST = 'www.baker.com';
+
+test.describe.serial('ExecuteSchemaValidator', () => {
+	test(
+		'Create virtual instances for schema validation',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: BAKER_HOST,
+				portalInstanceId: BAKER_HOST,
+				virtualHost: BAKER_HOST,
+			});
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/main/test.properties
+++ b/modules/test/playwright/tests/db-partition/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Partitioning

--- a/modules/test/playwright/tests/db-partition/phase1/config.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'db-partition.phase1',
+	testDir: 'tests/db-partition/phase1',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/db-partition/phase1/exportAndAddDBPartition.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/exportAndAddDBPartition.phase1.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {ApiHelpers} from '../../../helpers/ApiHelpers';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const VIRTUAL_HOST = 'www.able.com';
+
+const VIRTUAL_HOST_BASE_URL = `http://${VIRTUAL_HOST}:${liferayConfig.environment.port}`;
+
+// Document_1.doc is shared with Poshi's test dependencies.
+
+const DOCUMENT_PATH = path.join(
+	__dirname,
+	'../../../../../../portal-web/test/functional/com/liferay/portalweb/dependencies/Document_1.doc'
+);
+
+test.describe.serial('ExportAndAddDBPartition — Phase 1', () => {
+	test(
+		'Add www.able.com portal instance',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: VIRTUAL_HOST,
+				portalInstanceId: VIRTUAL_HOST,
+				virtualHost: VIRTUAL_HOST,
+			});
+		}
+	);
+
+	test(
+		'Upload DM document to www.able.com and verify',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			const company =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					VIRTUAL_HOST
+				);
+
+			const companyGroup =
+				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					company.companyId
+				);
+
+			const virtualInstancePage = await browser.newPage({
+				baseURL: VIRTUAL_HOST_BASE_URL,
+			});
+
+			await performLoginViaApi({
+				domain: `@${VIRTUAL_HOST}`,
+				loginUrl: VIRTUAL_HOST_BASE_URL,
+				page: virtualInstancePage,
+				screenName: 'test',
+			});
+
+			const virtualInstanceApiHelpers = new ApiHelpers(
+				virtualInstancePage,
+				VIRTUAL_HOST_BASE_URL
+			);
+
+			await virtualInstanceApiHelpers.headlessDelivery.postDocument(
+				companyGroup.groupId,
+				fs.createReadStream(DOCUMENT_PATH),
+				{
+					description: 'DM Document Description',
+					fileName: 'Document_1.doc',
+					title: 'DM Document Title',
+				}
+			);
+
+			await virtualInstancePage.goto(
+				'/~/control_panel/manage?p_p_id=com_liferay_document_library_web_portlet_DLAdminPortlet'
+			);
+
+			await expect(
+				virtualInstancePage.getByRole('link', {
+					name: 'DM Document Title',
+				})
+			).toBeVisible();
+
+			// Write company ID so the offline Ant step and phase 2 can use it.
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify({partitionCompanyId: company.companyId}, null, 2)
+			);
+
+			await virtualInstancePage.close();
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase1/exportAndAddDBPartitionWithUpgradedDB.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/exportAndAddDBPartitionWithUpgradedDB.phase1.spec.ts
@@ -23,14 +23,10 @@ test.describe.serial('ExportAndAddDBPartitionWithUpgradedDB — Phase 1', () => 
 		'Verify www.able.com and www.baker.com partitions are accessible',
 		{tag: '@LPD-91814'},
 		async ({apiHelpers, browser}) => {
-			const ableCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
-					ABLE_HOST
-				);
-			const bakerCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
-					BAKER_HOST
-				);
+			const [ableCompany, bakerCompany] = await Promise.all([
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(ABLE_HOST),
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(BAKER_HOST),
+			]);
 
 			const port = liferayConfig.environment.port;
 

--- a/modules/test/playwright/tests/db-partition/phase1/exportAndAddDBPartitionWithUpgradedDB.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/exportAndAddDBPartitionWithUpgradedDB.phase1.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+const BAKER_HOST = 'www.baker.com';
+
+test.describe.serial('ExportAndAddDBPartitionWithUpgradedDB — Phase 1', () => {
+	test(
+		'Verify www.able.com and www.baker.com partitions are accessible',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+			const bakerCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					BAKER_HOST
+				);
+
+			const port = liferayConfig.environment.port;
+
+			for (const host of [ABLE_HOST, BAKER_HOST]) {
+				const baseURL = `http://${host}:${port}`;
+
+				const instancePage = await browser.newPage({baseURL});
+
+				try {
+					await performLoginViaApi({
+						domain: `@${host}`,
+						loginUrl: baseURL,
+						page: instancePage,
+						screenName: 'test',
+					});
+
+					await expect(instancePage).toHaveURL(new RegExp(host));
+				}
+				finally {
+					await instancePage.close();
+				}
+			}
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify(
+					{
+						partitionCompanyIds: [
+							ableCompany.companyId,
+							bakerCompany.companyId,
+						],
+					},
+					null,
+					2
+				)
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase1/exportNonPartitionedCompanyAndAddDBPartition.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/exportNonPartitionedCompanyAndAddDBPartition.phase1.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {ApiHelpers} from '../../../helpers/ApiHelpers';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const VIRTUAL_HOST = 'www.able.com';
+
+const VIRTUAL_HOST_BASE_URL = `http://${VIRTUAL_HOST}:${liferayConfig.environment.port}`;
+
+const DOCUMENT_PATH = path.join(
+	__dirname,
+	'../../../../../../portal-web/test/functional/com/liferay/portalweb/dependencies/Document_1.doc'
+);
+
+test.describe
+	.serial('ExportNonPartitionedCompanyAndAddDBPartition — Phase 1', () => {
+	test(
+		'Add www.able.com portal instance',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: VIRTUAL_HOST,
+				portalInstanceId: VIRTUAL_HOST,
+				virtualHost: VIRTUAL_HOST,
+			});
+		}
+	);
+
+	test(
+		'Upload DM document to www.able.com and verify',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			const company =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					VIRTUAL_HOST
+				);
+
+			const companyGroup =
+				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					company.companyId
+				);
+
+			const virtualInstancePage = await browser.newPage({
+				baseURL: VIRTUAL_HOST_BASE_URL,
+			});
+
+			await performLoginViaApi({
+				domain: `@${VIRTUAL_HOST}`,
+				loginUrl: VIRTUAL_HOST_BASE_URL,
+				page: virtualInstancePage,
+				screenName: 'test',
+			});
+
+			const virtualInstanceApiHelpers = new ApiHelpers(
+				virtualInstancePage,
+				VIRTUAL_HOST_BASE_URL
+			);
+
+			await virtualInstanceApiHelpers.headlessDelivery.postDocument(
+				companyGroup.groupId,
+				fs.createReadStream(DOCUMENT_PATH),
+				{
+					description: 'DM Document Description',
+					fileName: 'Document_1.doc',
+					title: 'DM Document Title',
+				}
+			);
+
+			await virtualInstancePage.goto(
+				'/~/control_panel/manage?p_p_id=com_liferay_document_library_web_portlet_DLAdminPortlet'
+			);
+
+			await expect(
+				virtualInstancePage.getByRole('link', {
+					name: 'DM Document Title',
+				})
+			).toBeVisible();
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify({partitionCompanyId: company.companyId}, null, 2)
+			);
+
+			await virtualInstancePage.close();
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase1/importDatabaseToPostgreSQL.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/importDatabaseToPostgreSQL.phase1.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = loginTest();
+
+test.describe.serial('CanImportDatabaseToPostgreSQL — Phase 1', () => {
+	test(
+		'Portal is accessible before DB migration',
+		{tag: '@LPD-91814'},
+		async ({page}) => {
+			await page.goto('/');
+
+			await expect(page.getByText('Welcome to Liferay')).toBeVisible();
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase1/importPartitionedDatabaseToPostgreSQL.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/importPartitionedDatabaseToPostgreSQL.phase1.spec.ts
@@ -33,9 +33,7 @@ test.describe.serial('ImportPartitionedDatabaseToPostgreSQL — Phase 1', () => 
 					ABLE_HOST
 				);
 
-			const port = liferayConfig.environment.port;
-
-			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+			const ableBaseUrl = `http://${ABLE_HOST}:${liferayConfig.environment.port}`;
 
 			const instancePage = await browser.newPage({
 				baseURL: ableBaseUrl,

--- a/modules/test/playwright/tests/db-partition/phase1/importPartitionedDatabaseToPostgreSQL.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/importPartitionedDatabaseToPostgreSQL.phase1.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+test.describe.serial('ImportPartitionedDatabaseToPostgreSQL — Phase 1', () => {
+	test(
+		'Create www.able.com and verify partition is accessible',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const port = liferayConfig.environment.port;
+
+			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+
+			const instancePage = await browser.newPage({
+				baseURL: ableBaseUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableBaseUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+			}
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify(
+					{partitionCompanyId: ableCompany.companyId},
+					null,
+					2
+				)
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestart.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestart.phase1.spec.ts
@@ -33,9 +33,7 @@ test.describe.serial('NewCompanyStillAccessibleAfterRestart — Phase 1', () => 
 					ABLE_HOST
 				);
 
-			const port = liferayConfig.environment.port;
-
-			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+			const ableBaseUrl = `http://${ABLE_HOST}:${liferayConfig.environment.port}`;
 
 			const instancePage = await browser.newPage({
 				baseURL: ableBaseUrl,

--- a/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestart.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestart.phase1.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+test.describe.serial('NewCompanyStillAccessibleAfterRestart — Phase 1', () => {
+	test(
+		'Create www.able.com and verify accessible before restart',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const port = liferayConfig.environment.port;
+
+			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+
+			const instancePage = await browser.newPage({
+				baseURL: ableBaseUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableBaseUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+			}
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify(
+					{partitionCompanyId: ableCompany.companyId},
+					null,
+					2
+				)
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase1.spec.ts
@@ -34,9 +34,7 @@ test.describe
 					ABLE_HOST
 				);
 
-			const port = liferayConfig.environment.port;
-
-			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+			const ableBaseUrl = `http://${ABLE_HOST}:${liferayConfig.environment.port}`;
 
 			const instancePage = await browser.newPage({
 				baseURL: ableBaseUrl,

--- a/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase1.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase1/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase1.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+test.describe
+	.serial('NewCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase — Phase 1', () => {
+	test(
+		'Create www.able.com and verify accessible before restart',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const port = liferayConfig.environment.port;
+
+			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+
+			const instancePage = await browser.newPage({
+				baseURL: ableBaseUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableBaseUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+			}
+
+			fs.mkdirSync(path.dirname(STATE_FILE), {recursive: true});
+
+			fs.writeFileSync(
+				STATE_FILE,
+				JSON.stringify(
+					{partitionCompanyId: ableCompany.companyId},
+					null,
+					2
+				)
+			);
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase1/test.properties
+++ b/modules/test/playwright/tests/db-partition/phase1/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Partitioning

--- a/modules/test/playwright/tests/db-partition/phase2/config.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'db-partition.phase2',
+	testDir: 'tests/db-partition/phase2',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/db-partition/phase2/exportAndAddDBPartition.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/exportAndAddDBPartition.phase2.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const VIRTUAL_HOST = 'www.able.com';
+
+const VIRTUAL_HOST_BASE_URL = `http://${VIRTUAL_HOST}:${liferayConfig.environment.port}`;
+
+function readState(): {partitionCompanyId: number} {
+	return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+}
+
+test.describe.serial('ExportAndAddDBPartition — Phase 2', () => {
+	test(
+		'Default portal instance is accessible after DB rebuild',
+		{tag: '@LPD-91814'},
+		async ({page}) => {
+			await page.goto('/');
+
+			await expect(page.getByText('Welcome to Liferay')).toBeVisible();
+		}
+	);
+
+	test(
+		'www.able.com is accessible and DM document is visible after partition import',
+		{tag: '@LPD-91814'},
+		async ({browser}) => {
+			const {partitionCompanyId} = readState();
+
+			expect(partitionCompanyId).toBeTruthy();
+
+			const virtualInstancePage = await browser.newPage({
+				baseURL: VIRTUAL_HOST_BASE_URL,
+			});
+
+			await performLoginViaApi({
+				domain: `@${VIRTUAL_HOST}`,
+				loginUrl: VIRTUAL_HOST_BASE_URL,
+				page: virtualInstancePage,
+				screenName: 'test',
+			});
+
+			await virtualInstancePage.goto(
+				'/~/control_panel/manage?p_p_id=com_liferay_document_library_web_portlet_DLAdminPortlet'
+			);
+
+			await expect(
+				virtualInstancePage.getByRole('link', {
+					name: 'DM Document Title',
+				})
+			).toBeVisible();
+
+			await virtualInstancePage.close();
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase2/exportAndAddDBPartition.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/exportAndAddDBPartition.phase2.spec.ts
@@ -4,23 +4,18 @@
  */
 
 import {expect, mergeTests} from '@playwright/test';
-import * as fs from 'fs';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {liferayConfig} from '../../../liferay.config';
 import {performLoginViaApi} from '../../../utils/performLogin';
-import {STATE_FILE} from '../utils';
+import {readState} from '../utils';
 
 const test = mergeTests(apiHelpersTest, loginTest());
 
 const VIRTUAL_HOST = 'www.able.com';
 
 const VIRTUAL_HOST_BASE_URL = `http://${VIRTUAL_HOST}:${liferayConfig.environment.port}`;
-
-function readState(): {partitionCompanyId: number} {
-	return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
-}
 
 test.describe.serial('ExportAndAddDBPartition — Phase 2', () => {
 	test(

--- a/modules/test/playwright/tests/db-partition/phase2/exportAndAddDBPartitionWithUpgradedDB.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/exportAndAddDBPartitionWithUpgradedDB.phase2.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+const BAKER_HOST = 'www.baker.com';
+
+test.describe.serial('ExportAndAddDBPartitionWithUpgradedDB — Phase 2', () => {
+	test(
+		'Default portal instance is accessible after DB rebuild',
+		{tag: '@LPD-91814'},
+		async ({page}) => {
+			await page.goto('/');
+
+			await expect(page.getByText('Welcome to Liferay')).toBeVisible();
+		}
+	);
+
+	test(
+		'www.able.com and www.baker.com are accessible after partition import',
+		{tag: '@LPD-91814'},
+		async ({browser}) => {
+			const port = liferayConfig.environment.port;
+
+			for (const host of [ABLE_HOST, BAKER_HOST]) {
+				const baseURL = `http://${host}:${port}`;
+
+				const instancePage = await browser.newPage({baseURL});
+
+				try {
+					await performLoginViaApi({
+						domain: `@${host}`,
+						loginUrl: baseURL,
+						page: instancePage,
+						screenName: 'test',
+					});
+
+					await expect(instancePage).toHaveURL(new RegExp(host));
+				}
+				finally {
+					await instancePage.close();
+				}
+			}
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase2/exportNonPartitionedCompanyAndAddDBPartition.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/exportNonPartitionedCompanyAndAddDBPartition.phase2.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+import * as fs from 'fs';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+import {STATE_FILE} from '../utils';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const VIRTUAL_HOST = 'www.able.com';
+
+const VIRTUAL_HOST_BASE_URL = `http://${VIRTUAL_HOST}:${liferayConfig.environment.port}`;
+
+function readState(): {partitionCompanyId: number} {
+	return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+}
+
+test.describe
+	.serial('ExportNonPartitionedCompanyAndAddDBPartition — Phase 2', () => {
+	test(
+		'Default portal instance is accessible after DB rebuild',
+		{tag: '@LPD-91814'},
+		async ({page}) => {
+			await page.goto('/');
+
+			await expect(page.getByText('Welcome to Liferay')).toBeVisible();
+		}
+	);
+
+	test(
+		'www.able.com is accessible and DM document is visible after partition import',
+		{tag: '@LPD-91814'},
+		async ({browser}) => {
+			const {partitionCompanyId} = readState();
+
+			expect(partitionCompanyId).toBeTruthy();
+
+			const virtualInstancePage = await browser.newPage({
+				baseURL: VIRTUAL_HOST_BASE_URL,
+			});
+
+			await performLoginViaApi({
+				domain: `@${VIRTUAL_HOST}`,
+				loginUrl: VIRTUAL_HOST_BASE_URL,
+				page: virtualInstancePage,
+				screenName: 'test',
+			});
+
+			await virtualInstancePage.goto(
+				'/~/control_panel/manage?p_p_id=com_liferay_document_library_web_portlet_DLAdminPortlet'
+			);
+
+			await expect(
+				virtualInstancePage.getByRole('link', {
+					name: 'DM Document Title',
+				})
+			).toBeVisible();
+
+			await virtualInstancePage.close();
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase2/exportNonPartitionedCompanyAndAddDBPartition.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/exportNonPartitionedCompanyAndAddDBPartition.phase2.spec.ts
@@ -4,23 +4,18 @@
  */
 
 import {expect, mergeTests} from '@playwright/test';
-import * as fs from 'fs';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {liferayConfig} from '../../../liferay.config';
 import {performLoginViaApi} from '../../../utils/performLogin';
-import {STATE_FILE} from '../utils';
+import {readState} from '../utils';
 
 const test = mergeTests(apiHelpersTest, loginTest());
 
 const VIRTUAL_HOST = 'www.able.com';
 
 const VIRTUAL_HOST_BASE_URL = `http://${VIRTUAL_HOST}:${liferayConfig.environment.port}`;
-
-function readState(): {partitionCompanyId: number} {
-	return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
-}
 
 test.describe
 	.serial('ExportNonPartitionedCompanyAndAddDBPartition — Phase 2', () => {

--- a/modules/test/playwright/tests/db-partition/phase2/importDatabaseToPostgreSQL.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/importDatabaseToPostgreSQL.phase2.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = loginTest();
+
+test.describe.serial('CanImportDatabaseToPostgreSQL — Phase 2', () => {
+	test(
+		'Portal is accessible after DB migration to PostgreSQL',
+		{tag: '@LPD-91814'},
+		async ({page}) => {
+			await page.goto('/');
+
+			await expect(page.getByText('Welcome to Liferay')).toBeVisible();
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase2/importPartitionedDatabaseToPostgreSQL.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/importPartitionedDatabaseToPostgreSQL.phase2.spec.ts
@@ -29,9 +29,7 @@ test.describe.serial('ImportPartitionedDatabaseToPostgreSQL — Phase 2', () => 
 		'www.able.com partition is accessible after DB migration to PostgreSQL',
 		{tag: '@LPD-91814'},
 		async ({browser}) => {
-			const port = liferayConfig.environment.port;
-
-			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+			const ableBaseUrl = `http://${ABLE_HOST}:${liferayConfig.environment.port}`;
 
 			const instancePage = await browser.newPage({
 				baseURL: ableBaseUrl,

--- a/modules/test/playwright/tests/db-partition/phase2/importPartitionedDatabaseToPostgreSQL.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/importPartitionedDatabaseToPostgreSQL.phase2.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+test.describe.serial('ImportPartitionedDatabaseToPostgreSQL — Phase 2', () => {
+	test(
+		'Default portal is accessible on PostgreSQL',
+		{tag: '@LPD-91814'},
+		async ({page}) => {
+			await page.goto('/');
+
+			await expect(page.getByText('Welcome to Liferay')).toBeVisible();
+		}
+	);
+
+	test(
+		'www.able.com partition is accessible after DB migration to PostgreSQL',
+		{tag: '@LPD-91814'},
+		async ({browser}) => {
+			const port = liferayConfig.environment.port;
+
+			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+
+			const instancePage = await browser.newPage({
+				baseURL: ableBaseUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableBaseUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+			}
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestart.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestart.phase2.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+test.describe.serial('NewCompanyStillAccessibleAfterRestart — Phase 2', () => {
+	test(
+		'www.able.com is still accessible after server restart',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const port = liferayConfig.environment.port;
+
+			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+
+			const instancePage = await browser.newPage({
+				baseURL: ableBaseUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableBaseUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+
+				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+					ableCompany.companyId
+				);
+			}
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestart.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestart.phase2.spec.ts
@@ -24,9 +24,7 @@ test.describe.serial('NewCompanyStillAccessibleAfterRestart — Phase 2', () => 
 					ABLE_HOST
 				);
 
-			const port = liferayConfig.environment.port;
-
-			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+			const ableBaseUrl = `http://${ABLE_HOST}:${liferayConfig.environment.port}`;
 
 			const instancePage = await browser.newPage({
 				baseURL: ableBaseUrl,
@@ -46,7 +44,7 @@ test.describe.serial('NewCompanyStillAccessibleAfterRestart — Phase 2', () => 
 				await instancePage.close();
 
 				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
-					ableCompany.companyId
+					Number(ableCompany.companyId)
 				);
 			}
 		}

--- a/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase2.spec.ts
@@ -25,9 +25,7 @@ test.describe
 					ABLE_HOST
 				);
 
-			const port = liferayConfig.environment.port;
-
-			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+			const ableBaseUrl = `http://${ABLE_HOST}:${liferayConfig.environment.port}`;
 
 			const instancePage = await browser.newPage({
 				baseURL: ableBaseUrl,
@@ -47,7 +45,7 @@ test.describe
 				await instancePage.close();
 
 				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
-					ableCompany.companyId
+					Number(ableCompany.companyId)
 				);
 			}
 		}

--- a/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase2.spec.ts
+++ b/modules/test/playwright/tests/db-partition/phase2/newCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase.phase2.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {performLoginViaApi} from '../../../utils/performLogin';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+
+test.describe
+	.serial('NewCompanyStillAccessibleAfterRestartWithCaseInsensitiveDatabase — Phase 2', () => {
+	test(
+		'www.able.com is still accessible after server restart on case-insensitive database',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, browser}) => {
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const port = liferayConfig.environment.port;
+
+			const ableBaseUrl = `http://${ABLE_HOST}:${port}`;
+
+			const instancePage = await browser.newPage({
+				baseURL: ableBaseUrl,
+			});
+
+			try {
+				await performLoginViaApi({
+					domain: `@${ABLE_HOST}`,
+					loginUrl: ableBaseUrl,
+					page: instancePage,
+					screenName: 'test',
+				});
+
+				await expect(instancePage).toHaveURL(new RegExp(ABLE_HOST));
+			}
+			finally {
+				await instancePage.close();
+
+				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+					ableCompany.companyId
+				);
+			}
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/phase2/test.properties
+++ b/modules/test/playwright/tests/db-partition/phase2/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Partitioning

--- a/modules/test/playwright/tests/db-partition/scheduler/config.ts
+++ b/modules/test/playwright/tests/db-partition/scheduler/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'db-partition.scheduler',
+	testDir: 'tests/db-partition/scheduler',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/db-partition/scheduler/dbPartitionScheduler.spec.ts
+++ b/modules/test/playwright/tests/db-partition/scheduler/dbPartitionScheduler.spec.ts
@@ -27,45 +27,42 @@ test.describe
 				virtualHost: ABLE_HOST,
 			});
 
-			const ableCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
-					ABLE_HOST
-				);
-
-			const ableCompanyGroup =
-				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
-					ableCompany.companyId
-				);
-
-			const defaultCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+			const [ableCompany, defaultCompany] = await Promise.all([
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(ABLE_HOST),
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
 					'liferay.com'
-				);
+				),
+			]);
 
-			const defaultCompanyGroup =
-				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+			const [ableCompanyGroup, defaultCompanyGroup] = await Promise.all([
+				apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					ableCompany.companyId
+				),
+				apiHelpers.jsonWebServicesGroup.getCompanyGroup(
 					defaultCompany.companyId
-				);
+				),
+			]);
 
-			const ableStructureId = await getWebContentStructureId(
-				apiHelpers,
-				ableCompanyGroup.groupId,
-				'BASIC-WEB-CONTENT'
-			);
-
-			const defaultStructureId = await getWebContentStructureId(
-				apiHelpers,
-				defaultCompanyGroup.groupId,
-				'BASIC-WEB-CONTENT'
-			);
+			const [ableStructureId, defaultStructureId] = await Promise.all([
+				getWebContentStructureId(
+					apiHelpers,
+					ableCompanyGroup.groupId,
+					'BASIC-WEB-CONTENT'
+				),
+				getWebContentStructureId(
+					apiHelpers,
+					defaultCompanyGroup.groupId,
+					'BASIC-WEB-CONTENT'
+				),
+			]);
 
 			const scheduledDate = new Date(Date.now() + 2 * 60 * 1000);
 
-			const displayDateDay = scheduledDate.getUTCDate();
-			const displayDateHour = scheduledDate.getUTCHours();
-			const displayDateMinute = scheduledDate.getUTCMinutes();
-			const displayDateMonth = scheduledDate.getUTCMonth();
-			const displayDateYear = scheduledDate.getUTCFullYear();
+			const displayDateDay = scheduledDate.getDate();
+			const displayDateHour = scheduledDate.getHours();
+			const displayDateMinute = scheduledDate.getMinutes();
+			const displayDateMonth = scheduledDate.getMonth();
+			const displayDateYear = scheduledDate.getFullYear();
 
 			const ableArticle =
 				await apiHelpers.jsonWebServicesJournal.addWebContentDetailed({
@@ -119,28 +116,24 @@ test.describe
 
 			try {
 				await expect(async () => {
-					const defaultResponse = await page.request.post(
-						journalArticlePath,
-						{
+					const [defaultResponse, ableResponse] = await Promise.all([
+						page.request.post(journalArticlePath, {
 							data: defaultArticleUrlSearchParams.toString(),
 							headers: journalHeaders,
-						}
-					);
-
-					const defaultArticleData = await defaultResponse.json();
-
-					expect(defaultArticleData.status).toBe(WC_STATUS_APPROVED);
-
-					const ableResponse = await page.request.post(
-						journalArticlePath,
-						{
+						}),
+						page.request.post(journalArticlePath, {
 							data: ableArticleUrlSearchParams.toString(),
 							headers: journalHeaders,
-						}
-					);
+						}),
+					]);
 
-					const ableArticleData = await ableResponse.json();
+					const [defaultArticleData, ableArticleData] =
+						await Promise.all([
+							defaultResponse.json(),
+							ableResponse.json(),
+						]);
 
+					expect(defaultArticleData.status).toBe(WC_STATUS_APPROVED);
 					expect(ableArticleData.status).toBe(WC_STATUS_APPROVED);
 				}).toPass({timeout: 240_000});
 			}
@@ -151,7 +144,7 @@ test.describe
 				);
 
 				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
-					ableCompany.companyId
+					Number(ableCompany.companyId)
 				);
 			}
 		}
@@ -170,37 +163,34 @@ test.describe
 				virtualHost: ABLE_HOST,
 			});
 
-			const ableCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
-					ABLE_HOST
-				);
-
-			const ableCompanyGroup =
-				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
-					ableCompany.companyId
-				);
-
-			const defaultCompany =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+			const [ableCompany, defaultCompany] = await Promise.all([
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(ABLE_HOST),
+				apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
 					'liferay.com'
-				);
+				),
+			]);
 
-			const defaultCompanyGroup =
-				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+			const [ableCompanyGroup, defaultCompanyGroup] = await Promise.all([
+				apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					ableCompany.companyId
+				),
+				apiHelpers.jsonWebServicesGroup.getCompanyGroup(
 					defaultCompany.companyId
-				);
+				),
+			]);
 
-			const ableStructureId = await getWebContentStructureId(
-				apiHelpers,
-				ableCompanyGroup.groupId,
-				'BASIC-WEB-CONTENT'
-			);
-
-			const defaultStructureId = await getWebContentStructureId(
-				apiHelpers,
-				defaultCompanyGroup.groupId,
-				'BASIC-WEB-CONTENT'
-			);
+			const [ableStructureId, defaultStructureId] = await Promise.all([
+				getWebContentStructureId(
+					apiHelpers,
+					ableCompanyGroup.groupId,
+					'BASIC-WEB-CONTENT'
+				),
+				getWebContentStructureId(
+					apiHelpers,
+					defaultCompanyGroup.groupId,
+					'BASIC-WEB-CONTENT'
+				),
+			]);
 
 			const ableScheduledDate = new Date(Date.now() + 4 * 60 * 1000);
 
@@ -260,28 +250,24 @@ test.describe
 
 			try {
 				await expect(async () => {
-					const defaultResponse = await page.request.post(
-						journalArticlePath,
-						{
+					const [defaultResponse, ableResponse] = await Promise.all([
+						page.request.post(journalArticlePath, {
 							data: defaultArticleUrlSearchParams.toString(),
 							headers: journalHeaders,
-						}
-					);
-
-					const defaultArticleData = await defaultResponse.json();
-
-					expect(defaultArticleData.status).toBe(WC_STATUS_APPROVED);
-
-					const ableResponse = await page.request.post(
-						journalArticlePath,
-						{
+						}),
+						page.request.post(journalArticlePath, {
 							data: ableArticleUrlSearchParams.toString(),
 							headers: journalHeaders,
-						}
-					);
+						}),
+					]);
 
-					const ableArticleData = await ableResponse.json();
+					const [defaultArticleData, ableArticleData] =
+						await Promise.all([
+							defaultResponse.json(),
+							ableResponse.json(),
+						]);
 
+					expect(defaultArticleData.status).toBe(WC_STATUS_APPROVED);
 					expect(ableArticleData.status).toBe(WC_STATUS_APPROVED);
 				}).toPass({timeout: 360_000});
 			}
@@ -292,7 +278,7 @@ test.describe
 				);
 
 				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
-					ableCompany.companyId
+					Number(ableCompany.companyId)
 				);
 			}
 		}

--- a/modules/test/playwright/tests/db-partition/scheduler/dbPartitionScheduler.spec.ts
+++ b/modules/test/playwright/tests/db-partition/scheduler/dbPartitionScheduler.spec.ts
@@ -61,11 +61,11 @@ test.describe
 
 			const scheduledDate = new Date(Date.now() + 2 * 60 * 1000);
 
-			const displayDateDay = scheduledDate.getDate();
-			const displayDateHour = scheduledDate.getHours();
-			const displayDateMinute = scheduledDate.getMinutes();
-			const displayDateMonth = scheduledDate.getMonth();
-			const displayDateYear = scheduledDate.getFullYear();
+			const displayDateDay = scheduledDate.getUTCDate();
+			const displayDateHour = scheduledDate.getUTCHours();
+			const displayDateMinute = scheduledDate.getUTCMinutes();
+			const displayDateMonth = scheduledDate.getUTCMonth();
+			const displayDateYear = scheduledDate.getUTCFullYear();
 
 			const ableArticle =
 				await apiHelpers.jsonWebServicesJournal.addWebContentDetailed({

--- a/modules/test/playwright/tests/db-partition/scheduler/dbPartitionScheduler.spec.ts
+++ b/modules/test/playwright/tests/db-partition/scheduler/dbPartitionScheduler.spec.ts
@@ -1,0 +1,300 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {liferayConfig} from '../../../liferay.config';
+import {getWebContentStructureId} from '../../../utils/structured-content/getBasicWebContentStructureId';
+
+const test = mergeTests(apiHelpersTest, loginTest());
+
+const ABLE_HOST = 'www.able.com';
+const WC_STATUS_APPROVED = 0;
+
+test.describe
+	.serial('CanScheduleJobInVariousCompaniesWhenAutoUpgradeIsEnabled', () => {
+	test(
+		'Scheduled web content publishes in both instances after auto upgrade',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, page}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const ableCompanyGroup =
+				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					ableCompany.companyId
+				);
+
+			const defaultCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					'liferay.com'
+				);
+
+			const defaultCompanyGroup =
+				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					defaultCompany.companyId
+				);
+
+			const ableStructureId = await getWebContentStructureId(
+				apiHelpers,
+				ableCompanyGroup.groupId,
+				'BASIC-WEB-CONTENT'
+			);
+
+			const defaultStructureId = await getWebContentStructureId(
+				apiHelpers,
+				defaultCompanyGroup.groupId,
+				'BASIC-WEB-CONTENT'
+			);
+
+			const scheduledDate = new Date(Date.now() + 2 * 60 * 1000);
+
+			const displayDateDay = scheduledDate.getDate();
+			const displayDateHour = scheduledDate.getHours();
+			const displayDateMinute = scheduledDate.getMinutes();
+			const displayDateMonth = scheduledDate.getMonth();
+			const displayDateYear = scheduledDate.getFullYear();
+
+			const ableArticle =
+				await apiHelpers.jsonWebServicesJournal.addWebContentDetailed({
+					ddmStructureId: ableStructureId,
+					displayDateDay,
+					displayDateHour,
+					displayDateMinute,
+					displayDateMonth,
+					displayDateYear,
+					groupId: ableCompanyGroup.groupId,
+					titleMap: {en_US: 'Web Content Title'},
+				});
+
+			const defaultArticle =
+				await apiHelpers.jsonWebServicesJournal.addWebContentDetailed({
+					ddmStructureId: defaultStructureId,
+					displayDateDay,
+					displayDateHour,
+					displayDateMinute,
+					displayDateMonth,
+					displayDateYear,
+					groupId: defaultCompanyGroup.groupId,
+					titleMap: {en_US: 'Web Content Title'},
+				});
+
+			const journalArticlePath = `${liferayConfig.environment.baseUrl}/api/jsonws/journal.journalarticle/get-article`;
+
+			const journalHeaders = await apiHelpers.getJSONWebServicesHeaders();
+
+			const ableArticleUrlSearchParams = new URLSearchParams();
+
+			ableArticleUrlSearchParams.append(
+				'articleId',
+				ableArticle.articleId
+			);
+			ableArticleUrlSearchParams.append(
+				'groupId',
+				String(ableCompanyGroup.groupId)
+			);
+
+			const defaultArticleUrlSearchParams = new URLSearchParams();
+
+			defaultArticleUrlSearchParams.append(
+				'articleId',
+				defaultArticle.articleId
+			);
+			defaultArticleUrlSearchParams.append(
+				'groupId',
+				String(defaultCompanyGroup.groupId)
+			);
+
+			try {
+				await expect(async () => {
+					const defaultResponse = await page.request.post(
+						journalArticlePath,
+						{
+							data: defaultArticleUrlSearchParams.toString(),
+							headers: journalHeaders,
+						}
+					);
+
+					const defaultArticleData = await defaultResponse.json();
+
+					expect(defaultArticleData.status).toBe(WC_STATUS_APPROVED);
+
+					const ableResponse = await page.request.post(
+						journalArticlePath,
+						{
+							data: ableArticleUrlSearchParams.toString(),
+							headers: journalHeaders,
+						}
+					);
+
+					const ableArticleData = await ableResponse.json();
+
+					expect(ableArticleData.status).toBe(WC_STATUS_APPROVED);
+				}).toPass({timeout: 240_000});
+			}
+			finally {
+				await apiHelpers.jsonWebServicesJournal.deleteArticle(
+					String(defaultCompanyGroup.groupId),
+					defaultArticle.articleId
+				);
+
+				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+					ableCompany.companyId
+				);
+			}
+		}
+	);
+});
+
+test.describe
+	.serial('ScheduleWebContentChangesWithDBPartitioningActivatedAcrossVariousCompanies', () => {
+	test(
+		'Scheduled web content publishes in default and virtual instance',
+		{tag: '@LPD-91814'},
+		async ({apiHelpers, page}) => {
+			await apiHelpers.headlessPortalInstance.addVirtualInstance({
+				domain: ABLE_HOST,
+				portalInstanceId: ABLE_HOST,
+				virtualHost: ABLE_HOST,
+			});
+
+			const ableCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					ABLE_HOST
+				);
+
+			const ableCompanyGroup =
+				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					ableCompany.companyId
+				);
+
+			const defaultCompany =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					'liferay.com'
+				);
+
+			const defaultCompanyGroup =
+				await apiHelpers.jsonWebServicesGroup.getCompanyGroup(
+					defaultCompany.companyId
+				);
+
+			const ableStructureId = await getWebContentStructureId(
+				apiHelpers,
+				ableCompanyGroup.groupId,
+				'BASIC-WEB-CONTENT'
+			);
+
+			const defaultStructureId = await getWebContentStructureId(
+				apiHelpers,
+				defaultCompanyGroup.groupId,
+				'BASIC-WEB-CONTENT'
+			);
+
+			const ableScheduledDate = new Date(Date.now() + 4 * 60 * 1000);
+
+			const ableArticle =
+				await apiHelpers.jsonWebServicesJournal.addWebContentDetailed({
+					ddmStructureId: ableStructureId,
+					displayDateDay: ableScheduledDate.getDate(),
+					displayDateHour: ableScheduledDate.getHours(),
+					displayDateMinute: ableScheduledDate.getMinutes(),
+					displayDateMonth: ableScheduledDate.getMonth(),
+					displayDateYear: ableScheduledDate.getFullYear(),
+					groupId: ableCompanyGroup.groupId,
+					titleMap: {en_US: 'WC WebContent Title New Company'},
+				});
+
+			const defaultScheduledDate = new Date(Date.now() + 2 * 60 * 1000);
+
+			const defaultArticle =
+				await apiHelpers.jsonWebServicesJournal.addWebContentDetailed({
+					ddmStructureId: defaultStructureId,
+					displayDateDay: defaultScheduledDate.getDate(),
+					displayDateHour: defaultScheduledDate.getHours(),
+					displayDateMinute: defaultScheduledDate.getMinutes(),
+					displayDateMonth: defaultScheduledDate.getMonth(),
+					displayDateYear: defaultScheduledDate.getFullYear(),
+					groupId: defaultCompanyGroup.groupId,
+					titleMap: {
+						en_US: 'WC WebContent Title Default Company',
+					},
+				});
+
+			const journalArticlePath = `${liferayConfig.environment.baseUrl}/api/jsonws/journal.journalarticle/get-article`;
+
+			const journalHeaders = await apiHelpers.getJSONWebServicesHeaders();
+
+			const ableArticleUrlSearchParams = new URLSearchParams();
+
+			ableArticleUrlSearchParams.append(
+				'articleId',
+				ableArticle.articleId
+			);
+			ableArticleUrlSearchParams.append(
+				'groupId',
+				String(ableCompanyGroup.groupId)
+			);
+
+			const defaultArticleUrlSearchParams = new URLSearchParams();
+
+			defaultArticleUrlSearchParams.append(
+				'articleId',
+				defaultArticle.articleId
+			);
+			defaultArticleUrlSearchParams.append(
+				'groupId',
+				String(defaultCompanyGroup.groupId)
+			);
+
+			try {
+				await expect(async () => {
+					const defaultResponse = await page.request.post(
+						journalArticlePath,
+						{
+							data: defaultArticleUrlSearchParams.toString(),
+							headers: journalHeaders,
+						}
+					);
+
+					const defaultArticleData = await defaultResponse.json();
+
+					expect(defaultArticleData.status).toBe(WC_STATUS_APPROVED);
+
+					const ableResponse = await page.request.post(
+						journalArticlePath,
+						{
+							data: ableArticleUrlSearchParams.toString(),
+							headers: journalHeaders,
+						}
+					);
+
+					const ableArticleData = await ableResponse.json();
+
+					expect(ableArticleData.status).toBe(WC_STATUS_APPROVED);
+				}).toPass({timeout: 360_000});
+			}
+			finally {
+				await apiHelpers.jsonWebServicesJournal.deleteArticle(
+					String(defaultCompanyGroup.groupId),
+					defaultArticle.articleId
+				);
+
+				await apiHelpers.headlessPortalInstance.deleteVirtualInstance(
+					ableCompany.companyId
+				);
+			}
+		}
+	);
+});

--- a/modules/test/playwright/tests/db-partition/scheduler/env/osgi/configs/com.liferay.journal.configuration.JournalServiceConfiguration.config
+++ b/modules/test/playwright/tests/db-partition/scheduler/env/osgi/configs/com.liferay.journal.configuration.JournalServiceConfiguration.config
@@ -1,0 +1,1 @@
+checkInterval=I"1"

--- a/modules/test/playwright/tests/db-partition/scheduler/env/portal-ext.properties
+++ b/modules/test/playwright/tests/db-partition/scheduler/env/portal-ext.properties
@@ -1,0 +1,1 @@
+upgrade.database.auto.run=true

--- a/modules/test/playwright/tests/db-partition/scheduler/test.properties
+++ b/modules/test/playwright/tests/db-partition/scheduler/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Partitioning

--- a/modules/test/playwright/tests/db-partition/utils.ts
+++ b/modules/test/playwright/tests/db-partition/utils.ts
@@ -3,9 +3,14 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 
 export const STATE_FILE = path.join(
 	__dirname,
 	'../../test-results/db-partition-state.json'
 );
+
+export function readState(): {partitionCompanyId: number} {
+	return JSON.parse(fs.readFileSync(STATE_FILE, 'utf-8'));
+}

--- a/modules/test/playwright/tests/db-partition/utils.ts
+++ b/modules/test/playwright/tests/db-partition/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import * as path from 'path';
+
+export const STATE_FILE = path.join(
+	__dirname,
+	'../../test-results/db-partition-state.json'
+);

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/utils/setupUserRoleAndLoginAsUser.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/utils/setupUserRoleAndLoginAsUser.ts
@@ -13,7 +13,7 @@ type TRole = {
 	name: string;
 	rolePermissions?: Array<{
 		actionIds: string[];
-		primaryKey: string;
+		primaryKey: number | string;
 		resourceName: string;
 		scope: number;
 	}>;

--- a/modules/test/playwright/tests/workspaces/liferay-partner-workspace/main/types/role.d.ts
+++ b/modules/test/playwright/tests/workspaces/liferay-partner-workspace/main/types/role.d.ts
@@ -9,7 +9,7 @@ export type TRole = {
 	name: string;
 	rolePermissions?: Array<{
 		actionIds: string[];
-		primaryKey: string;
+		primaryKey: number | string;
 		resourceName: string;
 		scope: number;
 	}>;

--- a/modules/test/playwright/utils/createUserWithPermissions.ts
+++ b/modules/test/playwright/utils/createUserWithPermissions.ts
@@ -33,7 +33,7 @@ export type ActionId =
 
 export type RolePermission = {
 	actionIds: ActionId[];
-	primaryKey: string;
+	primaryKey: number | string;
 	resourceName: string;
 	scope: number;
 };


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91814

## What Is Being Fixed

There were no Playwright tests covering DB partition scenarios — export, import, clustering, and schema comparison — nor any CI batch macrodefs to drive their multi-phase execution in the test grid.

## How It Is Being Fixed

New Playwright test suites are added under `modules/test/playwright/tests/db-partition/` covering the main partition lifecycle (export, import, company creation, restart persistence, case-insensitive database variants), a clustering scenario, a scheduler scenario, and two schema comparison variants (compare-7413 and compare-latest-7413). Shared shell scripts for environment set-up and tear-down are colocated under `tests/db-partition/env/`. The multi-phase tests are split into phase1 and phase2 spec files that run as separate Playwright projects.

On the CI side, `build-test-batch.xml` receives new macrodefs that map each of these Playwright projects to batch test targets, enabling the test grid to schedule and execute them. A small change to `build-test.xml` guards an existing macro call that would otherwise clear a property when invoked outside a Poshi testcase context. Several helper utilities are updated to align type signatures with the new test scenarios.

## PR Check

**pr-check: PASS** — tested on `6cf2351e314752162929e374283f894fa3a5e315`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "6cf2351e314752162929e374283f894fa3a5e315"} -->