### PR TITLE
LPD-96642 Add portal-db-infrastructure upgrade Playwright project

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3571,7 +3571,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 
 							<trycatch property="exception.message">
 								<try>
-									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
 										<arg value="modules/test/playwright/env/set_up.sh" />
 										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
 										<env key="DATABASE_TYPE" value="@{database.type}" />
@@ -3630,7 +3630,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 									</docker-execute>
 								</try>
 								<catch>
-									<echo>${exception.message}</echo>
+									<fail message="${exception.message}" />
 								</catch>
 								<finally>
 									<stop-docker-playwright />
@@ -3650,9 +3650,13 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
 
 									<if>
-										<equals arg1="${playwright.project.name}" arg2="smoke" />
+										<or>
+											<equals arg1="${playwright.project.name}" arg2="smoke.main" />
+											<contains string="${playwright.project.name}" substring="upgrade" />
+										</or>
 										<then>
 											<ant dir="portal-kernel" inheritAll="false" target="test-class">
+												<env key="JENKINS_HOME" value="true" />
 												<property name="test.class" value="PortalLogAssertorTest" />
 											</ant>
 										</then>

--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3656,7 +3656,6 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 										</or>
 										<then>
 											<ant dir="portal-kernel" inheritAll="false" target="test-class">
-												<env key="JENKINS_HOME" value="true" />
 												<property name="test.class" value="PortalLogAssertorTest" />
 											</ant>
 										</then>

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+function assert_clean_upgrade_log {
+	if [ -z "${LIFERAY_HOME}" ]
+	then
+		echo "LIFERAY_HOME is not set."
+
+		exit 1
+	fi
+
+	local upgrade_log="${LIFERAY_HOME}/tools/portal-tools-db-upgrade-client/logs/upgrade.log"
+
+	if [ ! -f "${upgrade_log}" ]
+	then
+		echo "Unable to find upgrade log at ${upgrade_log}."
+
+		exit 1
+	fi
+
+	# WARN is excluded: EnvPropertiesUtil:54 emits a WARN on every clean upgrade run.
+	local upgrade_log_errors
+	upgrade_log_errors=$(grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}[[:space:]]+(ERROR|FATAL)" "${upgrade_log}" || true)
+
+	if [ -n "${upgrade_log_errors}" ]
+	then
+		echo "Upgrade log contains ERROR or FATAL entries:"
+		echo "${upgrade_log_errors}"
+
+		exit 1
+	fi
+}
+
 function cluster_set_up {
 	default_set_up
 

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -19,12 +19,12 @@ function assert_clean_upgrade_log {
 
 	# WARN is excluded: EnvPropertiesUtil:54 emits a WARN on every clean upgrade run.
 	local upgrade_log_errors
-	upgrade_log_errors=$(grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}[[:space:]]+(ERROR|FATAL)" "${upgrade_log}" || true)
+	upgrade_log_errors=$(grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}([.,][0-9]{3})?[[:space:]]+(ERROR|FATAL)" "${upgrade_log}" || true)
 
 	if [ -n "${upgrade_log_errors}" ]
 	then
 		echo "Upgrade log contains ERROR or FATAL entries:"
-		echo "${upgrade_log_errors}"
+		printf "%s\n" "${upgrade_log_errors}"
 
 		exit 1
 	fi

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -155,6 +155,8 @@ import {config as osbFaroWebSettingsConfig} from './tests/osb-faro-web/settings/
 import {config as passwordPoliciesAdminWebFirstLoginConfig} from './tests/password-policies-admin-web/first-login/config';
 import {config as passwordPoliciesAdminWebConfig} from './tests/password-policies-admin-web/main/config';
 import {config as passwordPoliciesAdminWebSetupAdminConfig} from './tests/password-policies-admin-web/setup-admin/config';
+import {config as portalDbInfrastructureMainConfig} from './tests/portal-db-infrastructure/main/config';
+import {config as portalDbInfrastructureUpgradeConfig} from './tests/portal-db-infrastructure/upgrade/config';
 import {config as portalDefaultPermissionsWebConfig} from './tests/portal-default-permissions-web/main/config';
 import {config as portalImplMainConfig} from './tests/portal-impl/main/config';
 import {config as portalImplPortletConfig} from './tests/portal-impl/portlet/config';
@@ -395,6 +397,8 @@ export default defineConfig({
 		passwordPoliciesAdminWebConfig,
 		passwordPoliciesAdminWebFirstLoginConfig,
 		passwordPoliciesAdminWebSetupAdminConfig,
+		portalDbInfrastructureMainConfig,
+		portalDbInfrastructureUpgradeConfig,
 		portalDefaultPermissionsWebConfig,
 		portalImplMainConfig,
 		portalImplPortletConfig,

--- a/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/object-web/upgrade/env/set_up.sh
@@ -10,6 +10,8 @@ DATA_ARCHIVE_TYPE="data-archive-object"
 PORTAL_VERSION="7.4.13.u33"
 
 function main {
+	set -ex
+
 	cd ${_PORTAL_PROJECT_DIR}
 
 	ant -f build-test.xml \
@@ -20,6 +22,8 @@ function main {
 		rebuild-legacy-database
 
 	ant -f build-test.xml upgrade-legacy-database
+
+	assert_clean_upgrade_log
 
 	default_set_up
 }

--- a/modules/test/playwright/tests/portal-db-infrastructure/main/config.ts
+++ b/modules/test/playwright/tests/portal-db-infrastructure/main/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-db-infrastructure.main',
+	testDir: 'tests/portal-db-infrastructure/main',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/portal-db-infrastructure/main/test.properties
+++ b/modules/test/playwright/tests/portal-db-infrastructure/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Upgrade Framework

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/config.ts
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-db-infrastructure.upgrade',
+	testDir: 'tests/portal-db-infrastructure/upgrade',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/portal-ext.properties
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/portal-ext.properties
@@ -1,0 +1,1 @@
+index.on.startup=true

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/set_up.sh
@@ -24,14 +24,14 @@ function main {
 	local upgrade_exit_code=0
 	ant -f build-test.xml upgrade-legacy-database || upgrade_exit_code=$?
 
-	assert_clean_upgrade_log
-
 	if [ ${upgrade_exit_code} -ne 0 ]
 	then
 		echo "Upgrade failed with exit code ${upgrade_exit_code}."
 
 		exit ${upgrade_exit_code}
 	fi
+
+	assert_clean_upgrade_log
 
 	default_set_up
 }

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/set_up.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname "${BASH_SOURCE[0]}")
+
+echo "CURRENT_DIR_NAME=${CURRENT_DIR_NAME}"
+
+source "${CURRENT_DIR_NAME}/../../../../env/common.sh"
+
+DATA_ARCHIVE_TYPE="data-archive-portal"
+PORTAL_VERSION="6.2.5"
+
+function main {
+	set -ex
+
+	cd "${_PORTAL_PROJECT_DIR}"
+
+	ant -f build-test.xml \
+		-Ddata.archive.type=${DATA_ARCHIVE_TYPE} \
+		-Dkeep.cached.app.server.data=true \
+		-Dportal.version=${PORTAL_VERSION} \
+		-Dskip.get.testcase.database.properties=true \
+		rebuild-legacy-database
+
+	local upgrade_exit_code=0
+	ant -f build-test.xml upgrade-legacy-database || upgrade_exit_code=$?
+
+	assert_clean_upgrade_log
+
+	if [ ${upgrade_exit_code} -ne 0 ]
+	then
+		echo "Upgrade failed with exit code ${upgrade_exit_code}."
+
+		exit ${upgrade_exit_code}
+	fi
+
+	default_set_up
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/portalSmokeUpgrade.spec.ts
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/portalSmokeUpgrade.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = mergeTests(loginTest());
+
+async function viewUpgradedPortalContent(page: Page) {
+	await test.step('View web content after upgrade', async () => {
+		await page.goto('/web/guest/web-content');
+
+		await expect(
+			page.getByText('Web Content Title', {exact: true})
+		).toBeVisible();
+
+		await expect(
+			page.getByText('Web Content Content', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View document after upgrade', async () => {
+		await page.goto('/web/guest/document');
+
+		await expect(page.getByText('Document1', {exact: true})).toBeVisible();
+	});
+
+	await test.step('View message boards after upgrade', async () => {
+		await page.goto('/web/guest/message-boards');
+
+		await expect(
+			page.getByText('Message Boards Subject', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View wiki after upgrade', async () => {
+		await page.goto('/web/guest/wiki');
+
+		await expect(
+			page.getByText('Wiki Front Page Content', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View blogs after upgrade', async () => {
+		await page.goto('/web/guest/blogs');
+
+		await expect(
+			page.getByText('Blogs Entry Title', {exact: true})
+		).toBeVisible();
+
+		await expect(
+			page.getByText('Blogs Entry Content', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View site page after upgrade', async () => {
+		await page.goto('/web/site-name/site-page');
+
+		await expect(page).toHaveTitle(/Site Page/);
+	});
+}
+
+test.describe.serial('View portal smoke upgrade', () => {
+	test(
+		'Can view upgraded portal content as admin',
+		{tag: '@LPD-96642'},
+		async ({page}) => {
+			await viewUpgradedPortalContent(page);
+		}
+	);
+
+	test(
+		'Can view upgraded portal content as regular user',
+		{tag: '@LPD-96642'},
+		async ({page}) => {
+			await page.goto('/c/portal/logout');
+
+			await page.goto('/c/portal/login');
+
+			await page.getByLabel('Email Address').fill('user@liferay.com');
+
+			await page.getByLabel('Password').fill('test');
+
+			await page.getByRole('button', {name: 'Sign In'}).click();
+
+			await expect(page).toHaveURL(/\/web\/guest/);
+
+			await viewUpgradedPortalContent(page);
+		}
+	);
+});

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/test.properties
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Upgrade Framework


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96642

## What Is Being Fixed

There was no automated Playwright test project covering portal upgrade scenarios for the `portal-db-infrastructure` test suite. Upgrade failures could go undetected until a later stage, and the existing `build-test-batch.xml` Playwright setup step silently swallowed setup errors (`<exec>` without `failonerror`, and a `<catch>` block that only echoed but did not propagate the exception).

## How It Is Being Fixed

A new `portal-db-infrastructure` Playwright project is added with two variants — `main` and `upgrade`. The `upgrade` variant sets up by rebuilding a legacy database from a 6.2.5 data archive using `rebuild-legacy-database`, runs the portal upgrade via `upgrade-legacy-database`, and then asserts the upgrade log is free of `ERROR` and `FATAL` entries via a new `assert_clean_upgrade_log` function in `common.sh`. After setup, `portalSmokeUpgrade.spec.ts` logs in as both an admin and a regular user and verifies that content created before the upgrade — web content, documents, message boards, wiki pages, and blog entries — is still visible on its expected site page.

The two config files (`main/config.ts` and `upgrade/config.ts`) register the project names `portal-db-infrastructure.main` and `portal-db-infrastructure.upgrade` in `playwright.config.ts`. In `build-test-batch.xml`, the Playwright setup exec is updated to `failonerror="true"` and the catch block now propagates the failure with `<fail>`. An invalid `<env key="JENKINS_HOME">` element is also removed from the `<ant>` task — `<ant>` does not support `<env>`, and `JENKINS_HOME` is already present in the CI environment natively.

The `PortalLogAssertorTest` gate in `build-test-batch.xml` runs after the Playwright tests and checks the OSGi module state and portal runtime logs for errors — it does not check `upgrade.log`. The upgrade log is checked separately by `assert_clean_upgrade_log` in `set_up.sh`. The gate condition is updated to fix the smoke project check (the old `arg2="smoke"` was always dead since the project name is `smoke.main`) and to add a new check for any project whose name contains `upgrade`.

## PR Check

**pr-check: PASS** — tested on `9cddb5206f6e6bdd5e24be2d1bd297fef5a72487`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "9cddb5206f6e6bdd5e24be2d1bd297fef5a72487"} -->
