### PR TITLE
LPD-82361 Add in memory Company and VirtualHost registries

### DIFF
--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyRegistryTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/CompanyRegistryTest.java
@@ -1,0 +1,103 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.company.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.CompanyRegistry;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author István András Dézsi
+ */
+@DataGuard(scope = DataGuard.Scope.NONE)
+@RunWith(Arquillian.class)
+public class CompanyRegistryTest extends BaseDBPartitionTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testAddAndDeleteCompany() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		long companyId = _company.getCompanyId();
+
+		Company company = CompanyRegistry.fetchCompany(companyId);
+
+		Assert.assertEquals(_company.getWebId(), company.getWebId());
+
+		_companyLocalService.deleteCompany(_company);
+
+		Assert.assertNull(CompanyRegistry.fetchCompany(companyId));
+	}
+
+	@Test
+	public void testFetchCompany() throws Exception {
+		long companyId = PortalInstancePool.getDefaultCompanyId();
+
+		Company defaultCompany = _companyLocalService.getCompany(companyId);
+
+		Company company = CompanyRegistry.fetchCompany(companyId);
+
+		Assert.assertEquals(defaultCompany.getWebId(), company.getWebId());
+	}
+
+	@Test
+	public void testFetchCompanyByWebId() throws Exception {
+		Company defaultCompany = _companyLocalService.getCompany(
+			PortalInstancePool.getDefaultCompanyId());
+
+		Company company = CompanyRegistry.fetchCompanyByWebId(
+			defaultCompany.getWebId());
+
+		Assert.assertEquals(
+			defaultCompany.getCompanyId(), company.getCompanyId());
+	}
+
+	@Test
+	public void testUpdateCompany() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		int maxUsers = RandomTestUtil.randomInt();
+
+		_companyLocalService.updateCompany(
+			_company.getCompanyId(), _company.getVirtualHostname(),
+			_company.getMx(), maxUsers, _company.isActive());
+
+		Company company = CompanyRegistry.fetchCompany(_company.getCompanyId());
+
+		Assert.assertEquals(maxUsers, company.getMaxUsers());
+	}
+
+	@DeleteAfterTestRun
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+}

--- a/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/VirtualHostRegistryTest.java
+++ b/modules/apps/company/company-test/src/testIntegration/java/com/liferay/company/service/test/VirtualHostRegistryTest.java
@@ -1,0 +1,105 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.company.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.VirtualHost;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.AssumeTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.VirtualHostRegistry;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author István András Dézsi
+ */
+@DataGuard(scope = DataGuard.Scope.NONE)
+@RunWith(Arquillian.class)
+public class VirtualHostRegistryTest extends BaseDBPartitionTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new AssumeTestRule("assume"), new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testAddAndDeleteCompany() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		String virtualHostname = _company.getVirtualHostname();
+
+		VirtualHost virtualHost = VirtualHostRegistry.fetchVirtualHost(
+			virtualHostname);
+
+		Assert.assertEquals(
+			_company.getCompanyId(), virtualHost.getCompanyId());
+
+		_companyLocalService.deleteCompany(_company);
+
+		Assert.assertNull(
+			VirtualHostRegistry.fetchVirtualHost(virtualHostname));
+	}
+
+	@Test
+	public void testFetchVirtualHost() throws Exception {
+		Company company = _companyLocalService.getCompany(
+			PortalInstancePool.getDefaultCompanyId());
+
+		VirtualHost virtualHost = VirtualHostRegistry.fetchVirtualHost(
+			company.getVirtualHostname());
+
+		Assert.assertEquals(company.getCompanyId(), virtualHost.getCompanyId());
+	}
+
+	@Test
+	public void testUpdateVirtualHostname() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+
+		String virtualHostname = _company.getVirtualHostname();
+
+		String newVirtualHostname =
+			RandomTestUtil.randomString() + StringPool.PERIOD +
+				RandomTestUtil.randomString(3);
+
+		_companyLocalService.updateCompany(
+			_company.getCompanyId(), newVirtualHostname, _company.getMx(),
+			_company.getMaxUsers(), _company.isActive());
+
+		Assert.assertNull(
+			VirtualHostRegistry.fetchVirtualHost(virtualHostname));
+
+		VirtualHost virtualHost = VirtualHostRegistry.fetchVirtualHost(
+			newVirtualHostname);
+
+		Assert.assertEquals(
+			_company.getCompanyId(), virtualHost.getCompanyId());
+	}
+
+	@DeleteAfterTestRun
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelMetricsView.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import {setCSPNonce} from 'frontend-js-web';
 import React, {useEffect, useRef} from 'react';
 
 import Sidebar from './Sidebar';
