### PR TITLE
LPD-91359 Fix flaky testGetLongRunningQueryInfos on PostgreSQL

### DIFF
--- a/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
+++ b/modules/apps/portal/portal-dao-test/src/testIntegration/java/com/liferay/portal/dao/db/test/DBTest.java
@@ -772,19 +772,22 @@ public class DBTest {
 
 			long endTime = System.currentTimeMillis() + 30000;
 
+			boolean foundLongRunningQuery = false;
+
 			while (System.currentTimeMillis() < endTime) {
 				for (DB.QueryInfo queryInfo :
 						db.getLongRunningQueryInfos(pollingConnection)) {
 
 					String query = queryInfo.getQuery();
 
-					if (!query.contains(_getSlowQueryFragment())) {
+					if (!query.contains(_getSlowQueryFragment()) ||
+						(queryInfo.getState() == null)) {
+
 						continue;
 					}
 
 					Assert.assertNotNull(queryInfo.getId());
 					Assert.assertNotNull(queryInfo.getSchema());
-					Assert.assertNotNull(queryInfo.getState());
 
 					for (DB.QueryInfo lockedQueryInfo :
 							db.getLockedQueryInfos(pollingConnection)) {
@@ -795,13 +798,19 @@ public class DBTest {
 							lockedQuery.contains(_getSlowQueryFragment()));
 					}
 
-					return;
+					foundLongRunningQuery = true;
+
+					break;
+				}
+
+				if (foundLongRunningQuery) {
+					break;
 				}
 
 				Thread.sleep(200);
 			}
 
-			Assert.fail();
+			Assert.assertTrue(foundLongRunningQuery);
 		}
 		finally {
 			if (futureTask != null) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91359

## What Is Being Fixed

The integration test `testGetLongRunningQueryInfos` (run against PostgreSQL via `PostgreSQLDBTest`) fails intermittently on `Assert.assertNotNull(queryInfo.getState())`. On PostgreSQL, `QueryInfo.state` maps to `pg_stat_activity.wait_event_type`, which is null whenever the monitored query is actively running but not currently parked on a wait event. The `getLongRunningQueryInfos` SQL deliberately returns those null-wait rows, so a poll that catches the background `select pg_sleep(2)` query in its brief active-but-not-yet-sleeping window sees a null state and fails the assertion — a timing-dependent flake (the same routine shows PASSED and FAILED on the same git SHA).

## How It Is Being Fixed

The test now treats a null `state` as "the query has not settled into its wait yet — keep polling" instead of asserting on it, and asserts a positive success flag (`foundLongRunningQuery`) after the loop. The test therefore passes only once it has observed the slow query with a populated state at least once, and fails cleanly if that never happens rather than through a bare timeout. This mirrors the existing `foundInLocked` pattern in the sibling tests. The `getId()` and `getSchema()` assertions are kept, and there is no production change — a null wait state for an actively running long-running query is correct behavior. The same fix also removes a latent version of this flake on SQL Server, whose `state` maps to the equally nullable `dm_exec_requests.wait_type`.

## Why Are There No Tests?

The change is confined to an integration test itself, fixing a flaky assertion; there is no production code change requiring new coverage. The modified test is the coverage, verified with 100 consecutive passing runs of `PostgreSQLDBTest.testGetLongRunningQueryInfos` against PostgreSQL 16.14.

## PR Check

**pr-check: PASS** — tested on `b0f38d8e649c63c9d625286cb09131a01ffaa370`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "b0f38d8e649c63c9d625286cb09131a01ffaa370"} -->
