### PR TITLE
LPD-94076 Fix data cleanup activation when search engine is offline

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PostUpgradeDataCleanupVerifyProcess.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.framework.ModuleServiceLifecycle;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -71,33 +72,51 @@ public class PostUpgradeDataCleanupVerifyProcess extends VerifyProcess {
 	private List<PostUpgradeDataCleanupProcess>
 		_getPostUpgradeDataCleanupProcesses() {
 
-		return ListUtil.fromArray(
-			new ClassNamePostUpgradeDataCleanupProcess(
-				_classNameLocalService, _companyLocalService, connection,
-				_objectDefinitionLocalService),
-			new ResourceActionPostUpgradeDataCleanupProcess(
-				connection, _resourceActionLocalService),
+		List<PostUpgradeDataCleanupProcess> postUpgradeDataCleanupProcesses =
+			ListUtil.fromArray(
+				new ClassNamePostUpgradeDataCleanupProcess(
+					_classNameLocalService, _companyLocalService, connection,
+					_objectDefinitionLocalService),
+				new ResourceActionPostUpgradeDataCleanupProcess(
+					connection, _resourceActionLocalService),
+				new ServiceComponentPostUpgradeDataCleanupProcess(
+					connection, _serviceComponentLocalService),
+				new StorePostUpgradeDataCleanupProcess(_store));
+
+		IndexInformation indexInformation = _indexInformationSnapshot.get();
+		IndexNameBuilder indexNameBuilder = _indexNameBuilderSnapshot.get();
+
+		if ((indexInformation == null) || (indexNameBuilder == null)) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Skipping search index cleanup: search engine unavailable");
+			}
+
+			return postUpgradeDataCleanupProcesses;
+		}
+
+		postUpgradeDataCleanupProcesses.add(
 			new SearchIndexPostUpgradeDataCleanupProcess(
-				_indexInformation, _indexNameBuilder),
-			new ServiceComponentPostUpgradeDataCleanupProcess(
-				connection, _serviceComponentLocalService),
-			new StorePostUpgradeDataCleanupProcess(_store));
+				indexInformation, indexNameBuilder));
+
+		return postUpgradeDataCleanupProcesses;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PostUpgradeDataCleanupVerifyProcess.class);
+
+	private static final Snapshot<IndexInformation> _indexInformationSnapshot =
+		new Snapshot<>(
+			PostUpgradeDataCleanupVerifyProcess.class, IndexInformation.class);
+	private static final Snapshot<IndexNameBuilder> _indexNameBuilderSnapshot =
+		new Snapshot<>(
+			PostUpgradeDataCleanupVerifyProcess.class, IndexNameBuilder.class);
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
-
-	@Reference
-	private IndexInformation _indexInformation;
-
-	@Reference
-	private IndexNameBuilder _indexNameBuilder;
 
 	@Reference(target = ModuleServiceLifecycle.PORTLETS_INITIALIZED)
 	private ModuleServiceLifecycle _moduleServiceLifecycle;

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/PostUpgradeDataCleanupVerifyProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/PostUpgradeDataCleanupVerifyProcessTest.java
@@ -6,7 +6,7 @@
 package com.liferay.data.cleanup.internal.verify.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.module.util.BundleUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
@@ -17,15 +17,10 @@ import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-
-import java.sql.Connection;
 
 import java.util.List;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,91 +39,65 @@ public class PostUpgradeDataCleanupVerifyProcessTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_connection = DataAccess.getConnection();
