### PR TITLE
LPD-93237 Run data cleanup processes concurrently in waves

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -11,7 +11,9 @@ import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.ReleaseConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
@@ -34,6 +36,7 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -80,12 +83,19 @@ public class DataCleanupPreupgradeProcessSuiteTest
 			long[] companyIds = PortalInstancePool.getCompanyIds();
 
 			_companiesCount = companyIds.length;
+
+			_safeCloseable = CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+				CompanyConstants.SYSTEM);
 		}
 	}
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		_updatePortalSchemaVersion(_currentPortalSchemaVersion);
+
+		if (_safeCloseable != null) {
+			_safeCloseable.close();
+		}
 	}
 
 	@Before
@@ -283,8 +293,9 @@ public class DataCleanupPreupgradeProcessSuiteTest
 
 	private static int _companiesCount = 1;
 	private static String _currentPortalSchemaVersion;
+	private static SafeCloseable _safeCloseable;
 
-	private final List<String> _cleanupMessages = new ArrayList<>();
+	private final List<String> _cleanupMessages = new CopyOnWriteArrayList<>();
 	private Map
 		<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
 			_originalDataCleanupPreupgradeProcessesMap;

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -13,15 +13,27 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.NamedThreadFactory;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 
 import java.sql.Connection;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 /**
  * @author Luis Ortiz
@@ -40,29 +52,135 @@ public class DataCleanupPreupgradeProcessSuite {
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses =
-				getSortedDataCleanupPreupgradeProcesses();
+			List<List<DataCleanupPreupgradeProcess>> waves =
+				getLayeredDataCleanupPreupgradeProcesses();
 
-			for (DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess :
-					dataCleanupPreupgradeProcesses) {
+			int maxWaveSize = 0;
 
-				Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
+			for (List<DataCleanupPreupgradeProcess> wave : waves) {
+				if (wave.size() > maxWaveSize) {
+					maxWaveSize = wave.size();
+				}
+			}
 
-				if (ArrayUtil.contains(
-						PropsValues.
-							UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
-						clazz.getName())) {
+			ExecutorService executorService = null;
 
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							"Skipping blacklisted data cleanup process: " +
-								clazz.getName());
-					}
+			if (maxWaveSize > 1) {
+				Runtime runtime = Runtime.getRuntime();
 
-					continue;
+				int availableProcessors = runtime.availableProcessors();
+
+				int maximumPoolSize = GetterUtil.getInteger(
+					PropsUtil.get("jdbc.default.maximumPoolSize"));
+
+				int poolSize;
+
+				if (maximumPoolSize > 0) {
+					poolSize = Math.max(
+						1,
+						Math.min(
+							availableProcessors, (int)(0.9 * maximumPoolSize)));
+				}
+				else {
+					poolSize = availableProcessors;
 				}
 
-				dataCleanupPreupgradeProcess.upgrade();
+				executorService = Executors.newFixedThreadPool(
+					Math.min(maxWaveSize, poolSize),
+					new NamedThreadFactory(
+						"data-cleanup-preupgrade-process-wave-thread",
+						Thread.NORM_PRIORITY, null));
+			}
+
+			try {
+				for (List<DataCleanupPreupgradeProcess> wave : waves) {
+					if (wave.size() == 1) {
+						_runProcess(wave.get(0));
+
+						continue;
+					}
+
+					CompletionService<Void> completionService =
+						new ExecutorCompletionService<>(executorService);
+
+					List<Future<Void>> futures = new ArrayList<>();
+
+					for (DataCleanupPreupgradeProcess process : wave) {
+						futures.add(
+							completionService.submit(
+								(Callable<Void>)() -> {
+									_runProcess(process);
+
+									return null;
+								}));
+					}
+
+					for (int i = 0; i < wave.size(); i++) {
+						try {
+							Future<Void> future = completionService.take();
+
+							future.get();
+						}
+						catch (ExecutionException executionException) {
+							for (Future<Void> future : futures) {
+								future.cancel(true);
+							}
+
+							Throwable throwable = executionException.getCause();
+
+							if (throwable instanceof Error) {
+								throw (Error)throwable;
+							}
+
+							if (throwable instanceof InterruptedException) {
+								Thread currentThread = Thread.currentThread();
+
+								currentThread.interrupt();
+							}
+
+							throw throwable instanceof Exception ?
+								(Exception)throwable :
+									new RuntimeException(throwable);
+						}
+						catch (InterruptedException interruptedException) {
+							for (Future<Void> future : futures) {
+								future.cancel(true);
+							}
+
+							Thread currentThread = Thread.currentThread();
+
+							currentThread.interrupt();
+
+							throw interruptedException;
+						}
+					}
+				}
+			}
+			finally {
+				if (executorService != null) {
+					executorService.shutdownNow();
+
+					try {
+						if (!executorService.awaitTermination(
+								10, TimeUnit.SECONDS)) {
+
+							if (_log.isWarnEnabled()) {
+								_log.warn(
+									"Unable to terminate some data cleanup " +
+										"threads gracefully");
+							}
+						}
+					}
+					catch (InterruptedException interruptedException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(interruptedException);
+						}
+
+						Thread currentThread = Thread.currentThread();
+
+						currentThread.interrupt();
+					}
+				}
 			}
 		}
 	}
@@ -72,6 +190,14 @@ public class DataCleanupPreupgradeProcessSuite {
 
 		return DataCleanupPreupgradeProcess.
 			getSortedDataCleanupPreupgradeProcesses(
+				_dataCleanupPreupgradeProcessesMap);
+	}
+
+	public List<List<DataCleanupPreupgradeProcess>>
+		getLayeredDataCleanupPreupgradeProcesses() {
+
+		return DataCleanupPreupgradeProcess.
+			getLayeredDataCleanupPreupgradeProcesses(
 				_dataCleanupPreupgradeProcessesMap);
 	}
 
@@ -269,6 +395,32 @@ public class DataCleanupPreupgradeProcessSuite {
 					companyDataCleanupPreupgradeProcess,
 					databaseTableAndColumnCaseDataCleanupPreupgradeProcess)
 			).build();
+	}
+
+	private void _runProcess(
+			DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess)
+		throws Exception {
+
+		Class<?> clazz = dataCleanupPreupgradeProcess.getClass();
+
+		if (ArrayUtil.contains(
+				PropsValues.UPGRADE_DATABASE_PREUPGRADE_DATA_CLEANUP_BLACKLIST,
+				clazz.getName())) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"Skipping blacklisted data cleanup process: " +
+						clazz.getName());
+			}
+
+			return;
+		}
+
+		try (LoggingTimer loggingTimer = new LoggingTimer(
+				clazz.getSimpleName())) {
+
+			dataCleanupPreupgradeProcess.upgrade();
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -5,35 +5,25 @@
 
 package com.liferay.portal.upgrade.data.cleanup;
 
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.portal.db.index.PrimaryKeyUpdaterUtil;
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.dao.db.BaseDBProcess;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
 import com.liferay.portal.kernel.upgrade.data.cleanup.DataCleanupPreupgradeProcess;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.LoggingTimer;
-import com.liferay.portal.kernel.util.NamedThreadFactory;
-import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.upgrade.PortalUpgradeProcess;
 
 import java.sql.Connection;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 /**
  * @author Luis Ortiz
@@ -52,136 +42,12 @@ public class DataCleanupPreupgradeProcessSuite {
 		}
 
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			List<List<DataCleanupPreupgradeProcess>> waves =
-				getLayeredDataCleanupPreupgradeProcesses();
+			DataCleanupConcurrentExecutor dataCleanupConcurrentExecutor =
+				new DataCleanupConcurrentExecutor();
 
-			int maxWaveSize = 0;
-
-			for (List<DataCleanupPreupgradeProcess> wave : waves) {
-				if (wave.size() > maxWaveSize) {
-					maxWaveSize = wave.size();
-				}
-			}
-
-			ExecutorService executorService = null;
-
-			if (maxWaveSize > 1) {
-				Runtime runtime = Runtime.getRuntime();
-
-				int availableProcessors = runtime.availableProcessors();
-
-				int maximumPoolSize = GetterUtil.getInteger(
-					PropsUtil.get("jdbc.default.maximumPoolSize"));
-
-				int poolSize;
-
-				if (maximumPoolSize > 0) {
-					poolSize = Math.max(
-						1,
-						Math.min(
-							availableProcessors, (int)(0.9 * maximumPoolSize)));
-				}
-				else {
-					poolSize = availableProcessors;
-				}
-
-				executorService = Executors.newFixedThreadPool(
-					Math.min(maxWaveSize, poolSize),
-					new NamedThreadFactory(
-						"data-cleanup-preupgrade-process-wave-thread",
-						Thread.NORM_PRIORITY, null));
-			}
-
-			try {
-				for (List<DataCleanupPreupgradeProcess> wave : waves) {
-					if (wave.size() == 1) {
-						_runProcess(wave.get(0));
-
-						continue;
-					}
-
-					CompletionService<Void> completionService =
-						new ExecutorCompletionService<>(executorService);
-
-					List<Future<Void>> futures = new ArrayList<>();
-
-					for (DataCleanupPreupgradeProcess process : wave) {
-						futures.add(
-							completionService.submit(
-								(Callable<Void>)() -> {
-									_runProcess(process);
-
-									return null;
-								}));
-					}
-
-					for (int i = 0; i < wave.size(); i++) {
-						try {
-							Future<Void> future = completionService.take();
-
-							future.get();
-						}
-						catch (ExecutionException executionException) {
-							for (Future<Void> future : futures) {
-								future.cancel(true);
-							}
-
-							Throwable throwable = executionException.getCause();
-
-							if (throwable instanceof Error) {
-								throw (Error)throwable;
-							}
-
-							if (throwable instanceof InterruptedException) {
-								Thread currentThread = Thread.currentThread();
-
-								currentThread.interrupt();
-							}
-
-							throw throwable instanceof Exception ?
-								(Exception)throwable :
-									new RuntimeException(throwable);
-						}
-						catch (InterruptedException interruptedException) {
-							for (Future<Void> future : futures) {
-								future.cancel(true);
-							}
-
-							Thread currentThread = Thread.currentThread();
-
-							currentThread.interrupt();
-
-							throw interruptedException;
-						}
-					}
-				}
-			}
-			finally {
-				if (executorService != null) {
-					executorService.shutdownNow();
-
-					try {
-						if (!executorService.awaitTermination(
-								10, TimeUnit.SECONDS)) {
-
-							if (_log.isWarnEnabled()) {
-								_log.warn(
-									"Unable to terminate some data cleanup " +
-										"threads gracefully");
-							}
-						}
-					}
-					catch (InterruptedException interruptedException) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(interruptedException);
-						}
-
-						Thread currentThread = Thread.currentThread();
-
-						currentThread.interrupt();
-					}
-				}
-			}
+			dataCleanupConcurrentExecutor._execute(
+				_getLayeredDataCleanupPreupgradeProcesses(),
+				this::_runDataCleanupPreupgradeProcess);
 		}
 	}
 
@@ -190,14 +56,6 @@ public class DataCleanupPreupgradeProcessSuite {
 
 		return DataCleanupPreupgradeProcess.
 			getSortedDataCleanupPreupgradeProcesses(
-				_dataCleanupPreupgradeProcessesMap);
-	}
-
-	public List<List<DataCleanupPreupgradeProcess>>
-		getLayeredDataCleanupPreupgradeProcesses() {
-
-		return DataCleanupPreupgradeProcess.
-			getLayeredDataCleanupPreupgradeProcesses(
 				_dataCleanupPreupgradeProcessesMap);
 	}
 
@@ -397,7 +255,15 @@ public class DataCleanupPreupgradeProcessSuite {
 			).build();
 	}
 
-	private void _runProcess(
+	private List<List<DataCleanupPreupgradeProcess>>
+		_getLayeredDataCleanupPreupgradeProcesses() {
+
+		return DataCleanupPreupgradeProcess.
+			getLayeredDataCleanupPreupgradeProcesses(
+				_dataCleanupPreupgradeProcessesMap);
+	}
+
+	private void _runDataCleanupPreupgradeProcess(
 			DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess)
 		throws Exception {
 
@@ -430,5 +296,35 @@ public class DataCleanupPreupgradeProcessSuite {
 		<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
 			_dataCleanupPreupgradeProcessesMap =
 				_createDataCleanupPreupgradeProcessesMap();
+
+	private static class DataCleanupConcurrentExecutor extends BaseDBProcess {
+
+		private void _execute(
+				List<List<DataCleanupPreupgradeProcess>>
+					dataCleanupPreupgradeProcessesList,
+				UnsafeConsumer<DataCleanupPreupgradeProcess, Exception>
+					unsafeConsumer)
+			throws Exception {
+
+			for (List<DataCleanupPreupgradeProcess>
+					dataCleanupPreupgradeProcesses :
+						dataCleanupPreupgradeProcessesList) {
+
+				if (dataCleanupPreupgradeProcesses.size() == 1) {
+					unsafeConsumer.accept(
+						dataCleanupPreupgradeProcesses.get(0));
+
+					continue;
+				}
+
+				processConcurrently(
+					dataCleanupPreupgradeProcesses.toArray(
+						new DataCleanupPreupgradeProcess[0]),
+					unsafeConsumer,
+					"Unable to run data cleanup processes concurrently");
+			}
+		}
+
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcess.java
@@ -5,14 +5,17 @@
 
 package com.liferay.portal.kernel.upgrade.data.cleanup;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ListUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Luis Ortiz
@@ -23,6 +26,92 @@ public class DataCleanupPreupgradeProcess extends UpgradeProcess {
 		DataCleanupPreupgradeProcess... dataCleanupPreupgradeProcesses) {
 
 		return ListUtil.fromArray(dataCleanupPreupgradeProcesses);
+	}
+
+	public static List<List<DataCleanupPreupgradeProcess>>
+		getLayeredDataCleanupPreupgradeProcesses(
+			Map
+				<DataCleanupPreupgradeProcess,
+				 List<DataCleanupPreupgradeProcess>>
+					dataCleanupPreupgradeProcessesMap) {
+
+		List<List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesList = new ArrayList<>();
+		Set<DataCleanupPreupgradeProcess>
+			completedDataCleanupPreupgradeProcesses = new HashSet<>();
+
+		while (completedDataCleanupPreupgradeProcesses.size() !=
+					dataCleanupPreupgradeProcessesMap.size()) {
+
+			List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses =
+				new ArrayList<>();
+
+			for (Map.Entry
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>> entry :
+						dataCleanupPreupgradeProcessesMap.entrySet()) {
+
+				DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess =
+					entry.getKey();
+
+				if (completedDataCleanupPreupgradeProcesses.contains(
+						dataCleanupPreupgradeProcess) ||
+					!completedDataCleanupPreupgradeProcesses.containsAll(
+						entry.getValue())) {
+
+					continue;
+				}
+
+				dataCleanupPreupgradeProcesses.add(
+					dataCleanupPreupgradeProcess);
+			}
+
+			if (dataCleanupPreupgradeProcesses.isEmpty()) {
+				for (Map.Entry
+						<DataCleanupPreupgradeProcess,
+						 List<DataCleanupPreupgradeProcess>> entry :
+							dataCleanupPreupgradeProcessesMap.entrySet()) {
+
+					if (completedDataCleanupPreupgradeProcesses.contains(
+							entry.getKey())) {
+
+						continue;
+					}
+
+					for (DataCleanupPreupgradeProcess dependency :
+							entry.getValue()) {
+
+						if (!dataCleanupPreupgradeProcessesMap.containsKey(
+								dependency)) {
+
+							DataCleanupPreupgradeProcess
+								dataCleanupPreupgradeProcess = entry.getKey();
+
+							Class<?> dataCleanupPreupgradeProcessClazz =
+								dataCleanupPreupgradeProcess.getClass();
+
+							Class<?> dependencyClazz = dependency.getClass();
+
+							throw new IllegalStateException(
+								StringBundler.concat(
+									"Missing dependency ",
+									dependencyClazz.getName(), " required by ",
+									dataCleanupPreupgradeProcessClazz.
+										getName()));
+						}
+					}
+				}
+
+				throw new IllegalStateException("Circular dependency");
+			}
+
+			completedDataCleanupPreupgradeProcesses.addAll(
+				dataCleanupPreupgradeProcesses);
+			dataCleanupPreupgradeProcessesList.add(
+				dataCleanupPreupgradeProcesses);
+		}
+
+		return dataCleanupPreupgradeProcessesList;
 	}
 
 	public static List<DataCleanupPreupgradeProcess>

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtil.java
@@ -15,6 +15,8 @@ import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.RetryAcceptor;
+import com.liferay.portal.kernel.service.SQLStateAcceptor;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -22,9 +24,11 @@ import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -104,18 +108,14 @@ public class OrphanReferencesDataCleanupUtil {
 			ResultSet resultSet = preparedStatement1.executeQuery()) {
 
 			if (!readOnly) {
-				try (PreparedStatement preparedStatement2 =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"delete ",
-								aliasNeeded ?
-									(_SOURCE_TABLE_ALIAS + StringPool.SPACE) :
-										"",
-								"from ", sourceTableName, StringPool.SPACE,
-								_SOURCE_TABLE_ALIAS, whereClause))) {
-
-					preparedStatement2.execute();
-				}
+				_executeDelete(
+					connection,
+					StringBundler.concat(
+						"delete ",
+						aliasNeeded ? (_SOURCE_TABLE_ALIAS + StringPool.SPACE) :
+							"",
+						"from ", sourceTableName, StringPool.SPACE,
+						_SOURCE_TABLE_ALIAS, whereClause));
 			}
 
 			if (!_log.isInfoEnabled()) {
@@ -222,6 +222,53 @@ public class OrphanReferencesDataCleanupUtil {
 
 		return StringUtil.replace(
 			whereClause, "[$SOURCE_TABLE_ALIAS$]", _SOURCE_TABLE_ALIAS);
+	}
+
+	private static void _executeDelete(Connection connection, String deleteSQL)
+		throws Exception {
+
+		int retryCount = 0;
+
+		while (true) {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(deleteSQL)) {
+
+				preparedStatement.executeUpdate();
+
+				return;
+			}
+			catch (SQLException sqlException) {
+				if ((retryCount >= _DELETE_DEADLOCK_MAX_RETRIES) ||
+					!_retryAcceptor.acceptException(
+						sqlException,
+						Collections.singletonMap(
+							SQLStateAcceptor.SQLSTATE,
+							SQLStateAcceptor.SQLSTATE_TRANSACTION_ROLLBACK))) {
+
+					throw sqlException;
+				}
+
+				retryCount++;
+
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Retrying delete after a database deadlock: " +
+							deleteSQL,
+						sqlException);
+				}
+
+				try {
+					Thread.sleep(_DELETE_DEADLOCK_RETRY_WAIT * retryCount);
+				}
+				catch (InterruptedException interruptedException) {
+					Thread currentThread = Thread.currentThread();
+
+					currentThread.interrupt();
+
+					throw interruptedException;
+				}
+			}
+		}
 	}
 
 	private static Set<String> _getFirstIndexColumnNames(
@@ -416,6 +463,10 @@ public class OrphanReferencesDataCleanupUtil {
 		return sb.toString();
 	}
 
+	private static final int _DELETE_DEADLOCK_MAX_RETRIES = 3;
+
+	private static final int _DELETE_DEADLOCK_RETRY_WAIT = 500;
+
 	private static final String _SOURCE_TABLE_ALIAS = "s";
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -426,5 +477,6 @@ public class OrphanReferencesDataCleanupUtil {
 			"Audit_AuditEvent", "CyrusUser", "CyrusVirtual", "SystemEvent"));
 	private static final List<String> _normalizedExcludedTableNames =
 		new ArrayList<>();
+	private static final RetryAcceptor _retryAcceptor = new SQLStateAcceptor();
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcessTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/DataCleanupPreupgradeProcessTest.java
@@ -1,0 +1,269 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade.data.cleanup;
+
+import com.liferay.portal.kernel.util.HashMapBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge Avalos
+ */
+public class DataCleanupPreupgradeProcessTest {
+
+	@Test
+	public void testGetLayeredDataCleanupPreupgradeProcessesWithCircularDependency() {
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess1 =
+			_createDataCleanupPreupgradeProcess();
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess2 =
+			_createDataCleanupPreupgradeProcess();
+
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesMap =
+				HashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						dataCleanupPreupgradeProcess1,
+						DataCleanupPreupgradeProcess.dependsOn(
+							dataCleanupPreupgradeProcess2)
+					).put(
+						dataCleanupPreupgradeProcess2,
+						DataCleanupPreupgradeProcess.dependsOn(
+							dataCleanupPreupgradeProcess1)
+					).build();
+
+		try {
+			DataCleanupPreupgradeProcess.
+				getLayeredDataCleanupPreupgradeProcesses(
+					dataCleanupPreupgradeProcessesMap);
+
+			Assert.fail();
+		}
+		catch (IllegalStateException illegalStateException) {
+			Assert.assertEquals(
+				"Circular dependency", illegalStateException.getMessage());
+		}
+	}
+
+	@Test
+	public void testGetLayeredDataCleanupPreupgradeProcessesWithDiamondDependency() {
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess1 =
+			_createDataCleanupPreupgradeProcess();
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess2 =
+			_createDataCleanupPreupgradeProcess();
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess3 =
+			_createDataCleanupPreupgradeProcess();
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess4 =
+			_createDataCleanupPreupgradeProcess();
+
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesMap =
+				HashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						dataCleanupPreupgradeProcess1,
+						DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						dataCleanupPreupgradeProcess2,
+						DataCleanupPreupgradeProcess.dependsOn(
+							dataCleanupPreupgradeProcess1)
+					).put(
+						dataCleanupPreupgradeProcess3,
+						DataCleanupPreupgradeProcess.dependsOn(
+							dataCleanupPreupgradeProcess1)
+					).put(
+						dataCleanupPreupgradeProcess4,
+						DataCleanupPreupgradeProcess.dependsOn(
+							dataCleanupPreupgradeProcess2,
+							dataCleanupPreupgradeProcess3)
+					).build();
+
+		List<List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesList =
+				DataCleanupPreupgradeProcess.
+					getLayeredDataCleanupPreupgradeProcesses(
+						dataCleanupPreupgradeProcessesMap);
+
+		Assert.assertEquals(
+			dataCleanupPreupgradeProcessesList.toString(), 3,
+			dataCleanupPreupgradeProcessesList.size());
+
+		List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses1 =
+			dataCleanupPreupgradeProcessesList.get(0);
+
+		Assert.assertEquals(
+			dataCleanupPreupgradeProcesses1.toString(), 1,
+			dataCleanupPreupgradeProcesses1.size());
+		Assert.assertSame(
+			dataCleanupPreupgradeProcess1,
+			dataCleanupPreupgradeProcesses1.get(0));
+
+		List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses2 =
+			dataCleanupPreupgradeProcessesList.get(1);
+
+		Assert.assertEquals(
+			dataCleanupPreupgradeProcesses2.toString(), 2,
+			dataCleanupPreupgradeProcesses2.size());
+		Assert.assertTrue(
+			dataCleanupPreupgradeProcesses2.contains(
+				dataCleanupPreupgradeProcess2));
+		Assert.assertTrue(
+			dataCleanupPreupgradeProcesses2.contains(
+				dataCleanupPreupgradeProcess3));
+
+		List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses3 =
+			dataCleanupPreupgradeProcessesList.get(2);
+
+		Assert.assertEquals(
+			dataCleanupPreupgradeProcesses3.toString(), 1,
+			dataCleanupPreupgradeProcesses3.size());
+		Assert.assertSame(
+			dataCleanupPreupgradeProcess4,
+			dataCleanupPreupgradeProcesses3.get(0));
+	}
+
+	@Test
+	public void testGetLayeredDataCleanupPreupgradeProcessesWithLinearChain() {
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess1 =
+			_createDataCleanupPreupgradeProcess();
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess2 =
+			_createDataCleanupPreupgradeProcess();
+		DataCleanupPreupgradeProcess dataCleanupPreupgradeProcess3 =
+			_createDataCleanupPreupgradeProcess();
+
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesMap =
+				HashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						dataCleanupPreupgradeProcess1,
+						DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						dataCleanupPreupgradeProcess2,
+						DataCleanupPreupgradeProcess.dependsOn(
+							dataCleanupPreupgradeProcess1)
+					).put(
+						dataCleanupPreupgradeProcess3,
+						DataCleanupPreupgradeProcess.dependsOn(
+							dataCleanupPreupgradeProcess2)
+					).build();
+
+		List<List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesList =
+				DataCleanupPreupgradeProcess.
+					getLayeredDataCleanupPreupgradeProcesses(
+						dataCleanupPreupgradeProcessesMap);
+
+		Assert.assertEquals(
+			dataCleanupPreupgradeProcessesList.toString(), 3,
+			dataCleanupPreupgradeProcessesList.size());
+
+		for (List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses :
+				dataCleanupPreupgradeProcessesList) {
+
+			Assert.assertEquals(
+				dataCleanupPreupgradeProcesses.toString(), 1,
+				dataCleanupPreupgradeProcesses.size());
+		}
+
+		List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses1 =
+			dataCleanupPreupgradeProcessesList.get(0);
+
+		Assert.assertSame(
+			dataCleanupPreupgradeProcess1,
+			dataCleanupPreupgradeProcesses1.get(0));
+
+		List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses2 =
+			dataCleanupPreupgradeProcessesList.get(1);
+
+		Assert.assertSame(
+			dataCleanupPreupgradeProcess2,
+			dataCleanupPreupgradeProcesses2.get(0));
+
+		List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses3 =
+			dataCleanupPreupgradeProcessesList.get(2);
+
+		Assert.assertSame(
+			dataCleanupPreupgradeProcess3,
+			dataCleanupPreupgradeProcesses3.get(0));
+	}
+
+	@Test
+	public void testGetLayeredDataCleanupPreupgradeProcessesWithMissingDependency() {
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesMap =
+				HashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						_createDataCleanupPreupgradeProcess(),
+						DataCleanupPreupgradeProcess.dependsOn(
+							_createDataCleanupPreupgradeProcess())
+					).build();
+
+		try {
+			DataCleanupPreupgradeProcess.
+				getLayeredDataCleanupPreupgradeProcesses(
+					dataCleanupPreupgradeProcessesMap);
+
+			Assert.fail();
+		}
+		catch (IllegalStateException illegalStateException) {
+			String message = illegalStateException.getMessage();
+
+			Assert.assertTrue(message.startsWith("Missing dependency "));
+		}
+	}
+
+	@Test
+	public void testGetLayeredDataCleanupPreupgradeProcessesWithNoDependencies() {
+		Map<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesMap =
+				HashMapBuilder.
+					<DataCleanupPreupgradeProcess,
+					 List<DataCleanupPreupgradeProcess>>put(
+						_createDataCleanupPreupgradeProcess(),
+						DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						_createDataCleanupPreupgradeProcess(),
+						DataCleanupPreupgradeProcess.dependsOn()
+					).put(
+						_createDataCleanupPreupgradeProcess(),
+						DataCleanupPreupgradeProcess.dependsOn()
+					).build();
+
+		List<List<DataCleanupPreupgradeProcess>>
+			dataCleanupPreupgradeProcessesList =
+				DataCleanupPreupgradeProcess.
+					getLayeredDataCleanupPreupgradeProcesses(
+						dataCleanupPreupgradeProcessesMap);
+
+		Assert.assertEquals(
+			dataCleanupPreupgradeProcessesList.toString(), 1,
+			dataCleanupPreupgradeProcessesList.size());
+
+		List<DataCleanupPreupgradeProcess> dataCleanupPreupgradeProcesses1 =
+			dataCleanupPreupgradeProcessesList.get(0);
+
+		Assert.assertEquals(
+			dataCleanupPreupgradeProcesses1.toString(), 3,
+			dataCleanupPreupgradeProcesses1.size());
+	}
+
+	private DataCleanupPreupgradeProcess _createDataCleanupPreupgradeProcess() {
+		return new DataCleanupPreupgradeProcess() {
+
+			@Override
+			protected void doUpgrade() {
+			}
+
+		};
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtilTest.java
@@ -6,12 +6,11 @@
 package com.liferay.portal.kernel.upgrade.data.cleanup.util;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,24 +29,13 @@ public class OrphanReferencesDataCleanupUtilTest {
 
 		Mockito.doThrow(
 			new SQLException(
-				"Constraint violation", _SQLSTATE_CONSTRAINT_VIOLATION)
+				RandomTestUtil.randomString(), _SQLSTATE_CONSTRAINT_VIOLATION)
 		).when(
 			preparedStatement
 		).executeUpdate();
 
-		Connection connection = Mockito.mock(Connection.class);
-
-		Mockito.when(
-			connection.prepareStatement(Mockito.anyString())
-		).thenReturn(
-			preparedStatement
-		);
-
 		try {
-			ReflectionTestUtil.invoke(
-				OrphanReferencesDataCleanupUtil.class, "_executeDelete",
-				new Class<?>[] {Connection.class, String.class}, connection,
-				"delete from foo where bar is null");
+			_invokeExecuteDelete(preparedStatement);
 
 			Assert.fail();
 		}
@@ -68,34 +56,15 @@ public class OrphanReferencesDataCleanupUtilTest {
 		PreparedStatement preparedStatement = Mockito.mock(
 			PreparedStatement.class);
 
-		AtomicInteger callCount = new AtomicInteger();
-
-		Mockito.doAnswer(
-			invocation -> {
-				if (callCount.incrementAndGet() == 1) {
-					throw new SQLException("Deadlock", _SQLSTATE_DEADLOCK);
-				}
-
-				return 0;
-			}
+		Mockito.doThrow(
+			new SQLException(RandomTestUtil.randomString(), _SQLSTATE_DEADLOCK)
+		).doReturn(
+			RandomTestUtil.randomInt()
 		).when(
 			preparedStatement
 		).executeUpdate();
 
-		Connection connection = Mockito.mock(Connection.class);
-
-		Mockito.when(
-			connection.prepareStatement(Mockito.anyString())
-		).thenReturn(
-			preparedStatement
-		);
-
-		ReflectionTestUtil.invoke(
-			OrphanReferencesDataCleanupUtil.class, "_executeDelete",
-			new Class<?>[] {Connection.class, String.class}, connection,
-			"delete from foo where bar is null");
-
-		Assert.assertEquals(2, callCount.get());
+		_invokeExecuteDelete(preparedStatement);
 
 		Mockito.verify(
 			preparedStatement, Mockito.times(2)
@@ -108,24 +77,13 @@ public class OrphanReferencesDataCleanupUtilTest {
 			PreparedStatement.class);
 
 		Mockito.doThrow(
-			new SQLException("Deadlock", _SQLSTATE_DEADLOCK)
+			new SQLException(RandomTestUtil.randomString(), _SQLSTATE_DEADLOCK)
 		).when(
 			preparedStatement
 		).executeUpdate();
 
-		Connection connection = Mockito.mock(Connection.class);
-
-		Mockito.when(
-			connection.prepareStatement(Mockito.anyString())
-		).thenReturn(
-			preparedStatement
-		);
-
 		try {
-			ReflectionTestUtil.invoke(
-				OrphanReferencesDataCleanupUtil.class, "_executeDelete",
-				new Class<?>[] {Connection.class, String.class}, connection,
-				"delete from foo where bar is null");
+			_invokeExecuteDelete(preparedStatement);
 
 			Assert.fail();
 		}
@@ -138,11 +96,28 @@ public class OrphanReferencesDataCleanupUtilTest {
 		int expectedAttempts =
 			(int)ReflectionTestUtil.getFieldValue(
 				OrphanReferencesDataCleanupUtil.class,
-				"_DELETE_MAX_DEADLOCK_RETRIES") + 1;
+				"_DELETE_DEADLOCK_MAX_RETRIES") + 1;
 
 		Mockito.verify(
 			preparedStatement, Mockito.times(expectedAttempts)
 		).executeUpdate();
+	}
+
+	private void _invokeExecuteDelete(PreparedStatement preparedStatement)
+		throws Exception {
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		ReflectionTestUtil.invoke(
+			OrphanReferencesDataCleanupUtil.class, "_executeDelete",
+			new Class<?>[] {Connection.class, String.class}, connection,
+			RandomTestUtil.randomString());
 	}
 
 	private static final String _SQLSTATE_CONSTRAINT_VIOLATION = "23000";

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/upgrade/data/cleanup/util/OrphanReferencesDataCleanupUtilTest.java
@@ -1,0 +1,152 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.upgrade.data.cleanup.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class OrphanReferencesDataCleanupUtilTest {
+
+	@Test
+	public void testExecuteDeleteWithoutRetry() throws Exception {
+		PreparedStatement preparedStatement = Mockito.mock(
+			PreparedStatement.class);
+
+		Mockito.doThrow(
+			new SQLException(
+				"Constraint violation", _SQLSTATE_CONSTRAINT_VIOLATION)
+		).when(
+			preparedStatement
+		).executeUpdate();
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		try {
+			ReflectionTestUtil.invoke(
+				OrphanReferencesDataCleanupUtil.class, "_executeDelete",
+				new Class<?>[] {Connection.class, String.class}, connection,
+				"delete from foo where bar is null");
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			SQLException sqlException = (SQLException)exception;
+
+			Assert.assertEquals(
+				_SQLSTATE_CONSTRAINT_VIOLATION, sqlException.getSQLState());
+		}
+
+		Mockito.verify(
+			preparedStatement, Mockito.times(1)
+		).executeUpdate();
+	}
+
+	@Test
+	public void testExecuteDeleteWithRetry() throws Exception {
+		PreparedStatement preparedStatement = Mockito.mock(
+			PreparedStatement.class);
+
+		AtomicInteger callCount = new AtomicInteger();
+
+		Mockito.doAnswer(
+			invocation -> {
+				if (callCount.incrementAndGet() == 1) {
+					throw new SQLException("Deadlock", _SQLSTATE_DEADLOCK);
+				}
+
+				return 0;
+			}
+		).when(
+			preparedStatement
+		).executeUpdate();
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		ReflectionTestUtil.invoke(
+			OrphanReferencesDataCleanupUtil.class, "_executeDelete",
+			new Class<?>[] {Connection.class, String.class}, connection,
+			"delete from foo where bar is null");
+
+		Assert.assertEquals(2, callCount.get());
+
+		Mockito.verify(
+			preparedStatement, Mockito.times(2)
+		).executeUpdate();
+	}
+
+	@Test
+	public void testExecuteDeleteWithRetryExhausted() throws Exception {
+		PreparedStatement preparedStatement = Mockito.mock(
+			PreparedStatement.class);
+
+		Mockito.doThrow(
+			new SQLException("Deadlock", _SQLSTATE_DEADLOCK)
+		).when(
+			preparedStatement
+		).executeUpdate();
+
+		Connection connection = Mockito.mock(Connection.class);
+
+		Mockito.when(
+			connection.prepareStatement(Mockito.anyString())
+		).thenReturn(
+			preparedStatement
+		);
+
+		try {
+			ReflectionTestUtil.invoke(
+				OrphanReferencesDataCleanupUtil.class, "_executeDelete",
+				new Class<?>[] {Connection.class, String.class}, connection,
+				"delete from foo where bar is null");
+
+			Assert.fail();
+		}
+		catch (Exception exception) {
+			SQLException sqlException = (SQLException)exception;
+
+			Assert.assertEquals(_SQLSTATE_DEADLOCK, sqlException.getSQLState());
+		}
+
+		int expectedAttempts =
+			(int)ReflectionTestUtil.getFieldValue(
+				OrphanReferencesDataCleanupUtil.class,
+				"_DELETE_MAX_DEADLOCK_RETRIES") + 1;
+
+		Mockito.verify(
+			preparedStatement, Mockito.times(expectedAttempts)
+		).executeUpdate();
+	}
+
+	private static final String _SQLSTATE_CONSTRAINT_VIOLATION = "23000";
+
+	private static final String _SQLSTATE_DEADLOCK = "40001";
+
+}

--- a/test.properties
+++ b/test.properties
@@ -3535,6 +3535,7 @@
         **/portal-db-partition-test/**/*Test.java,\
         **/portal-tools-db-partition*/**/*Test.java,\
         **/testIntegration/**/DatabaseTableAndColumnCaseDataCleanupPreupgradeProcessTest.java,\
+        **/testIntegration/**/DataCleanupPreupgradeProcessSuiteTest.java,\
         **/testIntegration/**/OrphanReferencesDataCleanupUtilTest.java,\
         **/testIntegration/**/UpgradeProcessDBPartitionTest.java,\
         **/testIntegration/**/company/service/test/*Test.java,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93237

## What Is Being Fixed

The data cleanup preupgrade processes ran strictly one after another, even when many had no dependency on each other. On large databases this made the preupgrade data cleanup phase unnecessarily slow. Separately, the orphan-reference delete statements could fail with an InnoDB deadlock, aborting the cleanup.

## How It Is Being Fixed

`DataCleanupPreupgradeProcess` gains `getLayeredDataCleanupPreupgradeProcesses`, which groups the processes into dependency layers: every process in a layer is independent of the others in that layer, so the suite runs each layer's members concurrently through `BaseDBProcess.processConcurrently` while keeping the layers themselves in dependency order. Single-process layers run inline. The grouping also detects and reports missing and circular dependencies.

To survive contention from the concurrent deletes, `OrphanReferencesDataCleanupUtil` now retries an orphan-reference delete on an InnoDB deadlock, using `SQLStateAcceptor` to recognize the transaction-rollback SQL state, retrying up to three times with a growing backoff.

The exported `com.liferay.portal.kernel.upgrade.data.cleanup` package is bumped from 5.0.0 to 5.1.0 for the new public method, and `DataCleanupPreupgradeProcessSuiteTest` is prepared to run in the database partition suite. Unit tests cover the layer grouping (including the missing- and circular-dependency cases) and the deadlock retry.

## PR Check

**pr-check: PASS** — tested on `150d7ea55d792d64db48d50d8614f7ecc3d884e0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS (targeted portal-core compile, per local convention) |
| Cross-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "150d7ea55d792d64db48d50d8614f7ecc3d884e0"} -->
