### PR TITLE
LPD-95490 Fix DLFileEntry unique-index collision in cleanup test

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/CounterDataCleanupPreupgradeProcessTest.java
@@ -254,6 +254,11 @@ public class CounterDataCleanupPreupgradeProcessTest
 		long fileEntryId1 = CounterLocalServiceUtil.increment();
 		long fileEntryId2 = CounterLocalServiceUtil.increment();
 		long fileEntryId3 = CounterLocalServiceUtil.increment();
+
+		long groupId1 = CounterLocalServiceUtil.increment();
+		long groupId2 = CounterLocalServiceUtil.increment();
+		long groupId3 = CounterLocalServiceUtil.increment();
+
 		long name =
 			CounterLocalServiceUtil.getCurrentId(DLFileEntry.class.getName()) +
 				100;
@@ -267,18 +272,21 @@ public class CounterDataCleanupPreupgradeProcessTest
 				runSQL(
 					StringBundler.concat(
 						"insert into DLFileEntry (mvccVersion, ",
-						"ctCollectionId, fileEntryId, name) values (0, 0,",
-						fileEntryId1, ", '", name, "')"));
+						"ctCollectionId, fileEntryId, groupId, name) values ",
+						"(0, 0, ", fileEntryId1, ", ", groupId1, ", '", name,
+						"')"));
 				runSQL(
 					StringBundler.concat(
 						"insert into DLFileEntry (mvccVersion, ",
-						"ctCollectionId, fileEntryId, name) values (0, 0,",
-						fileEntryId2, ", 'non-numeric')"));
+						"ctCollectionId, fileEntryId, groupId, name) values ",
+						"(0, 0, ", fileEntryId2, ", ", groupId2,
+						", 'non-numeric')"));
 				runSQL(
 					StringBundler.concat(
 						"insert into DLFileEntry (mvccVersion, ",
-						"ctCollectionId, fileEntryId, name) values (0, 0,",
-						fileEntryId3, ", '99999999999999999999')"));
+						"ctCollectionId, fileEntryId, groupId, name) values ",
+						"(0, 0, ", fileEntryId3, ", ", groupId3,
+						", '99999999999999999999')"));
 			},
 			(UnsafeConsumer<List<String>, Exception>)messages -> {
 				Assert.assertEquals(messages.toString(), 1, messages.size());


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95490

## What Is Being Fixed

The integration test `testUpgradeDLFileEntrySpecificCounterFilters` inserted three `DLFileEntry` rows without a `groupId`, so every row produced the identical unique-index tuple `(0, NULL, 0)`. SQL Server, Oracle, and DB2 treat `NULL` as equal to `NULL` in unique indexes, unlike MySQL and PostgreSQL, so the second and third inserts collided with the first on `IX_273362A5` and the test failed on those databases.

## How It Is Being Fixed

Each inserted row now gets a distinct `groupId` from `CounterLocalServiceUtil.increment()`. Because `groupId` is part of every unique index on `DLFileEntry`, distinct values keep every tuple unique across all of them. The insert SQL stays inline in each `runSQL` call, matching the other `DLFileEntry` inserts in the same file, rather than being extracted into a partial-SQL fragment constant.

## Why Are There No Tests?

The change is itself a fix to an existing integration test; there is no production behavior to cover, and the corrected test is the coverage.

## PR Check

**pr-check: PASS** — tested on `6d21e2a9ac53c0d20486cc6366fc5e362c64d656`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "6d21e2a9ac53c0d20486cc6366fc5e362c64d656"} -->
