### PR TITLE
LPD-96132 Cap upgrade worker threads to avoid exhausting JDBC connection pool

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.db.BaseDBProcess;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -103,6 +105,11 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		_originalDataCleanupPreupgradeProcessesMap =
 			ReflectionTestUtil.getFieldValue(
 				this, "_dataCleanupPreupgradeProcessesMap");
+
+		_fixedThreadPoolSize = ReflectionTestUtil.getFieldValue(
+			BaseDBProcess.class, "_fixedThreadPoolSize");
+
+		_originalFixedThreadPoolSizeValue = _fixedThreadPoolSize.getAndSet(0);
 	}
 
 	@After
@@ -110,6 +117,7 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		ReflectionTestUtil.setFieldValue(
 			this, "_dataCleanupPreupgradeProcessesMap",
 			_originalDataCleanupPreupgradeProcessesMap);
+		_fixedThreadPoolSize.set(_originalFixedThreadPoolSizeValue);
 	}
 
 	@Test
@@ -296,9 +304,11 @@ public class DataCleanupPreupgradeProcessSuiteTest
 	private static SafeCloseable _safeCloseable;
 
 	private final List<String> _cleanupMessages = new CopyOnWriteArrayList<>();
+	private AtomicInteger _fixedThreadPoolSize;
 	private Map
 		<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
 			_originalDataCleanupPreupgradeProcessesMap;
+	private int _originalFixedThreadPoolSizeValue;
 
 	private static class BlacklistedDataCleanupPreupgradeTestProcess
 		extends DataCleanupPreupgradeTestProcess {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -704,28 +704,31 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		Runtime runtime = Runtime.getRuntime();
 
-		int expectedMaxConnectionsCount =
-			Math.min(companyIds.length - 1, runtime.availableProcessors()) *
-				runtime.availableProcessors();
+		int availableProcessors = runtime.availableProcessors();
 
-		if (expectedMaxConnectionsCount > (0.9 * maximumPoolSize)) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"The database is close to reaching ", maximumPoolSize,
-						" connections. Consider increasing the property ",
-						"\"jdbc.default.maximumPoolSize\" to improve ",
-						"performance. Upgrade processes will continue in ",
-						"single threaded mode."));
-			}
+		int companyCount = Math.max(1, companyIds.length);
 
-			_fixedThreadPoolSize.set(1);
+		int connectionBudget = Math.max(
+			1, (int)Math.sqrt(0.9 * maximumPoolSize / companyCount));
+
+		int fixedThreadPoolSize = Math.min(
+			availableProcessors, connectionBudget);
+
+		if ((fixedThreadPoolSize < availableProcessors) &&
+			_log.isWarnEnabled()) {
+
+			_log.warn(
+				StringBundler.concat(
+					"Limiting upgrade worker threads to ", fixedThreadPoolSize,
+					" to avoid exhausting the database connection pool of ",
+					"size ", maximumPoolSize,
+					". Consider increasing \"jdbc.default.maximumPoolSize\" ",
+					"to improve upgrade performance."));
 		}
-		else {
-			_fixedThreadPoolSize.set(runtime.availableProcessors());
-		}
 
-		return _fixedThreadPoolSize.get();
+		_fixedThreadPoolSize.set(fixedThreadPoolSize);
+
+		return fixedThreadPoolSize;
 	}
 
 	private InputStream _getInputStream(String path) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
@@ -24,21 +24,41 @@ public class BaseDBProcessTest {
 
 	@Test
 	public void testGetFixedThreadPoolSize() throws Exception {
-		_testGetFixedThreadPoolSize(DBType.MYSQL, 1, 1);
+		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1, 1000);
 
 		Runtime runtime = Runtime.getRuntime();
 
-		_testGetFixedThreadPoolSize(
-			DBType.MYSQL, runtime.availableProcessors(), 1000);
+		int availableProcessors = runtime.availableProcessors();
 
-		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1000);
+		int amplePoolSize =
+			(int)(availableProcessors * availableProcessors / 0.9) + 1;
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL, availableProcessors, 1, amplePoolSize);
+
+		int smallPoolSize = 10;
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL,
+			Math.min(
+				availableProcessors,
+				Math.max(1, (int)Math.sqrt(0.9 * smallPoolSize))),
+			1, smallPoolSize);
+
+		_testGetFixedThreadPoolSize(DBType.MYSQL, 1, 5, smallPoolSize);
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL,
+			Math.min(
+				availableProcessors,
+				Math.max(1, (int)Math.sqrt(0.9 * smallPoolSize))),
+			0, smallPoolSize);
 	}
 
 	private void _testGetFixedThreadPoolSize(
-			DBType dbType, int expectedFixedThreadPoolSize, int maximumPoolSize)
+			DBType dbType, int expectedFixedThreadPoolSize, int companyCount,
+			int maximumPoolSize)
 		throws Exception {
-
-		Runtime runtime = Runtime.getRuntime();
 
 		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
 				Mockito.mockStatic(DBManagerUtil.class);
@@ -64,7 +84,7 @@ public class BaseDBProcessTest {
 			portalInstancePoolMockedStatic.when(
 				PortalInstancePool::getCompanyIds
 			).thenReturn(
-				new long[runtime.availableProcessors() + 2]
+				new long[companyCount]
 			);
 
 			propsUtilMockedStatic.when(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96132

## What Is Being Fixed

Upgrade processes on machines with high CPU counts were requesting more concurrent JDBC connections than the pool could serve. The prior formula computed `(companyCount - 1) * availableProcessors` worker threads, which failed to account for the two-level nesting that cleanup processes like `BaseAllTablesOrphanReferencesDataCleanupPreupgradeProcess` introduce — each outer worker spawns its own `processConcurrently` call, squaring the connection demand. On boxes with many cores this pushed the pool past its limit and caused upgrade failures.

## How It Is Being Fixed

`BaseDBProcess._getFixedThreadPoolSize` now derives the thread count using an inverse-square-root formula: `floor(sqrt(0.9 * maximumPoolSize / companyCount))`. The square root inverts the N² nesting so the peak connection count stays within 90% of the pool limit regardless of core count or company count. A `Math.max(1, companyCount)` guard prevents division by zero when no companies are present. A warning is logged when the connection budget forces the thread count below the number of available processors, directing operators to raise `jdbc.default.maximumPoolSize` if they want better upgrade throughput.

Unit tests in `BaseDBProcessTest` cover four scenarios: Hypersonic (single-threaded), ample pool with one company (full processor count), small pool with one company (budget cap), and small pool with multiple companies (per-company split), plus the zero-company guard. The integration test in `DataCleanupPreupgradeProcessSuiteTest` resets `_fixedThreadPoolSize` to zero before each run and restores the original value afterward so the new sizing logic is exercised under real portal conditions.

## PR Check

**pr-check: SKIPPED** — unit tests pass locally; integration test requires a running portal which is not available in CI pre-merge for this module.

<!-- pr-check {"reason": "unit tests pass locally; integration test requires a running portal which is not available in CI pre-merge for this module.", "result": "skipped", "sha": "dc9be319521cc9728850ce02968b9e0deb849f60"} -->
