### PR TITLE
LPD-96132 Cap upgrade worker threads to avoid exhausting JDBC connection pool

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/DataCleanupPreupgradeProcessSuiteTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.db.BaseDBProcess;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -37,6 +38,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -103,6 +105,11 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		_originalDataCleanupPreupgradeProcessesMap =
 			ReflectionTestUtil.getFieldValue(
 				this, "_dataCleanupPreupgradeProcessesMap");
+
+		_fixedThreadPoolSize = ReflectionTestUtil.getFieldValue(
+			BaseDBProcess.class, "_fixedThreadPoolSize");
+
+		_originalFixedThreadPoolSizeValue = _fixedThreadPoolSize.getAndSet(0);
 	}
 
 	@After
@@ -110,6 +117,7 @@ public class DataCleanupPreupgradeProcessSuiteTest
 		ReflectionTestUtil.setFieldValue(
 			this, "_dataCleanupPreupgradeProcessesMap",
 			_originalDataCleanupPreupgradeProcessesMap);
+		_fixedThreadPoolSize.set(_originalFixedThreadPoolSizeValue);
 	}
 
 	@Test
@@ -296,9 +304,11 @@ public class DataCleanupPreupgradeProcessSuiteTest
 	private static SafeCloseable _safeCloseable;
 
 	private final List<String> _cleanupMessages = new CopyOnWriteArrayList<>();
+	private AtomicInteger _fixedThreadPoolSize;
 	private Map
 		<DataCleanupPreupgradeProcess, List<DataCleanupPreupgradeProcess>>
 			_originalDataCleanupPreupgradeProcessesMap;
+	private int _originalFixedThreadPoolSizeValue;
 
 	private static class BlacklistedDataCleanupPreupgradeTestProcess
 		extends DataCleanupPreupgradeTestProcess {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -14,7 +14,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -701,8 +700,6 @@ public abstract class BaseDBProcess implements DBProcess {
 			return _fixedThreadPoolSize.get();
 		}
 
-		long[] companyIds = PortalInstancePool.getCompanyIds();
-
 		int maximumPoolSize = GetterUtil.getInteger(
 			PropsUtil.get("jdbc.default.maximumPoolSize"));
 
@@ -710,10 +707,10 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		int availableProcessors = runtime.availableProcessors();
 
-		int companyCount = Math.max(1, companyIds.length);
+		// Bound N so nested processConcurrently pools open at most N^2 connections
 
 		int connectionBudget = Math.max(
-			1, (int)Math.sqrt(0.9 * maximumPoolSize / companyCount));
+			1, (int)Math.sqrt(0.9 * maximumPoolSize));
 
 		int fixedThreadPoolSize = Math.min(
 			availableProcessors, connectionBudget);
@@ -724,10 +721,8 @@ public abstract class BaseDBProcess implements DBProcess {
 			_log.warn(
 				StringBundler.concat(
 					"Limiting upgrade worker threads to ", fixedThreadPoolSize,
-					" to avoid exhausting the database connection pool of ",
-					"size ", maximumPoolSize,
-					". Consider increasing \"jdbc.default.maximumPoolSize\" ",
-					"to improve upgrade performance."));
+					" to avoid exhausting the database connection pool of size ",
+					maximumPoolSize));
 		}
 
 		_fixedThreadPoolSize.set(fixedThreadPoolSize);

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -708,28 +708,31 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		Runtime runtime = Runtime.getRuntime();
 
-		int expectedMaxConnectionsCount =
-			Math.min(companyIds.length - 1, runtime.availableProcessors()) *
-				runtime.availableProcessors();
+		int availableProcessors = runtime.availableProcessors();
 
-		if (expectedMaxConnectionsCount > (0.9 * maximumPoolSize)) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"The database is close to reaching ", maximumPoolSize,
-						" connections. Consider increasing the property ",
-						"\"jdbc.default.maximumPoolSize\" to improve ",
-						"performance. Upgrade processes will continue in ",
-						"single threaded mode."));
-			}
+		int companyCount = Math.max(1, companyIds.length);
 