-	}
-
-	@AfterClass
-	public static void tearDownClass() {
-		DataAccess.cleanUp(_connection);
-	}
-
 	@Test
 	public void testGetPostUpgradeDataCleanupProcesses() throws Exception {
 		Bundle bundle = BundleUtil.getBundle(
 			SystemBundleUtil.getBundleContext(),
 			"com.liferay.data.cleanup.impl");
 
-		Class<?> postUpgradeDataCleanupVerifyProcessClass = bundle.loadClass(
+		Class<?> clazz = bundle.loadClass(
 			"com.liferay.data.cleanup.internal.verify." +
 				"PostUpgradeDataCleanupVerifyProcess");
 
-		Constructor<?> constructor =
-			postUpgradeDataCleanupVerifyProcessClass.getDeclaredConstructor();
+		Constructor<?> constructor = clazz.getDeclaredConstructor();
 
 		Object postUpgradeDataCleanupVerifyProcess = constructor.newInstance();
 
-		ReflectionTestUtil.setFieldValue(
-			postUpgradeDataCleanupVerifyProcess, "connection", _connection);
+		Snapshot<Object> snapshot = new Snapshot<>(
+			PostUpgradeDataCleanupVerifyProcessTest.class, Object.class,
+			"(component.name=__unavailable__)");
 
 		try (AutoCloseable autoCloseable1 =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
-					postUpgradeDataCleanupVerifyProcessClass,
-					"_indexInformationSnapshot",
-					new Snapshot<>(
-						PostUpgradeDataCleanupVerifyProcessTest.class,
-						Object.class));
+					clazz, "_indexInformationSnapshot", snapshot);
 			AutoCloseable autoCloseable2 =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
-					postUpgradeDataCleanupVerifyProcessClass,
-					"_indexNameBuilderSnapshot",
-					new Snapshot<>(
-						PostUpgradeDataCleanupVerifyProcessTest.class,
-						Object.class));
+					clazz, "_indexNameBuilderSnapshot", snapshot);
 			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.data.cleanup.internal.verify." +
 					"PostUpgradeDataCleanupVerifyProcess",
 				LoggerTestUtil.WARN)) {
 
-			Method method =
-				postUpgradeDataCleanupVerifyProcessClass.getDeclaredMethod(
-					"_getPostUpgradeDataCleanupProcesses");
-
-			method.setAccessible(true);
-
-			List<?> postUpgradeDataCleanupProcesses = (List<?>)method.invoke(
-				postUpgradeDataCleanupVerifyProcess);
+			List<?> postUpgradeDataCleanupProcesses = ReflectionTestUtil.invoke(
+				postUpgradeDataCleanupVerifyProcess,
+				"_getPostUpgradeDataCleanupProcesses", new Class<?>[0]);
 
 			Assert.assertEquals(
 				postUpgradeDataCleanupProcesses.toString(), 4,
 				postUpgradeDataCleanupProcesses.size());
 
-			for (Object postUpgradeDataCleanupProcess :
-					postUpgradeDataCleanupProcesses) {
+			List<String> classNames = TransformUtil.transform(
+				postUpgradeDataCleanupProcesses,
+				postUpgradeDataCleanupProcess -> {
+					Class<?> postUpgradeDataCleanupProcessClass =
+						postUpgradeDataCleanupProcess.getClass();
 
-				Class<?> clazz = postUpgradeDataCleanupProcess.getClass();
+					return postUpgradeDataCleanupProcessClass.getSimpleName();
+				});
 
-				String simpleName = clazz.getSimpleName();
-
-				Assert.assertFalse(
-					simpleName.equals(
-						"SearchIndexPostUpgradeDataCleanupProcess"));
-			}
+			Assert.assertFalse(
+				classNames.toString(),
+				classNames.contains(
+					"SearchIndexPostUpgradeDataCleanupProcess"));
 
 			List<String> messages = logCapture.getMessages();
 
-			String message = messages.get(0);
-
 			Assert.assertEquals(messages.toString(), 1, messages.size());
 
-			Assert.assertTrue(
-				message.contains(
-					"Skipping search index cleanup: search engine " +
-						"unavailable"));
+			Assert.assertEquals(
+				"Skipping search index cleanup: search engine unavailable",
+				messages.get(0));
 		}
 	}
-
-	private static Connection _connection;
 
 }

