### PR TITLE
LPD-88080 Keep a company in deletion process until it leaves the pool

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -244,7 +244,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 				company.getCompanyId());
 
 		try {
-			return _transactionAwareInvoke(
+			Company addedCompany = _transactionAwareInvoke(
 				() -> {
 					company.setWebId(webId);
 					company.setMx(mx);
@@ -332,6 +332,15 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					return updatedCompany;
 				});
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable.close();
+
+					return null;
+				});
+
+			return addedCompany;
 		}
 		catch (Throwable throwable) {
 			try {
@@ -351,14 +360,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			throw new PortalException(throwable);
-		}
-		finally {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable.close();
-
-					return null;
-				});
 		}
 	}
 
@@ -395,11 +396,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		SafeCloseable safeCloseable2 =
 			CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
 
-		companyPersistence.clearCache();
-		_virtualHostPersistence.clearCache();
-
 		try {
-			return _transactionAwareInvoke(
+			companyPersistence.clearCache();
+			_virtualHostPersistence.clearCache();
+
+			Company importedCompany = _transactionAwareInvoke(
 				() -> {
 					Company company = companyPersistence.findByPrimaryKey(
 						companyId);
@@ -441,6 +442,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					return _addDBPartitionCompany(company);
 				});
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable1.close();
+					safeCloseable2.close();
+
+					return null;
+				});
+
+			return importedCompany;
 		}
 		catch (Throwable throwable) {
 			try (SafeCloseable safeCloseable3 =
@@ -463,15 +474,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			throw new PortalException(throwable);
-		}
-		finally {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable1.close();
-					safeCloseable2.close();
-
-					return null;
-				});
 		}
 	}
 
@@ -673,7 +675,7 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		long companyId = toCompanyId;
 
 		try {
-			return _transactionAwareInvoke(
+			Company copiedCompany = _transactionAwareInvoke(
 				() -> {
 					Company company = fromCompany.cloneWithOriginalValues();
 
@@ -689,6 +691,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 					return _addDBPartitionCompany(company);
 				});
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable1.close();
+					safeCloseable2.close();
+
+					return null;
+				});
+
+			return copiedCompany;
 		}
 		catch (Throwable throwable) {
 			try (SafeCloseable safeCloseable3 =
@@ -709,15 +721,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			throw new PortalException(throwable);
-		}
-		finally {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable1.close();
-					safeCloseable2.close();
-
-					return null;
-				});
 		}
 	}
 
@@ -741,7 +744,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		try (SafeCloseable safeCloseable2 =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
-			return doDeleteCompany(companyId);
+			Company company = doDeleteCompany(companyId);
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable1.close();
+
+					return null;
+				});
+
+			return company;
 		}
 		catch (Throwable throwable) {
 			safeCloseable1.close();
@@ -751,14 +763,6 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			}
 
 			throw throwable;
-		}
-		finally {
-			TransactionCommitCallbackUtil.registerCallback(
-				() -> {
-					safeCloseable1.close();
-
-					return null;
-				});
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -734,20 +734,31 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 					companyId);
 		}
 
-		try (SafeCloseable safeCloseable1 =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId);
-			SafeCloseable safeCloseable2 =
-				PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
-					companyId)) {
+		SafeCloseable safeCloseable1 =
+			PortalInstances.setCompanyInDeletionProcessWithSafeCloseable(
+				companyId);
+
+		try (SafeCloseable safeCloseable2 =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
 
 			return doDeleteCompany(companyId);
 		}
-		catch (PortalException portalException) {
+		catch (Throwable throwable) {
+			safeCloseable1.close();
+
 			if (_log.isDebugEnabled()) {
-				_log.debug(portalException);
+				_log.debug(throwable);
 			}
 
-			throw portalException;
+			throw throwable;
+		}
+		finally {
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					safeCloseable1.close();
+
+					return null;
+				});
 		}
 	}
 
