### PR TITLE
LPD-92617 Add POST /portal-instances/{portalInstanceId}/export REST endpoint

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/bnd.bnd
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Portal Instances API
 Bundle-SymbolicName: com.liferay.headless.portal.instances.api
-Bundle-Version: 8.0.5
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.headless.portal.instances.dto.v1_0,\
 	com.liferay.headless.portal.instances.resource.v1_0

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
@@ -21,6 +21,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -55,6 +56,9 @@ public interface PortalInstanceResource {
 		throws Exception;
 
 	public PortalInstance postPortalInstance(PortalInstance portalInstance)
+		throws Exception;
+
+	public Response postPortalInstanceExport(String portalInstanceId)
 		throws Exception;
 
 	public void putPortalInstanceActivate(String portalInstanceId)
@@ -151,4 +155,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1561391421
+// LIFERAY-REST-BUILDER-HASH:-1120198807

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
@@ -68,6 +68,13 @@ public interface PortalInstanceResource {
 			PortalInstance portalInstance)
 		throws Exception;
 
+	public void postPortalInstanceExport(String portalInstanceId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postPortalInstanceExportHttpResponse(
+			String portalInstanceId)
+		throws Exception;
+
 	public void putPortalInstanceActivate(String portalInstanceId)
 		throws Exception;
 
@@ -723,6 +730,102 @@ public interface PortalInstanceResource {
 			return httpInvoker.invoke();
 		}
 
+		public void postPortalInstanceExport(String portalInstanceId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postPortalInstanceExportHttpResponse(portalInstanceId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postPortalInstanceExportHttpResponse(
+				String portalInstanceId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/export");
+
+			httpInvoker.path("portalInstanceId", portalInstanceId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public void putPortalInstanceActivate(String portalInstanceId)
 			throws Exception {
 
@@ -949,4 +1052,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2031700361
+// LIFERAY-REST-BUILDER-HASH:527938936

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/build.gradle
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.18.6"
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.26.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
@@ -15,7 +16,9 @@ dependencies {
 	compileOnly project(":apps:headless:headless-portal-instances:headless-portal-instances-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -232,3 +232,28 @@ paths:
                     description:
                         default response
             tags: ["PortalInstance"]
+    /portal-instances/{portalInstanceId}/export:
+        # @review
+        post:
+            description:
+                Exports the portal instance
+            operationId: postPortalInstanceExport
+            parameters:
+                -   in: path
+                    name: portalInstanceId
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                type: string
+                        application/xml:
+                            schema:
+                                type: string
+                    description:
+                        default response
+            # @review
+            tags: ["PortalInstance"]

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
@@ -28,6 +28,7 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collection;
@@ -205,6 +206,43 @@ public abstract class BasePortalInstanceResourceImpl
 		throws Exception {
 
 		return new PortalInstance();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/export'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Exports the portal instance"
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portalInstanceId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "PortalInstance")
+		}
+	)
+	@jakarta.ws.rs.Path("/portal-instances/{portalInstanceId}/export")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Response postPortalInstanceExport(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portalInstanceId")
+			String portalInstanceId)
+		throws Exception {
+
+		Response.ResponseBuilder responseBuilder = Response.ok();
+
+		return responseBuilder.build();
 	}
 
 	/**
@@ -718,4 +756,4 @@ public abstract class BasePortalInstanceResourceImpl
 		LogFactoryUtil.getLog(BasePortalInstanceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-745623835
+// LIFERAY-REST-BUILDER-HASH:-459579270

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -8,20 +8,42 @@ package com.liferay.headless.portal.instances.internal.resource.v1_0;
 import com.liferay.headless.portal.instances.dto.v1_0.Admin;
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstance;
 import com.liferay.headless.portal.instances.resource.v1_0.PortalInstanceResource;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.auth.EmailAddressValidator;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CompanyService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.EmailAddressValidatorFactory;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.pagination.Page;
 
+import jakarta.ws.rs.core.Response;
+
 import java.util.ArrayList;
+import java.util.Dictionary;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.felix.cm.file.ConfigurationHandler;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -128,6 +150,39 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	}
 
 	@Override
+	public Response postPortalInstanceExport(String portalInstanceId)
+		throws Exception {
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (!permissionChecker.isOmniadmin()) {
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
+		}
+
+		Company company = _companyService.getCompanyByWebId(portalInstanceId);
+
+		long companyId = company.getCompanyId();
+
+		try {
+			_companyLocalService.exportCompany(companyId);
+
+			_exportConfigurations(companyId);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to export portal instance " + portalInstanceId,
+				exception);
+
+			throw exception;
+		}
+
+		return Response.ok(
+			"lexported_" + companyId
+		).build();
+	}
+
+	@Override
 	public void putPortalInstanceActivate(String portalInstanceId)
 		throws Exception {
 
@@ -147,6 +202,117 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		_companyService.updateCompany(
 			company.getCompanyId(), company.getVirtualHostname(),
 			company.getMx(), company.getMaxUsers(), false);
+	}
+
+	private void _exportConfigurations(long companyId) throws Exception {
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			return;
+		}
+
+		Map<String, String> configurations = DBPartitionUtil.getConfigurations(
+			CompanyConstants.SYSTEM);
+
+		for (Map.Entry<String, String> entry : configurations.entrySet()) {
+			ScopedConfiguration scopedConfiguration = _getScopedConfiguration(
+				entry.getKey(), entry.getValue());
+
+			if ((scopedConfiguration == null) ||
+				!_isApplicable(companyId, scopedConfiguration)) {
+
+				continue;
+			}
+
+			DBPartitionUtil.exportConfiguration(
+				companyId, scopedConfiguration.getConfigurationId(),
+				scopedConfiguration.getEncodedDictionary());
+		}
+	}
+
+	private ScopedConfiguration _getScopedConfiguration(
+			String configurationId, String encodedDictionary)
+		throws Exception {
+
+		Dictionary<String, String> dictionary = ConfigurationHandler.read(
+			new UnsyncByteArrayInputStream(
+				encodedDictionary.getBytes(StringPool.UTF8)));
+
+		Object value = dictionary.get(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfiguration(
+				configurationId, encodedDictionary,
+				ExtendedObjectClassDefinition.Scope.GROUP,
+				GetterUtil.getLong(value));
+		}
+
+		value = dictionary.get(
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfiguration(
+				configurationId, encodedDictionary,
+				ExtendedObjectClassDefinition.Scope.COMPANY,
+				GetterUtil.getLong(value));
+		}
+
+		value = dictionary.get(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfiguration(
+				configurationId, encodedDictionary,
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+				GetterUtil.getString(value));
+		}
+
+		return null;
+	}
+
+	private boolean _isApplicable(
+			long companyId, ScopedConfiguration scopedConfiguration)
+		throws Exception {
+
+		if (Objects.equals(
+				scopedConfiguration.getScope(),
+				ExtendedObjectClassDefinition.Scope.COMPANY)) {
+
+			if (companyId == (long)scopedConfiguration.getScopePK()) {
+				return true;
+			}
+
+			return false;
+		}
+
+		if (Objects.equals(
+				scopedConfiguration.getScope(),
+				ExtendedObjectClassDefinition.Scope.GROUP)) {
+
+			long groupId = (long)scopedConfiguration.getScopePK();
+
+			Group group = _groupLocalService.fetchGroup(groupId);
+
+			if (group == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Unable to export configuration ",
+							scopedConfiguration.getConfigurationId(),
+							" because group ", groupId, " does not exist"));
+				}
+
+				return false;
+			}
+
+			if (group.getCompanyId() == companyId) {
+				return true;
+			}
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private PortalInstance _toPortalInstance(Company company) {
@@ -178,7 +344,51 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		}
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalInstanceResourceImpl.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
 	@Reference
 	private CompanyService _companyService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	private static class ScopedConfiguration {
+
+		public ScopedConfiguration(
+			String configurationId, String encodedDictionary,
+			ExtendedObjectClassDefinition.Scope scope, Object scopePK) {
+
+			_configurationId = configurationId;
+			_encodedDictionary = encodedDictionary;
+			_scope = scope;
+			_scopePK = scopePK;
+		}
+
+		public String getConfigurationId() {
+			return _configurationId;
+		}
+
+		public String getEncodedDictionary() {
+			return _encodedDictionary;
+		}
+
+		public ExtendedObjectClassDefinition.Scope getScope() {
+			return _scope;
+		}
+
+		public Object getScopePK() {
+			return _scopePK;
+		}
+
+		private final String _configurationId;
+		private final String _encodedDictionary;
+		private final ExtendedObjectClassDefinition.Scope _scope;
+		private final Object _scopePK;
+
+	}
 
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
@@ -330,6 +330,11 @@ public abstract class BasePortalInstanceResourceTestCase {
 	}
 
 	@Test
+	public void testPostPortalInstanceExport() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testPutPortalInstanceActivate() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		PortalInstance portalInstance =
@@ -1302,4 +1307,4 @@ public abstract class BasePortalInstanceResourceTestCase {
 			PortalInstanceResource _portalInstanceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1869092667
+// LIFERAY-REST-BUILDER-HASH:-1997465098

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -8,11 +8,15 @@ package com.liferay.headless.portal.instances.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.portal.instances.client.dto.v1_0.Admin;
 import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.client.http.HttpInvoker;
 import com.liferay.headless.portal.instances.client.pagination.Page;
 import com.liferay.headless.portal.instances.client.problem.Problem;
+import com.liferay.headless.portal.instances.client.resource.v1_0.PortalInstanceResource;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -20,15 +24,21 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.PrefsPropsTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -93,6 +103,15 @@ public class PortalInstanceResourceTest
 		_testPostPortalInstanceWithoutAdmin();
 		_testPostPortalInstanceWithAdmin();
 		_testPostPortalInstanceWithAdminAndCompanyStrangers();
+	}
+
+	@FeatureFlag("LPD-11342")
+	@Override
+	@Test
+	public void testPostPortalInstanceExport() throws Exception {
+		_testPostPortalInstanceExportForbidden();
+		_testPostPortalInstanceExportNonexistent();
+		_testPostPortalInstanceExportExisting();
 	}
 
 	@Override
@@ -371,6 +390,71 @@ public class PortalInstanceResourceTest
 		_testPatchPortalInstace(portalInstance, false, false, false);
 	}
 
+	private void _testPostPortalInstanceExportExisting() throws Exception {
+		Assume.assumeTrue(_db.isSupportsDBPartition());
+
+		HttpInvoker.HttpResponse httpResponse =
+			portalInstanceResource.postPortalInstanceExportHttpResponse(
+				_portalInstance.getPortalInstanceId());
+
+		Assert.assertEquals(200, httpResponse.getStatusCode());
+
+		String contentString = httpResponse.getContent();
+
+		Assert.assertTrue(
+			contentString.contains(
+				"lexported_" + _portalInstance.getCompanyId()));
+	}
+
+	private void _testPostPortalInstanceExportForbidden() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		try {
+			_userLocalService.updatePassword(
+				user.getUserId(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				PropsValues.DEFAULT_ADMIN_PASSWORD, false);
+
+			PortalInstanceResource userPortalInstanceResource =
+				PortalInstanceResource.builder(
+				).authentication(
+					user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+				).endpoint(
+					testCompany.getVirtualHostname(),
+					PortalUtil.getPortalServerPort(false), "http"
+				).locale(
+					LocaleUtil.getDefault()
+				).build();
+
+			userPortalInstanceResource.postPortalInstanceExport(
+				_portalInstance.getPortalInstanceId());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+		finally {
+			_userLocalService.deleteUser(user.getUserId());
+		}
+	}
+
+	private void _testPostPortalInstanceExportNonexistent() throws Exception {
+		try {
+			portalInstanceResource.postPortalInstanceExport(
+				RandomTestUtil.randomString());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
 	private void _testPostPortalInstanceWithAdmin() throws Exception {
 		PortalInstance randomPortalInstance = randomPortalInstance();
 
@@ -443,6 +527,9 @@ public class PortalInstanceResourceTest
 	private static CompanyLocalService _companyLocalService;
 
 	private static PortalInstance _portalInstance;
+
+	@Inject
+	private DB _db;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -401,9 +401,9 @@ public class PortalInstanceResourceTest
 
 		String contentString = httpResponse.getContent();
 
-		Assert.assertTrue(
-			contentString.contains(
-				"lexported_" + _portalInstance.getCompanyId()));
+		Assert.assertEquals(
+			"\"lexported_" + _portalInstance.getCompanyId() + "\"",
+			contentString.trim());
 	}
 
 	private void _testPostPortalInstanceExportForbidden() throws Exception {


### PR DESCRIPTION
## What

Adds `POST /portal-instances/{portalInstanceId}/export` to the headless portal instances REST API.

The endpoint:
- Requires omniadmin permission (403 otherwise)
- Returns 404 when the portal instance ID does not exist
- Calls `CompanyLocalService.exportCompany` to export the DB partition
- Exports OSGi configurations scoped to the target company when DB partitioning is disabled
- Gated behind feature flag `LPD-11342`

## Why

Exposes the portal instance export operation through the headless REST API so it can be triggered programmatically.

## Testing

Integration tests cover: 200 success (DB partition capable DBs only), 403 forbidden (non-omniadmin user), 404 not found.

---

**pr-check: PASS** — tested on `5e05d2598c230da7f5907af4dcd05d6fe761fb42`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |