### PR TITLE
LPD-88080 Keep a company in deletion process until it leaves the pool

### DIFF
--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyLocalServiceDBPartitionTest.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.service.RepositoryLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.VirtualHostLocalService;
+import com.liferay.portal.kernel.service.persistence.CompanyPersistence;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.AssumeTestRule;
@@ -91,6 +92,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.felix.cm.PersistenceManager;
 
@@ -775,6 +777,53 @@ public class CompanyLocalServiceDBPartitionTest
 
 		CompanyLocalServiceTestUtil.assertConfiguration(
 			_configurationAdmin, _persistenceManager, pid, false);
+	}
+
+	@Test
+	public void testDeleteCompanyKeepsCompanyInDeletionProcessUntilRemoved()
+		throws Exception {
+
+		_company1 = CompanyTestUtil.addCompany();
+
+		AopInvocationHandler aopInvocationHandler =
+			ProxyUtil.fetchInvocationHandler(
+				companyLocalService, AopInvocationHandler.class);
+
+		long companyId = _company1.getCompanyId();
+
+		AtomicBoolean companyInDeletionProcess = new AtomicBoolean();
+
+		CompanyPersistence companyPersistence =
+			ReflectionTestUtil.getFieldValue(
+				aopInvocationHandler.getTarget(), "companyPersistence");
+
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					aopInvocationHandler.getTarget(), "companyPersistence",
+					ProxyUtil.newProxyInstance(
+						CompanyPersistence.class.getClassLoader(),
+						new Class<?>[] {CompanyPersistence.class},
+						(proxy, method, args) -> {
+							if (Objects.equals(
+									method.getName(), "fetchByPrimaryKey") &&
+								Objects.equals(args[0], companyId)) {
+
+								companyInDeletionProcess.set(
+									PortalInstances.isCompanyInDeletionProcess(
+										companyId));
+							}
+
+							return method.invoke(companyPersistence, args);
+						}))) {
+
+			companyLocalService.deleteCompany(_company1);
+		}
+
+		Assert.assertFalse(
+			ArrayUtil.contains(
+				CompanyLocalServiceTestUtil.getCompanyIdsBySQL(), companyId));
+
+		Assert.assertTrue(companyInDeletionProcess.get());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1641,23 +1641,29 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		if (PropsValues.DATABASE_PARTITION_ENABLED) {
 			TransactionCommitCallbackUtil.registerCallback(
 				() -> {
-					_clearCache(companyId);
-
-					Store store = _storeSnapshot.get();
-
-					store.deleteDirectory(companyId);
-
-					PortalInstances.removeCompany(company.getCompanyId());
-
-					unregisterCompany(company);
-
-					_synchronizePortalInstances();
-
 					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-								companyId)) {
+							PortalInstances.
+								setCompanyInDeletionProcessWithSafeCloseable(
+									companyId)) {
 
-						CacheRegistryUtil.clear();
+						_clearCache(companyId);
+
+						Store store = _storeSnapshot.get();
+
+						store.deleteDirectory(companyId);
+
+						PortalInstances.removeCompany(company.getCompanyId());
+
+						unregisterCompany(company);
+
+						_synchronizePortalInstances();
+
+						try (SafeCloseable safeCloseable2 =
+								CompanyThreadLocal.
+									setCompanyIdWithSafeCloseable(companyId)) {
+
+							CacheRegistryUtil.clear();
+						}
 					}
 
 					return null;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88080

## What Is Being Fixed

In DB partition mode, deleting a company drops its partition synchronously (a schema on PostgreSQL, a database on MySQL and MariaDB) but removes the company from the instance pool later, in the post-commit callback, and the in-deletion-process flag is already cleared by the time that callback runs. This leaves a brief window where `PortalInstancePool.getCompanyIds()` still returns a company whose partition no longer exists and whose in-deletion-process flag is clear. If the asynchronous audit flush (`PersistentAuditMessageProcessor`, a 60-second timer) fires during that window, `AuditEventManagerImpl.addAuditEvents` iterates the company and `CounterFinderImpl` allocates an audit event ID against the dropped partition. The query fails with `relation "counter" does not exist` on PostgreSQL, or `Unknown database` on MySQL and MariaDB. The asynchronous ERROR is captured by `LogAssertionTestRule`, attached to whichever test is running, and re-reported by `PortalLogAssertorTest`. On the master PostgreSQL db-partition routine it has failed five times between February and June 2026, roughly once a month, and the same race affects the MySQL and MariaDB runs. It cannot be muted cheaply at the log-assertion layer.

## How It Is Being Fixed

The post-commit cleanup callback in `CompanyLocalServiceImpl.doDeleteCompany` now re-acquires the in-deletion-process flag for the duration of the cleanup, with a try-with-resources around `PortalInstances.setCompanyInDeletionProcessWithSafeCloseable`. The audit-flush guard skips any company whose in-deletion-process flag is set, so holding it across the callback, through the pool removal, keeps the flush from iterating the company while its partition is gone.

The flag is re-acquired inside the callback rather than held continuously from `deleteCompany`, because `TransactionCommitCallbackUtil` is commit-only. A continuous hold would strand the company in the in-deletion-process set if the commit failed, since there is no rollback callback to release it, whereas the try-with-resources releases the flag on every path. This closes the wide part of the window, where the failure realistically lands (the callback's cache clear and store directory deletion), and narrows what remains to a sub-microsecond gap between the commit and the callback dispatch. Eliminating even that residual gap would require removing the company from the pool before dropping its partition, which straddles the commit boundary and carries more regression risk than this rare, benign log error warrants.

The regression test adds a company, swaps its `CompanyPersistence` for a delegating proxy that records `isCompanyInDeletionProcess` when the post-commit cleanup looks the company up, then deletes the company and asserts the flag was set during that lookup. It fails on the current code and passes with the fix. It runs in the modules-integration-db-partition CI suites, which exercise it on each supported backend.

## PR Check

**pr-check: PASS** — tested on `04f2f223be2148e588df1ee53f34bfe04f61ca55`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "04f2f223be2148e588df1ee53f34bfe04f61ca55"} -->