@@ -1641,29 +1652,23 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		if (PropsValues.DATABASE_PARTITION_ENABLED) {
 			TransactionCommitCallbackUtil.registerCallback(
 				() -> {
+					_clearCache(companyId);
+
+					Store store = _storeSnapshot.get();
+
+					store.deleteDirectory(companyId);
+
+					PortalInstances.removeCompany(company.getCompanyId());
+
+					unregisterCompany(company);
+
+					_synchronizePortalInstances();
+
 					try (SafeCloseable safeCloseable =
-							PortalInstances.
-								setCompanyInDeletionProcessWithSafeCloseable(
-									companyId)) {
+							CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+								companyId)) {
 
-						_clearCache(companyId);
-
-						Store store = _storeSnapshot.get();
-
-						store.deleteDirectory(companyId);
-
-						PortalInstances.removeCompany(company.getCompanyId());
-
-						unregisterCompany(company);
-
-						_synchronizePortalInstances();
-
-						try (SafeCloseable safeCloseable2 =
-								CompanyThreadLocal.
-									setCompanyIdWithSafeCloseable(companyId)) {
-
-							CacheRegistryUtil.clear();
-						}
+						CacheRegistryUtil.clear();
 					}
 
 					return null;

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -1641,23 +1641,29 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		if (PropsValues.DATABASE_PARTITION_ENABLED) {
 			TransactionCommitCallbackUtil.registerCallback(
 				() -> {
-					_clearCache(companyId);
-
-					Store store = _storeSnapshot.get();
-
-					store.deleteDirectory(companyId);
-
-					PortalInstances.removeCompany(company.getCompanyId());
-
-					unregisterCompany(company);
-
-					_synchronizePortalInstances();
-
 					try (SafeCloseable safeCloseable =
-							CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-								companyId)) {
+							PortalInstances.
+								setCompanyInDeletionProcessWithSafeCloseable(
+									companyId)) {
 
-						CacheRegistryUtil.clear();
+						_clearCache(companyId);
+
+						Store store = _storeSnapshot.get();
+
+						store.deleteDirectory(companyId);
+
+						PortalInstances.removeCompany(company.getCompanyId());
+
+						unregisterCompany(company);
+
+						_synchronizePortalInstances();
+
+						try (SafeCloseable safeCloseable2 =
+								CompanyThreadLocal.
+									setCompanyIdWithSafeCloseable(companyId)) {
+
+							CacheRegistryUtil.clear();
+						}
 					}
 
 					return null;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88080

## What Is Being Fixed

In DB partition mode, deleting a company drops its partition synchronously (a schema on PostgreSQL, a database on MySQL and MariaDB) but removes the company from the instance pool later, in a post-commit callback, and the in-deletion-process flag is cleared before that callback runs. This leaves a window where `PortalInstancePool.getCompanyIds()` still returns a company whose partition no longer exists and whose in-deletion-process flag is clear. If the asynchronous audit flush (`PersistentAuditMessageProcessor`) fires during that window, `AuditEventManagerImpl.addAuditEvents` iterates the company and `CounterFinderImpl` allocates an audit event ID against the dropped partition, failing with `relation "counter" does not exist` on PostgreSQL or `Unknown database` on MySQL and MariaDB. The asynchronous ERROR is captured by `LogAssertionTestRule` and re-reported by `PortalLogAssertorTest`. It has failed on the master db-partition routines roughly once a month.

## How It Is Being Fixed

The in-deletion-process flag is now held continuously from `deleteCompany` until after the company leaves the instance pool. `deleteCompany` acquires the flag and releases it through a commit callback registered after the cleanup callback that calls `PortalInstances.removeCompany`, so at commit the FIFO order runs the pool removal first and clears the flag only afterward. This eliminates the window across the commit boundary rather than only narrowing it. On the failure path the flag is closed explicitly, because a rollback discards commit callbacks and would otherwise strand the company in the deletion set.

The same success-path commit-callback pattern is applied to `addCompany`, `importCompany`, and `copyCompany`. These previously released their flag through a callback registered in a `finally` block while also closing it in the `catch`; on the exception path the transaction rolls back and the callback list is discarded, so the `finally` registered a callback that could never run. Registering it only after the transactional work succeeds removes that dead registration, leaving the explicit `catch` close as the single release on failure. The import path also moved its cache-clear calls inside the `try`, so a failure there can no longer leak the flag.

## Why Are There No Tests?

The regression is covered by `PortalLogAssertorTest`: the asynchronous `counter does not exist` / `Unknown database` error is captured by `LogAssertionTestRule` and re-reported there, which is the existing signal for this class of failure. The original `CompanyPersistence`-proxy test was removed as too heavyweight for the behavior it asserted.

## PR Check

**pr-check: PASS** — tested on `f7de50b55053ee0ff4acd1356b715eee10da3b28`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "f7de50b55053ee0ff4acd1356b715eee10da3b28"} -->