--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/PostUpgradeDataCleanupVerifyProcessTest.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/PostUpgradeDataCleanupVerifyProcessTest.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.data.cleanup.internal.verify.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.module.service.Snapshot;
+import com.liferay.portal.kernel.module.util.BundleUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+
+import java.sql.Connection;
+
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class PostUpgradeDataCleanupVerifyProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_connection = DataAccess.getConnection();
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		DataAccess.cleanUp(_connection);
+	}
+
+	@Test
+	public void testGetPostUpgradeDataCleanupProcesses() throws Exception {
+		Bundle bundle = BundleUtil.getBundle(
+			SystemBundleUtil.getBundleContext(),
+			"com.liferay.data.cleanup.impl");
+
+		Class<?> postUpgradeDataCleanupVerifyProcessClass = bundle.loadClass(
+			"com.liferay.data.cleanup.internal.verify." +
+				"PostUpgradeDataCleanupVerifyProcess");
+
+		Constructor<?> constructor =
+			postUpgradeDataCleanupVerifyProcessClass.getDeclaredConstructor();
+
+		Object postUpgradeDataCleanupVerifyProcess = constructor.newInstance();
+
+		ReflectionTestUtil.setFieldValue(
+			postUpgradeDataCleanupVerifyProcess, "connection", _connection);
+
+		try (AutoCloseable autoCloseable1 =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					postUpgradeDataCleanupVerifyProcessClass,
+					"_indexInformationSnapshot",
+					new Snapshot<>(
+						PostUpgradeDataCleanupVerifyProcessTest.class,
+						Object.class));
+			AutoCloseable autoCloseable2 =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					postUpgradeDataCleanupVerifyProcessClass,
+					"_indexNameBuilderSnapshot",
+					new Snapshot<>(
+						PostUpgradeDataCleanupVerifyProcessTest.class,
+						Object.class));
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.data.cleanup.internal.verify." +
+					"PostUpgradeDataCleanupVerifyProcess",
+				LoggerTestUtil.WARN)) {
+
+			Method method =
+				postUpgradeDataCleanupVerifyProcessClass.getDeclaredMethod(
+					"_getPostUpgradeDataCleanupProcesses");
+
+			method.setAccessible(true);
+
+			List<?> postUpgradeDataCleanupProcesses = (List<?>)method.invoke(
+				postUpgradeDataCleanupVerifyProcess);
+
+			Assert.assertEquals(
+				postUpgradeDataCleanupProcesses.toString(), 4,
+				postUpgradeDataCleanupProcesses.size());
+
+			for (Object postUpgradeDataCleanupProcess :
+					postUpgradeDataCleanupProcesses) {
+
+				Class<?> clazz = postUpgradeDataCleanupProcess.getClass();
+
+				String simpleName = clazz.getSimpleName();
+
+				Assert.assertFalse(
+					simpleName.equals(
+						"SearchIndexPostUpgradeDataCleanupProcess"));
+			}
+
+			List<String> messages = logCapture.getMessages();
+
+			String message = messages.get(0);
+
+			Assert.assertEquals(messages.toString(), 1, messages.size());
+
+			Assert.assertTrue(
+				message.contains(
+					"Skipping search index cleanup: search engine " +
+						"unavailable"));
+		}
+	}
+
+	private static Connection _connection;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94076

## What Is Being Fixed

`PostUpgradeDataCleanupVerifyProcess` injected `IndexInformation` and `IndexNameBuilder` as mandatory `@Reference` dependencies. When the search engine is offline those services are unavailable, so the component never activates and the verify process fails, leaving the upgrade marked as unresolved.

## How It Is Being Fixed

The two mandatory references are replaced with optional `Snapshot` lookups. When either service is unavailable, the search index cleanup is skipped with a warning and the remaining post-upgrade data cleanup processes still run, so the verify process completes successfully. An integration test exercises the skip path by pointing both snapshots at an unavailable component.

## PR Check

**pr-check: PASS** — tested on `93b6bc2b3aec067f1ce900676a060e90c6853d2f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "93b6bc2b3aec067f1ce900676a060e90c6853d2f"} -->