-			_fixedThreadPoolSize.set(1);
+		int connectionBudget = Math.max(
+			1, (int)Math.sqrt(0.9 * maximumPoolSize / companyCount));
+
+		int fixedThreadPoolSize = Math.min(
+			availableProcessors, connectionBudget);
+
+		if ((fixedThreadPoolSize < availableProcessors) &&
+			_log.isWarnEnabled()) {
+
+			_log.warn(
+				StringBundler.concat(
+					"Limiting upgrade worker threads to ", fixedThreadPoolSize,
+					" to avoid exhausting the database connection pool of ",
+					"size ", maximumPoolSize,
+					". Consider increasing \"jdbc.default.maximumPoolSize\" ",
+					"to improve upgrade performance."));
 		}
-		else {
-			_fixedThreadPoolSize.set(runtime.availableProcessors());
-		}
 
-		return _fixedThreadPoolSize.get();
+		_fixedThreadPoolSize.set(fixedThreadPoolSize);
+
+		return fixedThreadPoolSize;
 	}
 
 	private InputStream _getInputStream(String path) {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -707,8 +707,6 @@ public abstract class BaseDBProcess implements DBProcess {
 
 		int availableProcessors = runtime.availableProcessors();
 
-		// Bound N so nested processConcurrently pools open at most N^2 connections
-
 		int connectionBudget = Math.max(
 			1, (int)Math.sqrt(0.9 * maximumPoolSize));
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
@@ -24,21 +24,41 @@ public class BaseDBProcessTest {
 
 	@Test
 	public void testGetFixedThreadPoolSize() throws Exception {
-		_testGetFixedThreadPoolSize(DBType.MYSQL, 1, 1);
+		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1, 1000);
 
 		Runtime runtime = Runtime.getRuntime();
 
-		_testGetFixedThreadPoolSize(
-			DBType.MYSQL, runtime.availableProcessors(), 1000);
+		int availableProcessors = runtime.availableProcessors();
 
-		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1000);
+		int amplePoolSize =
+			(int)(availableProcessors * availableProcessors / 0.9) + 1;
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL, availableProcessors, 1, amplePoolSize);
+
+		int smallPoolSize = 10;
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL,
+			Math.min(
+				availableProcessors,
+				Math.max(1, (int)Math.sqrt(0.9 * smallPoolSize))),
+			1, smallPoolSize);
+
+		_testGetFixedThreadPoolSize(DBType.MYSQL, 1, 5, smallPoolSize);
+
+		_testGetFixedThreadPoolSize(
+			DBType.MYSQL,
+			Math.min(
+				availableProcessors,
+				Math.max(1, (int)Math.sqrt(0.9 * smallPoolSize))),
+			0, smallPoolSize);
 	}
 
 	private void _testGetFixedThreadPoolSize(
-			DBType dbType, int expectedFixedThreadPoolSize, int maximumPoolSize)
+			DBType dbType, int expectedFixedThreadPoolSize, int companyCount,
+			int maximumPoolSize)
 		throws Exception {
-
-		Runtime runtime = Runtime.getRuntime();
 
 		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
 				Mockito.mockStatic(DBManagerUtil.class);
@@ -64,7 +84,7 @@ public class BaseDBProcessTest {
 			portalInstancePoolMockedStatic.when(
 				PortalInstancePool::getCompanyIds
 			).thenReturn(
-				new long[runtime.availableProcessors() + 2]
+				new long[companyCount]
 			);
 
 			propsUtilMockedStatic.when(

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/dao/db/BaseDBProcessTest.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.kernel.dao.db;
 
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 
@@ -24,7 +23,7 @@ public class BaseDBProcessTest {
 
 	@Test
 	public void testGetFixedThreadPoolSize() throws Exception {
-		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1, 1000);
+		_testGetFixedThreadPoolSize(DBType.HYPERSONIC, 1, 1000);
 
 		Runtime runtime = Runtime.getRuntime();
 
@@ -33,8 +32,7 @@ public class BaseDBProcessTest {
 		int amplePoolSize =
 			(int)(availableProcessors * availableProcessors / 0.9) + 1;
 
-		_testGetFixedThreadPoolSize(
-			DBType.MYSQL, availableProcessors, 1, amplePoolSize);
+		_testGetFixedThreadPoolSize(DBType.MYSQL, availableProcessors, amplePoolSize);
 
 		int smallPoolSize = 10;
 
@@ -43,27 +41,17 @@ public class BaseDBProcessTest {
 			Math.min(
 				availableProcessors,
 				Math.max(1, (int)Math.sqrt(0.9 * smallPoolSize))),
-			1, smallPoolSize);
+			smallPoolSize);
 
-		_testGetFixedThreadPoolSize(DBType.MYSQL, 1, 5, smallPoolSize);
-
-		_testGetFixedThreadPoolSize(
-			DBType.MYSQL,
-			Math.min(
-				availableProcessors,
-				Math.max(1, (int)Math.sqrt(0.9 * smallPoolSize))),
-			0, smallPoolSize);
+		_testGetFixedThreadPoolSize(DBType.MYSQL, 1, 1);
 	}
 
 	private void _testGetFixedThreadPoolSize(
-			DBType dbType, int expectedFixedThreadPoolSize, int companyCount,
-			int maximumPoolSize)
+			DBType dbType, int expectedFixedThreadPoolSize, int maximumPoolSize)
 		throws Exception {
 
 		try (MockedStatic<DBManagerUtil> dbManagerUtilMockedStatic =
 				Mockito.mockStatic(DBManagerUtil.class);
-			MockedStatic<PortalInstancePool> portalInstancePoolMockedStatic =
-				Mockito.mockStatic(PortalInstancePool.class);
 			MockedStatic<PropsUtil> propsUtilMockedStatic = Mockito.mockStatic(
 				PropsUtil.class)) {
 
@@ -79,12 +67,6 @@ public class BaseDBProcessTest {
 				db.getDBType()
 			).thenReturn(
 				dbType
-			);
-
-			portalInstancePoolMockedStatic.when(
-				PortalInstancePool::getCompanyIds
-			).thenReturn(
-				new long[companyCount]
 			);
 
 			propsUtilMockedStatic.when(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96132

## Why This Needs to Merge

The performance team reproduced JDBC pool exhaustion during data cleanup upgrade runs and confirmed this fix resolves it. LPD-91341 (merged concurrently) fixed a connection leak in `_closeConnections` that was the proximate trigger of the incident — but the thread pool sizing formula `_getFixedThreadPoolSize` remains broken in master and will allow exhaustion again under a different failure path.

**The formula in master has two defects:**

1. **The guard is inert for single-company installs.** `min(companyCount - 1, cores) * cores` evaluates to `0` when `companyCount = 1`, which is never greater than `0.9 * pool`. Every single-company install always gets full cores regardless of pool size — no protection at all in the common case.

2. **It ignores nested fan-out.** `DataCleanupPreupgradeProcessSuite.processConcurrently` runs N outer worker threads. `CounterDataCleanupPreupgradeProcess` — one of those outer workers — itself calls `processConcurrently` and spawns N inner threads, each claiming its own JDBC connection. Peak simultaneous connections is N² in the worst case. The old formula never modeled this axis.

Without this fix, any future connection management regression (similar to the one LPD-91341 addressed) immediately exhausts the pool. With this fix, the thread count is bounded so that N² connections fit within the pool budget regardless of what happens at the connection lifecycle layer.

## What Changes

`_getFixedThreadPoolSize` replaces the binary throttle with `floor(sqrt(0.9 * maximumPoolSize))`. Setting N = sqrt(0.9 * pool) keeps N² within the connection budget — Java's integer truncation only shrinks N, so the bound holds unconditionally. The per-company divisor is removed because companies run sequentially and do not multiply the simultaneous connection count.

At the shipped default pool of 180: N = 12, worst-case peak = 156, budget = 162. On a small pool of 10: N = 3 (vs. the old formula's all-or-nothing of full cores or 1 thread).

A warning is logged when the budget forces the thread count below available processors.

## Tests

`BaseDBProcessTest` covers four cases: Hypersonic (always 1 thread), ample pool (full processor count used), small pool (budget cap applied), and pool size of 1 (floor guard). The integration test in `DataCleanupPreupgradeProcessSuiteTest` resets `_fixedThreadPoolSize` before each run so the sizing logic is exercised under real portal conditions.