### PR TITLE
LPD-96466 Prevent DB2 result set closed error in concurrent processing

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -56,11 +56,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.naming.NamingException;
@@ -779,6 +783,10 @@ public abstract class BaseDBProcess implements DBProcess {
 			boolean notificationEnabled = NotificationThreadLocal.isEnabled();
 			boolean workflowEnabled = WorkflowThreadLocal.isEnabled();
 
+			AtomicBoolean atomicBoolean = new AtomicBoolean();
+			BlockingQueue<T> blockingQueue = new ArrayBlockingQueue<>(
+				fixedThreadPoolSize);
+
 			Callable<Void> callable = () -> {
 				NotificationThreadLocal.setEnabled(notificationEnabled);
 				WorkflowThreadLocal.setEnabled(workflowEnabled);
@@ -789,14 +797,14 @@ public abstract class BaseDBProcess implements DBProcess {
 					PreparedStatement preparedStatement = null;
 
 					while (true) {
-						T current = null;
-
-						synchronized (unsafeSupplier) {
-							current = unsafeSupplier.get();
-						}
+						T current = blockingQueue.poll(1, TimeUnit.SECONDS);
 
 						if (current == null) {
-							break;
+							if (atomicBoolean.get()) {
+								break;
+							}
+
+							continue;
 						}
 
 						if (Validator.isNull(updateSQL)) {
@@ -830,6 +838,22 @@ public abstract class BaseDBProcess implements DBProcess {
 				futures.add(
 					executorService.submit(
 						new CompanyInheritableThreadLocalCallable<>(callable)));
+			}
+
+			try {
+				T current = unsafeSupplier.get();
+
+				while (current != null) {
+					if (blockingQueue.offer(current, 1, TimeUnit.SECONDS)) {
+						current = unsafeSupplier.get();
+					}
+					else if (throwableCollector.getThrowable() != null) {
+						return;
+					}
+				}
+			}
+			finally {
+				atomicBoolean.set(true);
 			}
 		}
 		finally {

--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -783,8 +783,8 @@ public abstract class BaseDBProcess implements DBProcess {
 			boolean notificationEnabled = NotificationThreadLocal.isEnabled();
 			boolean workflowEnabled = WorkflowThreadLocal.isEnabled();
 
-			AtomicBoolean atomicBoolean = new AtomicBoolean();
-			BlockingQueue<T> blockingQueue = new ArrayBlockingQueue<>(
+			AtomicBoolean producerFinished = new AtomicBoolean();
+			BlockingQueue<T> queue = new ArrayBlockingQueue<>(
 				fixedThreadPoolSize);
 
 			Callable<Void> callable = () -> {
@@ -796,14 +796,10 @@ public abstract class BaseDBProcess implements DBProcess {
 				try {
 					PreparedStatement preparedStatement = null;
 
-					while (true) {
-						T current = blockingQueue.poll(1, TimeUnit.SECONDS);
+					while (!producerFinished.get() || !queue.isEmpty()) {
+						T current = queue.poll(1, TimeUnit.SECONDS);
 
 						if (current == null) {
-							if (atomicBoolean.get()) {
-								break;
-							}
-
 							continue;
 						}
 
@@ -844,7 +840,7 @@ public abstract class BaseDBProcess implements DBProcess {
 				T current = unsafeSupplier.get();
 
 				while (current != null) {
-					if (blockingQueue.offer(current, 1, TimeUnit.SECONDS)) {
+					if (queue.offer(current, 1, TimeUnit.SECONDS)) {
 						current = unsafeSupplier.get();
 					}
 					else if (throwableCollector.getThrowable() != null) {
@@ -853,7 +849,7 @@ public abstract class BaseDBProcess implements DBProcess {
 				}
 			}
 			finally {
-				atomicBoolean.set(true);
+				producerFinished.set(true);
 			}
 		}
 		finally {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96466

## What Is Being Fixed

On DB2, upgrade processes that call `BaseDBProcess.processConcurrently` fail with `ERRORCODE=-4470` "result set is closed". LPD-91341 moved the `resultSet.next()` call out of the thread that opened the result set and into the worker callables. DB2 rejects reading a cursor from a thread other than the one that opened it, so only DB2 fails, and only once the result set exceeds the JDBC fetch size (`UPGRADE_CONCURRENT_FETCH_SIZE`, 1000 by default).

## How It Is Being Fixed

The owning thread now produces the rows and the workers only consume them. The producer reads the result set on the thread that opened it and hands each row to the workers through a bounded `ArrayBlockingQueue`; the workers take rows from the queue and run the existing per-worker batching and transaction handling. The queue is bounded by the worker count so a large table is not buffered into memory, and the producer stops early when a worker has already failed, so the pipeline cannot deadlock. A follow-up commit renames the coordination locals and folds the worker termination into the loop condition for readability, with no behavior change.

## Why Are There No Tests?

The behavior is already covered by the pre-existing `BaseUuidUpgradeProcessTest`, which drives `processConcurrently` over 10,000 rows — well above the 1000-row default fetch size — and therefore reproduces the `-4470` on the DB2 CI lane without this fix. The fix itself was verified against a live DB2 instance. The dedicated DB2 integration test and the thread-assertion unit test that earlier drafts added were dropped as redundant with that existing coverage.

## PR Check

**pr-check: PASS** — tested on `04147804e69b4e3b24536d3fe478d477dacecac2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Baseline | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "04147804e69b4e3b24536d3fe478d477dacecac2"} -->
