### PR TITLE
LPD-91341 Scope autoCommit to AutoBatch flush boundaries

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/BaseDBProcessTest.java
@@ -34,11 +34,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -551,9 +554,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 				"select id from " + _TABLE_NAME,
 				resultSet -> new Object[] {resultSet.getInt("id")},
 				values -> {
-					Thread currentThread = Thread.currentThread();
-
-					threadIds.add(currentThread.getId());
+					_recordThread(threadIds);
 
 					int value = (int)values[0];
 
@@ -573,9 +574,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 				"update " + _TABLE_NAME + " set typeInteger = ? where id = ?",
 				resultSet -> new Object[] {resultSet.getInt("id")},
 				(values, preparedStatement) -> {
-					Thread currentThread = Thread.currentThread();
-
-					threadIds.add(currentThread.getId());
+					_recordThread(threadIds);
 
 					int value = (int)values[0];
 
@@ -599,9 +598,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 			threadIds -> processConcurrently(
 				values.toArray(new Integer[0]),
 				value -> {
-					Thread currentThread = Thread.currentThread();
-
-					threadIds.add(currentThread.getId());
+					_recordThread(threadIds);
 
 					runSQL(
 						StringBundler.concat(
@@ -629,6 +626,18 @@ public class BaseDBProcessTest extends BaseDBProcess {
 		}
 	}
 
+	private void _recordThread(Set<Long> threadIds)
+		throws InterruptedException {
+
+		Thread currentThread = Thread.currentThread();
+
+		threadIds.add(currentThread.getId());
+
+		_countDownLatch.countDown();
+
+		_countDownLatch.await(1, TimeUnit.MINUTES);
+	}
+
 	private void _validateIndex(String[] columnNames) throws Exception {
 		List<IndexMetadata> indexMetadatas = ReflectionTestUtil.invoke(
 			_db, "getIndexMetadatas",
@@ -654,6 +663,10 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	private void _validateProcessConcurrently(
 			UnsafeConsumer<Set<Long>, Exception> unsafeConsumer)
 		throws Exception {
+
+		Runtime runtime = Runtime.getRuntime();
+
+		Assume.assumeTrue(runtime.availableProcessors() > 1);
 
 		_populateTable();
 
@@ -692,5 +705,7 @@ public class BaseDBProcessTest extends BaseDBProcess {
 	private static DB _db;
 	private static DBInspector _dbInspector;
 	private static AtomicLong _tempIndexCounter;
+
+	private final CountDownLatch _countDownLatch = new CountDownLatch(2);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -886,7 +886,18 @@ public abstract class BaseDBProcess implements DBProcess {
 				result = method.invoke(_preparedStatement, args);
 			}
 			catch (InvocationTargetException invocationTargetException) {
-				throw invocationTargetException.getCause();
+				Throwable causeThrowable = invocationTargetException.getCause();
+
+				if (_transaction) {
+					try {
+						_finishTransaction(false);
+					}
+					catch (SQLException sqlException) {
+						causeThrowable.addSuppressed(sqlException);
+					}
+				}
+
+				throw causeThrowable;
 			}
 
 			if (addBatch) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -570,46 +570,6 @@ public abstract class BaseDBProcess implements DBProcess {
 		}
 	}
 
-	private Connection _enableTransactionForCurrentThread()
-		throws SQLException {
-
-		Map<Thread, Connection> connectionsMap = _connectionsMaps.get(
-			PropsValues.DATABASE_PARTITION_ENABLED ?
-				CompanyThreadLocal.getCompanyId() : CompanyConstants.SYSTEM);
-
-		if (connectionsMap == null) {
-			return null;
-		}
-
-		Connection workerConnection = connectionsMap.get(
-			Thread.currentThread());
-
-		if (workerConnection == null) {
-			return null;
-		}
-
-		boolean previousAutoCommit = workerConnection.getAutoCommit();
-
-		if (!previousAutoCommit) {
-			return null;
-		}
-
-		if (!_transactionalConnections.add(workerConnection)) {
-			return null;
-		}
-
-		try {
-			workerConnection.setAutoCommit(false);
-		}
-		catch (SQLException sqlException) {
-			_transactionalConnections.remove(workerConnection);
-
-			throw sqlException;
-		}
-
-		return workerConnection;
-	}
-
 	private void _finishAndCloseConnection(Connection connection) {
 		if (_transactionalConnections.remove(connection)) {
 			if (_log.isWarnEnabled()) {
@@ -660,8 +620,18 @@ public abstract class BaseDBProcess implements DBProcess {
 						AutoBatchPreparedStatementUtil.autoBatch(
 							connection, updateSQL);
 
-					Connection workerConnection =
-						_enableTransactionForCurrentThread();
+					Map<Thread, Connection> connectionsMap =
+						_connectionsMaps.get(
+							PropsValues.DATABASE_PARTITION_ENABLED ?
+								CompanyThreadLocal.getCompanyId() :
+									CompanyConstants.SYSTEM);
+
+					if (connectionsMap == null) {
+						return preparedStatement;
+					}
+
+					Connection workerConnection = connectionsMap.get(
+						Thread.currentThread());
 
 					if (workerConnection == null) {
 						return preparedStatement;
@@ -671,7 +641,7 @@ public abstract class BaseDBProcess implements DBProcess {
 						ClassLoader.getSystemClassLoader(),
 						new Class<?>[] {PreparedStatement.class},
 						new BatchCommitInvocationHandler(
-							workerConnection, preparedStatement));
+							workerConnection, _transactionalConnections, preparedStatement));
 				}
 				catch (SQLException sqlException) {
 					throw new RuntimeException(sqlException);
@@ -913,6 +883,12 @@ public abstract class BaseDBProcess implements DBProcess {
 
 			String methodName = method.getName();
 
+			boolean isAddBatch = methodName.equals("addBatch");
+
+			if (isAddBatch && !_transaction) {
+				_startTransaction();
+			}
+
 			Object result;
 
 			try {
@@ -922,32 +898,80 @@ public abstract class BaseDBProcess implements DBProcess {
 				throw invocationTargetException.getCause();
 			}
 
-			if (methodName.equals("addBatch")) {
+			if (isAddBatch) {
 				if (++_count >= PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
-					_count = 0;
-
-					_connection.commit();
+					_finishTransaction(true);
 				}
 			}
-			else if (methodName.equals("executeBatch") && (_count > 0)) {
-				_count = 0;
+			else if (methodName.equals("executeBatch") &&
+					 _transaction) {
 
-				_connection.commit();
+				_finishTransaction(true);
 			}
 
 			return result;
 		}
 
 		private BatchCommitInvocationHandler(
-			Connection connection, PreparedStatement preparedStatement) {
+			Connection connection, Set<Connection> ownedConnections,
+			PreparedStatement preparedStatement) {
 
 			_connection = connection;
+			_transactionalConnections = ownedConnections;
 			_preparedStatement = preparedStatement;
 		}
 
+		private void _finishTransaction(boolean commit) throws SQLException {
+			_count = 0;
+			_transaction = false;
+
+			_transactionalConnections.remove(_connection);
+
+			try {
+				if (commit) {
+					_connection.commit();
+				}
+				else {
+					_connection.rollback();
+				}
+			}
+			finally {
+				try {
+					_connection.setAutoCommit(true);
+				}
+				catch (SQLException sqlException) {
+					_log.error(
+						"Unable to reset auto-commit to true", sqlException);
+				}
+			}
+		}
+
+		private void _startTransaction() throws SQLException {
+			if (!_connection.getAutoCommit()) {
+				return;
+			}
+
+			if (!_transactionalConnections.add(_connection)) {
+				return;
+			}
+
+			try {
+				_connection.setAutoCommit(false);
+			}
+			catch (SQLException sqlException) {
+				_transactionalConnections.remove(_connection);
+
+				throw sqlException;
+			}
+
+			_transaction = true;
+		}
+
+		private final Set<Connection> _transactionalConnections;
 		private final Connection _connection;
 		private int _count;
 		private final PreparedStatement _preparedStatement;
+		private boolean _transaction;
 
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -641,7 +641,7 @@ public abstract class BaseDBProcess implements DBProcess {
 						ClassLoader.getSystemClassLoader(),
 						new Class<?>[] {PreparedStatement.class},
 						new BatchCommitInvocationHandler(
-							workerConnection, _transactionalConnections, preparedStatement));
+							workerConnection, preparedStatement));
 				}
 				catch (SQLException sqlException) {
 					throw new RuntimeException(sqlException);
@@ -874,8 +874,7 @@ public abstract class BaseDBProcess implements DBProcess {
 	private final Set<Connection> _transactionalConnections =
 		ConcurrentHashMap.newKeySet();
 
-	private static class BatchCommitInvocationHandler
-		implements InvocationHandler {
+	private class BatchCommitInvocationHandler implements InvocationHandler {
 
 		@Override
 		public Object invoke(Object proxy, Method method, Object[] args)
@@ -903,8 +902,8 @@ public abstract class BaseDBProcess implements DBProcess {
 					_finishTransaction(true);
 				}
 			}
-			else if (methodName.equals("executeBatch") &&
-					 _transaction) {
+			else if (_transaction &&
+					 methodName.equals("executeBatch")) {
 
 				_finishTransaction(true);
 			}
@@ -913,11 +912,9 @@ public abstract class BaseDBProcess implements DBProcess {
 		}
 
 		private BatchCommitInvocationHandler(
-			Connection connection, Set<Connection> ownedConnections,
-			PreparedStatement preparedStatement) {
+			Connection connection, PreparedStatement preparedStatement) {
 
 			_connection = connection;
-			_transactionalConnections = ownedConnections;
 			_preparedStatement = preparedStatement;
 		}
 
@@ -967,7 +964,6 @@ public abstract class BaseDBProcess implements DBProcess {
 			_transaction = true;
 		}
 
-		private final Set<Connection> _transactionalConnections;
 		private final Connection _connection;
 		private int _count;
 		private final PreparedStatement _preparedStatement;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -571,41 +571,33 @@ public abstract class BaseDBProcess implements DBProcess {
 	}
 
 	private void _finishAndCloseConnection(Connection connection) {
-		if (_transactionalConnections.remove(connection)) {
+		Boolean autoCommit = _autoCommits.remove(connection);
+
+		if (autoCommit != null) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					"Closing a connection that still has an autoCommit " +
 						"override");
 			}
 
-			_finishTransactionalConnection(connection, false);
+			try {
+				connection.rollback();
+			}
+			catch (SQLException sqlException) {
+				_log.error(
+					"Unable to finish a transactional connection",
+					sqlException);
+			}
+
+			try {
+				connection.setAutoCommit(autoCommit);
+			}
+			catch (SQLException sqlException) {
+				_log.error("Unable to set autoCommit", sqlException);
+			}
 		}
 
 		DataAccess.cleanUp(connection);
-	}
-
-	private void _finishTransactionalConnection(
-		Connection connection, boolean commit) {
-
-		try {
-			if (commit) {
-				connection.commit();
-			}
-			else {
-				connection.rollback();
-			}
-		}
-		catch (SQLException sqlException) {
-			_log.error(
-				"Unable to finish a transactional connection", sqlException);
-		}
-
-		try {
-			connection.setAutoCommit(true);
-		}
-		catch (SQLException sqlException) {
-			_log.error("Unable to set autoCommit", sqlException);
-		}
 	}
 
 	private PreparedStatement _getConcurrentPreparedStatement(
@@ -869,10 +861,10 @@ public abstract class BaseDBProcess implements DBProcess {
 	private static final AtomicInteger _fixedThreadPoolSize = new AtomicInteger(
 		0);
 
+	private final Map<Connection, Boolean> _autoCommits =
+		new ConcurrentHashMap<>();
 	private final Map<Long, Map<Thread, Connection>> _connectionsMaps =
 		new ConcurrentHashMap<>();
-	private final Set<Connection> _transactionalConnections =
-		ConcurrentHashMap.newKeySet();
 
 	private class BatchCommitInvocationHandler implements InvocationHandler {
 
@@ -882,9 +874,9 @@ public abstract class BaseDBProcess implements DBProcess {
 
 			String methodName = method.getName();
 
-			boolean isAddBatch = methodName.equals("addBatch");
+			boolean addBatch = methodName.equals("addBatch");
 
-			if (isAddBatch && !_transaction) {
+			if (addBatch && !_transaction) {
 				_startTransaction();
 			}
 
@@ -897,14 +889,12 @@ public abstract class BaseDBProcess implements DBProcess {
 				throw invocationTargetException.getCause();
 			}
 
-			if (isAddBatch) {
+			if (addBatch) {
 				if (++_count >= PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
 					_finishTransaction(true);
 				}
 			}
-			else if (_transaction &&
-					 methodName.equals("executeBatch")) {
-
+			else if (_transaction && methodName.equals("executeBatch")) {
 				_finishTransaction(true);
 			}
 
@@ -922,8 +912,6 @@ public abstract class BaseDBProcess implements DBProcess {
 			_count = 0;
 			_transaction = false;
 
-			_transactionalConnections.remove(_connection);
-
 			try {
 				if (commit) {
 					_connection.commit();
@@ -933,32 +921,34 @@ public abstract class BaseDBProcess implements DBProcess {
 				}
 			}
 			finally {
+				Boolean autoCommit = _autoCommits.remove(_connection);
+
 				try {
-					_connection.setAutoCommit(true);
+					_connection.setAutoCommit(
+						GetterUtil.getBoolean(autoCommit, true));
 				}
 				catch (SQLException sqlException) {
-					_log.error(
-						"Unable to reset auto-commit to true", sqlException);
+					_log.error("Unable to set autoCommit", sqlException);
 				}
 			}
 		}
 
 		private void _startTransaction() throws SQLException {
-			if (!_connection.getAutoCommit()) {
+			boolean autoCommit = _connection.getAutoCommit();
+
+			if (_autoCommits.putIfAbsent(_connection, autoCommit) != null) {
 				return;
 			}
 
-			if (!_transactionalConnections.add(_connection)) {
-				return;
-			}
+			if (autoCommit) {
+				try {
+					_connection.setAutoCommit(false);
+				}
+				catch (SQLException sqlException) {
+					_autoCommits.remove(_connection);
 
-			try {
-				_connection.setAutoCommit(false);
-			}
-			catch (SQLException sqlException) {
-				_transactionalConnections.remove(_connection);
-
-				throw sqlException;
+					throw sqlException;
+				}
 			}
 
 			_transaction = true;

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -40,6 +40,7 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 import java.sql.Connection;
@@ -56,7 +57,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -545,46 +545,106 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		Collection<Connection> connections = connectionsMap.values();
 
-		try {
-			Iterator<Connection> iterator = connections.iterator();
+		Iterator<Connection> iterator = connections.iterator();
 
-			while (iterator.hasNext()) {
-				Connection connection = iterator.next();
+		while (iterator.hasNext()) {
+			Connection connection = iterator.next();
 
-				iterator.remove();
+			iterator.remove();
 
-				connection.close();
-			}
-		}
-		catch (SQLException sqlException) {
-			_log.error(sqlException);
+			_finishAndCloseConnection(connection);
 		}
 	}
 
 	private void _closeConnections(
 		Map<Thread, Connection> connectionsMap, Thread thread) {
 
-		if (MapUtil.isEmpty(connectionsMap)) {
+		if (connectionsMap == null) {
 			return;
 		}
 
+		Connection connection = connectionsMap.remove(thread);
+
+		if (connection != null) {
+			_finishAndCloseConnection(connection);
+		}
+	}
+
+	private Connection _enableTransactionForCurrentThread()
+		throws SQLException {
+
+		Map<Thread, Connection> connectionsMap = _connectionsMaps.get(
+			PropsValues.DATABASE_PARTITION_ENABLED ?
+				CompanyThreadLocal.getCompanyId() : CompanyConstants.SYSTEM);
+
+		if (connectionsMap == null) {
+			return null;
+		}
+
+		Connection workerConnection = connectionsMap.get(
+			Thread.currentThread());
+
+		if (workerConnection == null) {
+			return null;
+		}
+
+		boolean previousAutoCommit = workerConnection.getAutoCommit();
+
+		if (!previousAutoCommit) {
+			return null;
+		}
+
+		if (!_transactionalConnections.add(workerConnection)) {
+			return null;
+		}
+
 		try {
-			for (Map.Entry<Thread, Connection> entry :
-					connectionsMap.entrySet()) {
+			workerConnection.setAutoCommit(false);
+		}
+		catch (SQLException sqlException) {
+			_transactionalConnections.remove(workerConnection);
 
-				if (entry.getKey() == thread) {
-					Connection connection = entry.getValue();
+			throw sqlException;
+		}
 
-					connectionsMap.remove(entry.getKey());
+		return workerConnection;
+	}
 
-					connection.close();
+	private void _finishAndCloseConnection(Connection connection) {
+		if (_transactionalConnections.remove(connection)) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Closing a connection that still has an autoCommit " +
+						"override");
+			}
 
-					return;
-				}
+			_finishTransactionalConnection(connection, false);
+		}
+
+		DataAccess.cleanUp(connection);
+	}
+
+	private void _finishTransactionalConnection(
+		Connection connection, boolean commit) {
+
+		try {
+			if (commit) {
+				connection.commit();
+			}
+			else {
+				connection.rollback();
 			}
 		}
 		catch (SQLException sqlException) {
-			_log.error(sqlException);
+			_log.error(
+				"Unable to finish a transactional connection", sqlException);
+		}
+
+		try {
+			connection.setAutoCommit(true);
+		}
+		catch (SQLException sqlException) {
+			_log.error("Unable to set autoCommit", sqlException);
 		}
 	}
 
@@ -596,8 +656,22 @@ public abstract class BaseDBProcess implements DBProcess {
 			Thread.currentThread(),
 			k -> {
 				try {
-					return AutoBatchPreparedStatementUtil.autoBatch(
-						connection, updateSQL);
+					PreparedStatement preparedStatement =
+						AutoBatchPreparedStatementUtil.autoBatch(
+							connection, updateSQL);
+
+					Connection workerConnection =
+						_enableTransactionForCurrentThread();
+
+					if (workerConnection == null) {
+						return preparedStatement;
+					}
+
+					return (PreparedStatement)ProxyUtil.newProxyInstance(
+						ClassLoader.getSystemClassLoader(),
+						new Class<?>[] {PreparedStatement.class},
+						new BatchCommitInvocationHandler(
+							workerConnection, preparedStatement));
 				}
 				catch (SQLException sqlException) {
 					throw new RuntimeException(sqlException);
@@ -728,70 +802,78 @@ public abstract class BaseDBProcess implements DBProcess {
 			Objects.requireNonNull(unsafeBiConsumer);
 		}
 
+		int fixedThreadPoolSize = _getFixedThreadPoolSize();
+
 		ExecutorService executorService = Executors.newFixedThreadPool(
-			_getFixedThreadPoolSize());
+			fixedThreadPoolSize);
 
 		List<Future<Void>> futures = new ArrayList<>();
 		Map<Thread, PreparedStatement> preparedStatementHashMap =
 			new ConcurrentHashMap<>();
-		Set<Thread> threads = new CopyOnWriteArraySet<>();
 		ThrowableCollector throwableCollector = new ThrowableCollector();
 
 		try {
 			boolean notificationEnabled = NotificationThreadLocal.isEnabled();
 			boolean workflowEnabled = WorkflowThreadLocal.isEnabled();
 
-			T next = null;
+			for (int i = 0; i < fixedThreadPoolSize; i++) {
+				futures.add(
+					executorService.submit(
+						new CompanyInheritableThreadLocalCallable<>(
+							() -> {
+								NotificationThreadLocal.setEnabled(
+									notificationEnabled);
+								WorkflowThreadLocal.setEnabled(workflowEnabled);
 
-			while ((next = unsafeSupplier.get()) != null) {
-				T current = next;
+								Thread currentThread = Thread.currentThread();
 
-				Future<Void> future = executorService.submit(
-					new CompanyInheritableThreadLocalCallable<>(
-						() -> {
-							NotificationThreadLocal.setEnabled(
-								notificationEnabled);
-							WorkflowThreadLocal.setEnabled(workflowEnabled);
+								try {
+									PreparedStatement preparedStatement = null;
 
-							try {
-								threads.add(Thread.currentThread());
+									while (true) {
+										T current = null;
 
-								if (Validator.isNull(updateSQL)) {
-									unsafeConsumer.accept(current);
+										synchronized (unsafeSupplier) {
+											current = unsafeSupplier.get();
+										}
+
+										if (current == null) {
+											break;
+										}
+
+										if (Validator.isNull(updateSQL)) {
+											unsafeConsumer.accept(current);
+										}
+										else {
+											preparedStatement =
+												_getConcurrentPreparedStatement(
+													updateSQL,
+													preparedStatementHashMap);
+
+											unsafeBiConsumer.accept(
+												current, preparedStatement);
+										}
+									}
+
+									if (preparedStatement != null) {
+										preparedStatement.executeBatch();
+
+										preparedStatement.close();
+									}
 								}
-								else {
-									unsafeBiConsumer.accept(
-										current,
-										_getConcurrentPreparedStatement(
-											updateSQL,
-											preparedStatementHashMap));
+								catch (Exception exception) {
+									throwableCollector.collect(exception);
 								}
-							}
-							catch (Exception exception) {
-								throwableCollector.collect(exception);
-							}
+								finally {
+									closeConnections(currentThread);
+								}
 
-							return null;
-						}));
-
-				if (futures.size() >=
-						PropsValues.
-							UPGRADE_CONCURRENT_PROCESS_FUTURE_LIST_MAX_SIZE) {
-
-					for (Future<Void> curFuture : futures) {
-						curFuture.get();
-					}
-
-					futures.clear();
-				}
-
-				futures.add(future);
+								return null;
+							})));
 			}
 		}
 		finally {
 			try {
-				executorService.shutdown();
-
 				for (Future<Void> future : futures) {
 					future.get();
 				}
@@ -805,26 +887,9 @@ public abstract class BaseDBProcess implements DBProcess {
 
 					ReflectionUtil.throwException(throwable);
 				}
-
-				try {
-					for (PreparedStatement preparedStatement :
-							preparedStatementHashMap.values()) {
-
-						preparedStatement.executeBatch();
-
-						preparedStatement.close();
-					}
-				}
-				catch (Exception exception) {
-					_log.error(exceptionMessage, exception);
-
-					throw exception;
-				}
 			}
 			finally {
-				for (Thread thread : threads) {
-					closeConnections(thread);
-				}
+				executorService.shutdown();
 			}
 		}
 	}
@@ -836,6 +901,55 @@ public abstract class BaseDBProcess implements DBProcess {
 
 	private final Map<Long, Map<Thread, Connection>> _connectionsMaps =
 		new ConcurrentHashMap<>();
+	private final Set<Connection> _transactionalConnections =
+		ConcurrentHashMap.newKeySet();
+
+	private static class BatchCommitInvocationHandler
+		implements InvocationHandler {
+
+		@Override
+		public Object invoke(Object proxy, Method method, Object[] args)
+			throws Throwable {
+
+			String methodName = method.getName();
+
+			Object result;
+
+			try {
+				result = method.invoke(_preparedStatement, args);
+			}
+			catch (InvocationTargetException invocationTargetException) {
+				throw invocationTargetException.getCause();
+			}
+
+			if (methodName.equals("addBatch")) {
+				if (++_count >= PropsValues.HIBERNATE_JDBC_BATCH_SIZE) {
+					_count = 0;
+
+					_connection.commit();
+				}
+			}
+			else if (methodName.equals("executeBatch") && (_count > 0)) {
+				_count = 0;
+
+				_connection.commit();
+			}
+
+			return result;
+		}
+
+		private BatchCommitInvocationHandler(
+			Connection connection, PreparedStatement preparedStatement) {
+
+			_connection = connection;
+			_preparedStatement = preparedStatement;
+		}
+
+		private final Connection _connection;
+		private int _count;
+		private final PreparedStatement _preparedStatement;
+
+	}
 
 	private class ConnectionThreadProxyInvocationHandler
 		implements InvocationHandler {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91341

## What Is Being Fixed

Concurrent upgrade UPDATEs run through `BaseDBProcess.processConcurrently` execute with autoCommit enabled, so each batched statement is committed individually instead of as a transaction scoped to the AutoBatch flush boundaries. The fix also has to stay correct whether database partitioning is enabled or disabled, where the worker connections are partition-routed and bound to the thread that uses them.

## How It Is Being Fixed

processConcurrently now disables autoCommit on each worker connection and commits at the AutoBatch flush boundaries (and once at the end), turning per-statement auto-commits into batch-scoped transactions. Each worker connection's original autoCommit value is captured when the transaction starts and restored when it finishes, rather than forcing it back to true, so a connection that arrives with autoCommit already disabled is left in its original state and autoCommit is only flipped when it actually needs changing. The worker connection is defensively rolled back and finalized on its own thread, which keeps it correct under partitioning, and a null guard on the per-thread cleanup prevents a NullPointerException when a company created no worker connections.

## Why Are There No Tests?

The behavior is covered by the existing `BaseDBProcessTest.testProcessConcurrently*` integration tests; this PR hardens them with a CountDownLatch so they deterministically run on multiple threads. The partition-enabled path was validated end to end with partition-enabled upgrade runs.

## PR Check

**pr-check: PASS** — tested on `5dc18e1e8d52a4b454bcaa6407baf087b75c31ca`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS — no exported API change, no version bump |
| Full Portal Build | PASS |

<!-- pr-check {"result": "success", "sha": "5dc18e1e8d52a4b454bcaa6407baf087b75c31ca"} -->