@@ -11,7 +12,9 @@ const SidebarPanelMetricsView = ({html}) => {
 	const elementRef = useRef();
 
 	useEffect(() => {
-		const fragment = document.createRange().createContextualFragment(html);
+		const fragment = document
+			.createRange()
+			.createContextualFragment(setCSPNonce(html));
 
 		elementRef.current.innerHTML = '';
 

--- a/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-web/src/main/resources/META-INF/resources/management_bar/controls/snapshots/SnapshotsControls.tsx
@@ -616,30 +616,39 @@ const SnapshotsControls = () => {
 									}
 									key={group.label || 'default'}
 								>
-									{group.items.map((snapshot: ISnapshot) => (
-										<ClayDropDown.Item
-											active={
-												snapshot.erc ===
-												activeSnapshot.erc
-											}
-											key={snapshot.erc}
-											onClick={() =>
-												onSnapshotChange({
-													defaultSnapshot,
-													snapshots,
-													value: snapshot.erc,
-												})
-											}
-											symbolRight={
-												snapshot.erc ===
-												activeSnapshot.erc
-													? 'check'
-													: undefined
-											}
-										>
-											{snapshot.label}
-										</ClayDropDown.Item>
-									))}
+									{group.items.map((snapshot: ISnapshot) => {
+										const isActiveSnapshot =
+											snapshot.erc === activeSnapshot.erc;
+
+										return (
+											<ClayDropDown.Item
+												aria-current={
+													isActiveSnapshot ||
+													undefined
+												}
+												className={
+													isActiveSnapshot
+														? 'active'
+														: undefined
+												}
+												key={snapshot.erc}
+												onClick={() =>
+													onSnapshotChange({
+														defaultSnapshot,
+														snapshots,
+														value: snapshot.erc,
+													})
+												}
+												symbolRight={
+													isActiveSnapshot
+														? 'check'
+														: undefined
+												}
+											>
+												{snapshot.label}
+											</ClayDropDown.Item>
+										);
+									})}
 								</ClayDropDown.Group>
 							))}
 						</ClayDropDown.ItemList>

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/components/Modal.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/modal/components/Modal.tsx
@@ -7,7 +7,7 @@ import ClayButton from '@clayui/button';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import classNames from 'classnames';
-import {navigate} from 'frontend-js-web';
+import {navigate, setCSPNonce} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import Iframe, {IframeOnOpen} from './Iframe';
@@ -228,7 +228,7 @@ export default function Modal({
 			if (html) {
 				const fragment = document
 					.createRange()
-					.createContextualFragment(html);
+					.createContextualFragment(setCSPNonce(html));
 
 				if (bodyRef.current) {
 					bodyRef.current.innerHTML = '';

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/index.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/index.js
@@ -112,6 +112,7 @@ import runScriptsInElement from './util/run_scripts_in_element.es';
 import selectFolder from './util/select_folder';
 import {getSessionValue, setSessionValue} from './util/session.es';
 import sessionStorage from './util/session_storage';
+import setCSPNonce from './util/set_csp_nonce';
 import showCapsLock from './util/show_caps_lock';
 import sub from './util/sub';
 import toCharCode from './util/to_char_code.es';
@@ -333,6 +334,7 @@ Liferay.Util.openWindow = openWindow;
 Liferay.Util.openInDialog = openInDialog;
 Liferay.Util.removeEntitySelection = removeEntitySelection;
 Liferay.Util.selectFolder = selectFolder;
+Liferay.Util.setCSPNonce = setCSPNonce;
 Liferay.Util.setPortletConfigurationIconAction =
 	setPortletConfigurationIconAction;
 Liferay.Util.showCapsLock = showCapsLock;
@@ -440,6 +442,7 @@ Liferay.__INTERNALS = {
 	runScriptsInElement,
 	selectFolder,
 	sessionStorage,
+	setCSPNonce,
 	setCookie,
 	setFormValues,
 	setSessionValue,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet/portlet.es.js
@@ -7,6 +7,7 @@ import fetch from '../util/fetch.es';
 import objectToFormData from '../util/form/object_to_form_data.es';
 import getPortletId from '../util/get_portlet_id';
 import createPortletURL from '../util/portlet_url/create_portlet_url.es';
+import setCSPNonce from '../util/set_csp_nonce';
 import register from './register.es';
 
 /**
@@ -102,6 +103,8 @@ export function minimizePortlet(portletSelector, trigger, options) {
 						)
 							.then((response) => response.text())
 							.then((response) => {
+								response = setCSPNonce(response);
+
 								const range = document.createRange();
 
 								range.selectNode(portlet);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/side_navigation.es.js
@@ -6,6 +6,7 @@
 import EventEmitter from './events/EventEmitter';
 import throttle from './throttle.es';
 import fetch from './util/fetch.es';
+import setCSPNonce from './util/set_csp_nonce';
 
 const SCRIPT_URL = document.currentScript.src;
 
@@ -454,6 +455,8 @@ SideNavigation.prototype = {
 					return response.text();
 				})
 				.then((text) => {
+					text = setCSPNonce(text);
+
 					const range = document.createRange();
 
 					range.selectNode(sidebar);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/set_csp_nonce.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/util/set_csp_nonce.js
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/**
+ * Rewrites the nonce of every inline `<script>`/`<style>` in the given markup
+ * to the nonce bound to the current document (`Liferay.CSP.nonce`).
+ *
+ * Markup fetched over AJAX carries the nonce of its own response. When
+ * per-request nonces are in effect (for example when SPA is disabled) that
+ * nonce does not match the one bound to the current document, so injecting the
+ * markup (for example through `Range.createContextualFragment`, which evaluates
+ * scripts and applies styles) is blocked by the Content Security Policy.
+ * Rewriting the nonces to the document nonce keeps the injected content valid.
+ *
+ * @param {string} html The markup to rewrite.
+ * @return {string} The markup with its inline script/style nonces rewritten.
+ */
+export default function setCSPNonce(html) {
+	if (
+		typeof html !== 'string' ||
+		!window.Liferay ||
+		!Liferay.CSP ||
+		!Liferay.CSP.nonce
+	) {
+		return html;
+	}
+
+	return html.replace(
+		/(<(?:script|style)\b[^>]*\bnonce=")[^"]*(")/gi,
+		`$1${Liferay.CSP.nonce}$2`
+	);
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.d.ts
@@ -777,6 +777,9 @@ export function sub(
 /* Returns the stored value of a cookie, undefined if not present */
 export function getCookie(name: string, type: TYPE_VALUES): string | undefined;
 
+/* Rewrites the inline script/style nonces in the given markup to the document nonce */
+export function setCSPNonce(html: string): string;
+
 /* Sets a cookie of a specific type if user has consented */
 export function setCookie(
 	name: string,

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/main/index.js
@@ -64,6 +64,7 @@ export const {
 	runScriptsInElement,
 	selectFolder,
 	sessionStorage,
+	setCSPNonce,
 	setCookie,
 	setFormValues,
 	setSessionValue,

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleIndexVersionsTest.java
@@ -6,15 +6,13 @@
 package com.liferay.journal.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalHelper;
 import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.portlet.PortalPreferences;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
-import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.search.BaseIndexerPostProcessor;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
@@ -23,16 +21,19 @@ import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerPostProcessor;
 import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
-import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
+import com.liferay.portal.kernel.settings.FallbackKeysSettingsUtil;
+import com.liferay.portal.kernel.settings.ModifiableSettings;
+import com.liferay.portal.kernel.settings.Settings;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.legacy.searcher.SearchRequestBuilderFactory;
 import com.liferay.portal.search.searcher.SearchResponse;
@@ -75,30 +76,29 @@ public class JournalArticleIndexVersionsTest {
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
 
-		PortalPreferences portalPreferences =
-			_portletPreferencesFactory.getPortalPreferences(
-				TestPropsValues.getUserId(), true);
+		Settings settings = FallbackKeysSettingsUtil.getSettings(
+			new CompanyServiceSettingsLocator(
+				TestPropsValues.getCompanyId(),
+				JournalServiceConfiguration.class.getName()));
 
-		_originalPortalPreferencesXML = _portletPreferencesFactory.toXML(
-			portalPreferences);
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
 
-		portalPreferences.setValue(
-			"", "expireAllArticleVersionsEnabled", "true");
-		portalPreferences.setValue(
-			"", "indexAllArticleVersionsEnabled", "false");
+		_originalExpireAllArticleVersionsEnabled = GetterUtil.getBoolean(
+			modifiableSettings.getValue(
+				"expireAllArticleVersionsEnabled", "true"));
+		_originalIndexAllArticleVersionsEnabled = GetterUtil.getBoolean(
+			modifiableSettings.getValue(
+				"indexAllArticleVersionsEnabled", "true"));
 
-		_portalPreferencesLocalService.updatePreferences(
-			TestPropsValues.getCompanyId(),
-			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-			PortletPreferencesFactoryUtil.toXML(portalPreferences));
+		_updateJournalServiceConfiguration(true, false);
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		_portalPreferencesLocalService.updatePreferences(
-			TestPropsValues.getCompanyId(),
-			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-			_originalPortalPreferencesXML);
+		_updateJournalServiceConfiguration(
+			_originalExpireAllArticleVersionsEnabled,
+			_originalIndexAllArticleVersionsEnabled);
 	}
 
 	@Test
@@ -366,17 +366,30 @@ public class JournalArticleIndexVersionsTest {
 	}
 
 	private void _enableIndexAllArticleVersions() throws Exception {
-		PortalPreferences portalPreferences =
-			_portletPreferencesFactory.getPortalPreferences(
-				TestPropsValues.getUserId(), true);
+		_updateJournalServiceConfiguration(true, true);
+	}
 
-		portalPreferences.setValue(
-			"", "indexAllArticleVersionsEnabled", "true");
+	private void _updateJournalServiceConfiguration(
+			boolean expireAllArticleVersionsEnabled,
+			boolean indexAllArticleVersionsEnabled)
+		throws Exception {
 
-		_portalPreferencesLocalService.updatePreferences(
-			TestPropsValues.getCompanyId(),
-			PortletKeys.PREFS_OWNER_TYPE_COMPANY,
-			PortletPreferencesFactoryUtil.toXML(portalPreferences));
+		Settings settings = FallbackKeysSettingsUtil.getSettings(
+			new CompanyServiceSettingsLocator(
+				TestPropsValues.getCompanyId(),
+				JournalServiceConfiguration.class.getName()));
+
+		ModifiableSettings modifiableSettings =
+			settings.getModifiableSettings();
+
+		modifiableSettings.setValue(
+			"expireAllArticleVersionsEnabled",
+			String.valueOf(expireAllArticleVersionsEnabled));
+		modifiableSettings.setValue(
+			"indexAllArticleVersionsEnabled",
+			String.valueOf(indexAllArticleVersionsEnabled));
+
+		modifiableSettings.store();
 	}
 
 	@DeleteAfterTestRun
@@ -391,13 +404,8 @@ public class JournalArticleIndexVersionsTest {
 	@Inject
 	private JournalHelper _journalHelper;
 
-	private String _originalPortalPreferencesXML;
-
-	@Inject
-	private PortalPreferencesLocalService _portalPreferencesLocalService;
-
-	@Inject
-	private PortletPreferencesFactory _portletPreferencesFactory;
+	private boolean _originalExpireAllArticleVersionsEnabled;
+	private boolean _originalIndexAllArticleVersionsEnabled;
 
 	@Inject
 	private Searcher _searcher;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LookAndFeelThemeEdit.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LookAndFeelThemeEdit.js
@@ -4,7 +4,7 @@
  */
 
 import {openSelectionModal} from 'frontend-js-components-web';
-import {fetch, objectToFormData} from 'frontend-js-web';
+import {fetch, objectToFormData, setCSPNonce} from 'frontend-js-web';
 
 export default function ({
 	changeThemeButtonId,
@@ -49,6 +49,8 @@ export default function ({
 					})
 						.then((response) => response.text())
 						.then((response) => {
+							response = setCSPNonce(response);
+
 							const range = document.createRange();
 							const fragment =
 								range.createContextualFragment(response);

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view_message_content.jsp
@@ -329,6 +329,8 @@ if (portletTitleBasedNavigation) {
 					);
 
 					if (messageContainer) {
+						response = Liferay.Util.setCSPNonce(response);
+
 						messageContainer.appendChild(
 							document
 								.createRange()

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/LayoutFinder.js
@@ -6,7 +6,13 @@
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import {openToast} from 'frontend-js-components-web';
-import {fetch, objectToFormData, setSessionValue, sub} from 'frontend-js-web';
+import {
+	fetch,
+	objectToFormData,
+	setCSPNonce,
+	setSessionValue,
+	sub,
+} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
@@ -99,6 +105,8 @@ function LayoutFinder({
 					);
 
 					sidebar.innerHTML = '';
+
+					productMenuContent = setCSPNonce(productMenuContent);
 
 					const range = document.createRange();
 					range.selectNode(sidebar);

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
@@ -9,7 +9,7 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLink from '@clayui/link';
 import {openToast} from 'frontend-js-components-web';
-import {fetch, navigate, setSessionValue} from 'frontend-js-web';
+import {fetch, navigate, setCSPNonce, setSessionValue} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
@@ -43,6 +43,8 @@ function PageTypeSelector({
 						);
 
 						sidebar.innerHTML = '';
+
+						productMenuContent = setCSPNonce(productMenuContent);
 
 						const range = document.createRange();
 						range.selectNode(sidebar);

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -135,6 +135,8 @@ SiteAdministrationPanelCategoryDisplayContext siteAdministrationPanelCategoryDis
 
 						sidebar.innerHTML = '';
 
+						response = Liferay.Util.setCSPNonce(response);
+
 						var range = document.createRange();
 						range.selectNode(sidebar);
 

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/index.js
@@ -4,7 +4,7 @@
  */
 
 import {openModal} from 'frontend-js-components-web';
-import {addParams, fetch, navigate} from 'frontend-js-web';
+import {addParams, fetch, navigate, setCSPNonce} from 'frontend-js-web';
 
 export function signInButtonPropsTransformer({
 	additionalProps: {redirect: initialRedirect, signInURL},
@@ -20,6 +20,8 @@ export function signInButtonPropsTransformer({
 	const updateModalContent = (html) => {
 		const modalBody = document.querySelector('.liferay-modal-body');
 		if (modalBody) {
+			html = setCSPNonce(html);
+
 			const fragment = document
 				.createRange()
 				.createContextualFragment(html);

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/main/systemDataSets.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/main/systemDataSets.spec.ts
@@ -721,7 +721,7 @@ test(
 
 			await userViewsDropdown.waitFor();
 
-			const userViewMenuItem = userViewsDropdown.getByRole('option', {
+			const userViewMenuItem = userViewsDropdown.getByRole('menuitem', {
 				name: userView1Name,
 			});
 

--- a/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-web/main/tests/advanced/accessibility.spec.ts
@@ -9,6 +9,7 @@ import {featureFlagsTest} from '../../../../../fixtures/featureFlagsTest';
 import {isolatedSiteTest} from '../../../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../../../fixtures/loginTest';
 import {checkAccessibility} from '../../../../../utils/checkAccessibility';
+import getRandomString from '../../../../../utils/getRandomString';
 import {EFDSVisualizationMode, waitForFDS} from '../../../../../utils/waitFor';
 import {fdsSamplePageTest} from '../../fixtures/fdsSamplePageTest';
 
@@ -283,6 +284,8 @@ test('Advanced FDS is accessible across user views', async ({
 	fdsSamplePage,
 	page,
 }) => {
+	const userViewName = getRandomString();
+
 	await test.step('Open user views menu', async () => {
 		await fdsSamplePage.userViewsSelectorButton.click();
 
@@ -324,7 +327,7 @@ test('Advanced FDS is accessible across user views', async ({
 
 		await fdsSamplePage.userViewsSaveModal
 			.getByLabel('NameRequired')
-			.fill('Accessibility View');
+			.fill(userViewName);
 
 		await fdsSamplePage.userViewsSaveModal
 			.getByRole('button', {name: 'Save'})
@@ -361,6 +364,24 @@ test('Advanced FDS is accessible across user views', async ({
 		});
 
 		await page.keyboard.press('Escape');
+	});
+
+	// Delete the saved view so it does not linger for the next run. User
+	// views are persisted per user and are not removed with the isolated
+	// site.
+
+	await test.step('Delete the saved view', async () => {
+		await fdsSamplePage.userViewsActionsButton.click();
+
+		await fdsSamplePage.dropdownMenu
+			.getByRole('menuitem', {name: 'Delete View'})
+			.click();
+
+		await fdsSamplePage.userViewsDeleteAlert
+			.getByRole('button', {name: 'Delete'})
+			.click();
+
+		await fdsSamplePage.userViewsDeleteAlert.waitFor({state: 'hidden'});
 	});
 });
 

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
@@ -38,6 +38,8 @@ test(
 				'Bookmark',
 				'Image',
 				'Video',
+				'Timestamp',
+				'Styles'
 			];
 
 			const availableButtons =

--- a/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
+++ b/modules/test/playwright/tests/frontend-editor-ckeditor-web/main/tests/ckeditor5/react.spec.ts
@@ -39,7 +39,7 @@ test(
 				'Image',
 				'Video',
 				'Timestamp',
-				'Styles'
+				'Styles',
 			];
 
 			const availableButtons =

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -135,6 +135,7 @@ import com.liferay.portal.liveusers.LiveUsers;
 import com.liferay.portal.security.auth.EmailAddressValidatorFactory;
 import com.liferay.portal.service.base.CompanyLocalServiceBaseImpl;
 import com.liferay.portal.util.PortalInstances;
+import com.liferay.portal.util.VirtualHostRegistry;
 
 import jakarta.portlet.PortletException;
 import jakarta.portlet.PortletPreferences;
@@ -831,6 +832,10 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		if ((virtualHost == null) && virtualHostname.contains("xn--")) {
 			virtualHost = _virtualHostPersistence.fetchByHostname(
 				IDN.toUnicode(virtualHostname));
+		}
+
+		if ((virtualHost == null) && PropsValues.DATABASE_PARTITION_ENABLED) {
+			virtualHost = VirtualHostRegistry.fetchVirtualHost(virtualHostname);
 		}
 
 		if ((virtualHost == null) || (virtualHost.getLayoutSetId() != 0)) {

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java
@@ -134,6 +134,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.liveusers.LiveUsers;
 import com.liferay.portal.security.auth.EmailAddressValidatorFactory;
 import com.liferay.portal.service.base.CompanyLocalServiceBaseImpl;
+import com.liferay.portal.util.CompanyRegistry;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.util.VirtualHostRegistry;
 
@@ -842,7 +843,15 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			return null;
 		}
 
-		return companyPersistence.fetchByPrimaryKey(virtualHost.getCompanyId());
+		long companyId = virtualHost.getCompanyId();
+
+		Company company = companyPersistence.fetchByPrimaryKey(companyId);
+
+		if ((company == null) && PropsValues.DATABASE_PARTITION_ENABLED) {
+			company = CompanyRegistry.fetchCompany(companyId);
+		}
+
+		return company;
 	}
 
 	@Override
@@ -1013,6 +1022,16 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	 */
 	@Override
 	public Company getCompanyByWebId(String webId) throws PortalException {
+		Company company = companyPersistence.fetchByWebId(webId);
+
+		if ((company == null) && PropsValues.DATABASE_PARTITION_ENABLED) {
+			company = CompanyRegistry.fetchCompanyByWebId(webId);
+		}
+
+		if (company != null) {
+			return company;
+		}
+
 		return companyPersistence.findByWebId(webId);
 	}
 
@@ -1144,7 +1163,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	public Company updateCompany(Company company) {
 		_companyInfoPersistence.update(company.getCompanyInfo());
 
-		return super.updateCompany(company);
+		Company updatedCompany = super.updateCompany(company);
+
+		_updateCompanyRegistry(updatedCompany);
+
+		return updatedCompany;
 	}
 
 	/**
@@ -1192,7 +1215,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		company.setMaxUsers(maxUsers);
 		company.setActive(active);
 
-		companyPersistence.update(company);
+		company = companyPersistence.update(company);
+
+		_updateCompanyRegistry(company);
 
 		// Virtual host
 
@@ -1267,7 +1292,9 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		company.setType(type);
 		company.setSize(size);
 
-		companyPersistence.update(company);
+		company = companyPersistence.update(company);
+
+		_updateCompanyRegistry(company);
 
 		// Virtual host
 
@@ -1364,7 +1391,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 
 		company.setIndexNameNext(indexNameNext);
 
-		return companyPersistence.update(company);
+		company = companyPersistence.update(company);
+
+		_updateCompanyRegistry(company);
+
+		return company;
 	}
 
 	@Override
@@ -1377,7 +1408,11 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		company.setIndexNameCurrent(indexNameCurrent);
 		company.setIndexNameNext(indexNameNext);
 
-		return companyPersistence.update(company);
+		company = companyPersistence.update(company);
+
+		_updateCompanyRegistry(company);
+
+		return company;
 	}
 
 	/**
@@ -1603,6 +1638,8 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 			company.setLogoId(logoId);
 
 			company = companyPersistence.update(company);
+
+			_updateCompanyRegistry(company);
 		}
 
 		return company;
@@ -1863,6 +1900,17 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	}
 
 	protected void registerCompany(Company company) {
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			CompanyRegistry.register(company);
+
+			for (VirtualHost virtualHost :
+					_virtualHostLocalService.getVirtualHosts(
+						company.getCompanyId())) {
+
+				VirtualHostRegistry.register(virtualHost);
+			}
+		}
+
 		PortalInstanceLifecycleManager portalInstanceLifecycleManager =
 			_serviceTracker.getService();
 
@@ -1896,6 +1944,13 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 	}
 
 	protected void unregisterCompany(Company company) {
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			long companyId = company.getCompanyId();
+
+			CompanyRegistry.unregister(companyId);
+			VirtualHostRegistry.unregisterVirtualHosts(companyId);
+		}
+
 		PortalInstanceLifecycleManager portalInstanceLifecycleManager =
 			_serviceTracker.getService();
 
@@ -2559,6 +2614,19 @@ public class CompanyLocalServiceImpl extends CompanyLocalServiceBaseImpl {
 		catch (Throwable throwable) {
 			throw new PortalException(throwable);
 		}
+	}
+
+	private void _updateCompanyRegistry(Company company) {
+		if (!PropsValues.DATABASE_PARTITION_ENABLED) {
+			return;
+		}
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				CompanyRegistry.register(company);
+
+				return null;
+			});
 	}
 
 	private void _updateGroupLanguageIds(

--- a/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/VirtualHostLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.impl.LayoutSetImpl;
 import com.liferay.portal.service.base.VirtualHostLocalServiceBaseImpl;
+import com.liferay.portal.util.VirtualHostRegistry;
 
 import java.net.IDN;
 import java.net.Inet6Address;
@@ -112,6 +113,10 @@ public class VirtualHostLocalServiceImpl
 		if ((virtualHost == null) && hostname.contains("xn--")) {
 			virtualHost = virtualHostPersistence.fetchByHostname(
 				IDN.toUnicode(hostname));
+		}
+
+		if ((virtualHost == null) && PropsValues.DATABASE_PARTITION_ENABLED) {
+			virtualHost = VirtualHostRegistry.fetchVirtualHost(hostname);
 		}
 
 		return virtualHost;
@@ -240,6 +245,8 @@ public class VirtualHostLocalServiceImpl
 			virtualHostPersistence.update(virtualHost);
 		}
 
+		List<VirtualHost> removedVirtualHosts = new ArrayList<>();
+
 		Iterator<VirtualHost> iterator = virtualHosts.iterator();
 
 		while (iterator.hasNext()) {
@@ -248,11 +255,29 @@ public class VirtualHostLocalServiceImpl
 			if (!hostnames.containsKey(virtualHost.getHostname())) {
 				iterator.remove();
 
+				removedVirtualHosts.add(virtualHost);
+
 				virtualHostPersistence.remove(virtualHost);
 			}
 		}
 
 		virtualHostPersistence.cacheResult(virtualHosts);
+
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					for (VirtualHost removedVirtualHost : removedVirtualHosts) {
+						VirtualHostRegistry.unregister(
+							removedVirtualHost.getHostname());
+					}
+
+					for (VirtualHost virtualHost : virtualHosts) {
+						VirtualHostRegistry.register(virtualHost);
+					}
+
+					return null;
+				});
+		}
 
 		Company company = _companyPersistence.fetchByPrimaryKey(companyId);
 

--- a/portal-impl/src/com/liferay/portal/util/CompanyRegistry.java
+++ b/portal-impl/src/com/liferay/portal/util/CompanyRegistry.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author István András Dézsi
+ */
+public class CompanyRegistry {
+
+	public static Company fetchCompany(long companyId) {
+		return _companies.get(companyId);
+	}
+
+	public static Company fetchCompanyByWebId(String webId) {
+		if (Validator.isNull(webId)) {
+			return null;
+		}
+
+		for (Company company : _companies.values()) {
+			if (webId.equals(company.getWebId())) {
+				return company;
+			}
+		}
+
+		return null;
+	}
+
+	public static void register(Company company) {
+		_companies.put(company.getCompanyId(), company);
+	}
+
+	public static void unregister(long companyId) {
+		_companies.remove(companyId);
+	}
+
+	private static final Map<Long, Company> _companies =
+		new ConcurrentHashMap<>();
+
+}

--- a/portal-impl/src/com/liferay/portal/util/VirtualHostRegistry.java
+++ b/portal-impl/src/com/liferay/portal/util/VirtualHostRegistry.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.util;
+
+import com.liferay.portal.kernel.model.VirtualHost;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * @author István András Dézsi
+ */
+public class VirtualHostRegistry {
+
+	public static VirtualHost fetchVirtualHost(String hostname) {
+		if (Validator.isNull(hostname)) {
+			return null;
+		}
+
+		return _virtualHosts.get(StringUtil.toLowerCase(hostname));
+	}
+
+	public static void register(VirtualHost virtualHost) {
+		String hostname = virtualHost.getHostname();
+
+		if (Validator.isNull(hostname)) {
+			return;
+		}
+
+		_virtualHosts.put(StringUtil.toLowerCase(hostname), virtualHost);
+	}
+
+	public static void unregister(String hostname) {
+		if (Validator.isNull(hostname)) {
+			return;
+		}
+
+		_virtualHosts.remove(StringUtil.toLowerCase(hostname));
+	}
+
+	public static void unregisterVirtualHosts(long companyId) {
+		Collection<VirtualHost> virtualHosts = _virtualHosts.values();
+
+		virtualHosts.removeIf(
+			virtualHost -> virtualHost.getCompanyId() == companyId);
+	}
+
+	private static final Map<String, VirtualHost> _virtualHosts =
+		new ConcurrentHashMap<>();
+
+}

--- a/portal-impl/src/com/liferay/portal/util/VirtualHostRegistry.java
+++ b/portal-impl/src/com/liferay/portal/util/VirtualHostRegistry.java
@@ -9,6 +9,8 @@ import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.net.IDN;
+
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -23,7 +25,15 @@ public class VirtualHostRegistry {
 			return null;
 		}
 
-		return _virtualHosts.get(StringUtil.toLowerCase(hostname));
+		VirtualHost virtualHost = _virtualHosts.get(
+			StringUtil.toLowerCase(hostname));
+
+		if ((virtualHost == null) && hostname.contains("xn--")) {
+			virtualHost = _virtualHosts.get(
+				StringUtil.toLowerCase(IDN.toUnicode(hostname)));
+		}
+
+		return virtualHost;
 	}
 
 	public static void register(VirtualHost virtualHost) {

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 79.1.0
+version 79.2.0

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -15,6 +15,7 @@
 		<suppress checks="ClassNameIdCheck" files="portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/db/partition/util/DBPartitionUtil\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl\.java" />
+		<suppress checks="CompanyIterationCheck" files="portal-impl/src/com/liferay/portal/util/CompanyRegistry\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/dao/db/DBInspector\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/instance/PortalInstancePool\.java" />
 		<suppress checks="CompanyIterationCheck" files="portal-kernel/src/com/liferay/portal/kernel/upgrade/BaseCompanyIdUpgradeProcess\.java" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97113

## What Is Being Fixed

LPD-82361 restricts `Company` and `VirtualHost` visibility across partitioned instances. Converting the tables directly proved high risk: enumeration and resolution read the default partition tables, so every table movement raced company creation and deletion. The restructure lands the low risk foundation first: registries that decouple cross partition resolution from the physical table layout.

## How It Is Being Fixed

`CompanyRegistry` and `VirtualHostRegistry` (`portal-impl`, `com.liferay.portal.util`) are plain concurrent maps, push populated through the company lifecycle: every company passes through `registerCompany` at every startup and on create, import and copy, and through `unregisterCompany` on deletion, so the registries are complete at boot, converge on every lifecycle event, and a restart heals any drift. There is deliberately no lazy population, since a lazy fan out through `forEachCompanyId` from a locked thread would permanently cache a single company view. `registerCompany` also registers the company's virtual hosts through the service call, which is safe inside transaction commit callbacks; `unregisterCompany` removes both by company ID without a database read, since the rows are already gone at callback time; the `Company` update paths register the fresh snapshot again after commit; `updateVirtualHosts` unregisters removed hostnames and registers the current set.

`getCompanyByWebId`, `fetchCompanyByVirtualHost` and `fetchVirtualHost` consult the registries when persistence misses and database partitioning is enabled, with the same Punycode retry the persistence path applies to `xn--` hostnames. While `Company` and `VirtualHost` remain control tables the fallbacks are dormant, so this PR is behavior neutral. The table movement subtasks make the registries load bearing, tighten the guards with `DBPartition.isCurrentCompanyRestricted` once the `CompanyInfo` column split lands, audit virtual host write paths that bypass `updateVirtualHosts`, and take up cluster propagation (the registries are per node maps healed at boot).

New integration tests (`CompanyRegistryTest`, `VirtualHostRegistryTest`) cover startup population (the boot registered default company and its virtual host resolve from the registries with no test side registration), create and delete sync, and update sync. Against a running MySQL bundle with partitioning enabled: the 7 new registry tests, `CompanyLocalServiceDBPartitionTest` (14 of 14) and `CompanyLocalServiceTest` (36 tests, 0 failures) are green, and a full bundle rebuild boots clean. Recommended CI suites before forwarding, to be triggered separately: source format, relevant, upgrade and database partition.

## PR Check

**pr-check: PASS** — tested on `34b212345e3b05bc53833c39b73748b8a9e5ef41`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "34b212345e3b05bc53833c39b73748b8a9e5ef41"} -->
