### PR TITLE
LPD-92617 Add POST /portal-instances/{portalInstanceId}/export endpoint

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/bnd.bnd
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Portal Instances API
 Bundle-SymbolicName: com.liferay.headless.portal.instances.api
-Bundle-Version: 8.0.5
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.headless.portal.instances.dto.v1_0,\
 	com.liferay.headless.portal.instances.resource.v1_0

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
@@ -57,6 +57,9 @@ public interface PortalInstanceResource {
 	public PortalInstance postPortalInstance(PortalInstance portalInstance)
 		throws Exception;
 
+	public void postPortalInstanceExport(String portalInstanceId)
+		throws Exception;
+
 	public void putPortalInstanceActivate(String portalInstanceId)
 		throws Exception;
 
@@ -151,4 +154,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1561391421
+// LIFERAY-REST-BUILDER-HASH:-1171522594

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
@@ -68,6 +68,13 @@ public interface PortalInstanceResource {
 			PortalInstance portalInstance)
 		throws Exception;
 
+	public void postPortalInstanceExport(String portalInstanceId)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postPortalInstanceExportHttpResponse(
+			String portalInstanceId)
+		throws Exception;
+
 	public void putPortalInstanceActivate(String portalInstanceId)
 		throws Exception;
 
@@ -723,6 +730,113 @@ public interface PortalInstanceResource {
 			return httpInvoker.invoke();
 		}
 
+		public void postPortalInstanceExport(String portalInstanceId)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postPortalInstanceExportHttpResponse(portalInstanceId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postPortalInstanceExportHttpResponse(
+				String portalInstanceId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/export");
+
+			httpInvoker.path("portalInstanceId", portalInstanceId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public void putPortalInstanceActivate(String portalInstanceId)
 			throws Exception {
 
@@ -949,4 +1063,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:2031700361
+// LIFERAY-REST-BUILDER-HASH:570569193

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/build.gradle
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.18.6"
 	compileOnly group: "com.liferay", name: "jakarta.ws.rs", version: "3.1.0.LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay", name: "org.apache.felix.configadmin", version: "1.9.26.LIFERAY-PATCHED-1"
 	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
@@ -15,7 +16,9 @@ dependencies {
 	compileOnly project(":apps:headless:headless-portal-instances:headless-portal-instances-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -232,3 +232,20 @@ paths:
                     description:
                         default response
             tags: ["PortalInstance"]
+    /portal-instances/{portalInstanceId}/export:
+        post:
+            description:
+                Exports the portal instance
+            operationId: postPortalInstanceExport
+            parameters:
+                -   in: path
+                    name: portalInstanceId
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["PortalInstance"]

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
@@ -210,6 +210,39 @@ public abstract class BasePortalInstanceResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/export'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Exports the portal instance"
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portalInstanceId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "PortalInstance")
+		}
+	)
+	@jakarta.ws.rs.Path("/portal-instances/{portalInstanceId}/export")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void postPortalInstanceExport(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portalInstanceId")
+			String portalInstanceId)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'PUT' 'http://localhost:8080/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/activate'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -718,4 +751,4 @@ public abstract class BasePortalInstanceResourceImpl
 		LogFactoryUtil.getLog(BasePortalInstanceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-745623835
+// LIFERAY-REST-BUILDER-HASH:-1475337886

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -8,20 +8,41 @@ package com.liferay.headless.portal.instances.internal.resource.v1_0;
 import com.liferay.headless.portal.instances.dto.v1_0.Admin;
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstance;
 import com.liferay.headless.portal.instances.resource.v1_0.PortalInstanceResource;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.auth.EmailAddressValidator;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.CompanyService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.EmailAddressValidatorFactory;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import java.util.ArrayList;
+import java.util.Dictionary;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.felix.cm.file.ConfigurationHandler;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -128,6 +149,41 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 	}
 
 	@Override
+	public void postPortalInstanceExport(String portalInstanceId)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-11342")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (!permissionChecker.isOmniadmin()) {
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
+		}
+
+		Company company = _companyService.getCompanyByWebId(portalInstanceId);
+
+		long companyId = company.getCompanyId();
+
+		try {
+			_companyLocalService.exportCompany(companyId);
+
+			_exportConfigurations(companyId);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to export portal instance " + portalInstanceId,
+				exception);
+
+			throw exception;
+		}
+	}
+
+	@Override
 	public void putPortalInstanceActivate(String portalInstanceId)
 		throws Exception {
 
@@ -147,6 +203,126 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		_companyService.updateCompany(
 			company.getCompanyId(), company.getVirtualHostname(),
 			company.getMx(), company.getMaxUsers(), false);
+	}
+
+	private void _exportConfigurations(long companyId) throws Exception {
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			return;
+		}
+
+		Map<String, String> configurations = DBPartitionUtil.getConfigurations(
+			CompanyConstants.SYSTEM);
+
+		for (Map.Entry<String, String> entry : configurations.entrySet()) {
+			try {
+				ScopedConfiguration scopedConfiguration =
+					_getScopedConfiguration(entry.getKey(), entry.getValue());
+
+				if ((scopedConfiguration == null) ||
+					!_isApplicable(companyId, scopedConfiguration)) {
+
+					continue;
+				}
+
+				DBPartitionUtil.exportConfiguration(
+					companyId, scopedConfiguration.getConfigurationId(),
+					scopedConfiguration.getEncodedDictionary());
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to export configuration " + entry.getKey(),
+						exception);
+				}
+			}
+		}
+	}
+
+	private ScopedConfiguration _getScopedConfiguration(
+			String configurationId, String encodedDictionary)
+		throws Exception {
+
+		Dictionary<String, String> dictionary = ConfigurationHandler.read(
+			new UnsyncByteArrayInputStream(
+				encodedDictionary.getBytes(StringPool.UTF8)));
+
+		Object value = dictionary.get(
+			ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfiguration(
+				configurationId, encodedDictionary,
+				ExtendedObjectClassDefinition.Scope.GROUP,
+				GetterUtil.getLong(value));
+		}
+
+		value = dictionary.get(
+			ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfiguration(
+				configurationId, encodedDictionary,
+				ExtendedObjectClassDefinition.Scope.COMPANY,
+				GetterUtil.getLong(value));
+		}
+
+		value = dictionary.get(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+				getPropertyKey());
+
+		if (value != null) {
+			return new ScopedConfiguration(
+				configurationId, encodedDictionary,
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+				GetterUtil.getString(value));
+		}
+
+		return null;
+	}
+
+	private boolean _isApplicable(
+			long companyId, ScopedConfiguration scopedConfiguration)
+		throws Exception {
+
+		if (Objects.equals(
+				scopedConfiguration.getScope(),
+				ExtendedObjectClassDefinition.Scope.COMPANY)) {
+
+			if (companyId == (long)scopedConfiguration.getScopePK()) {
+				return true;
+			}
+
+			return false;
+		}
+
+		if (Objects.equals(
+				scopedConfiguration.getScope(),
+				ExtendedObjectClassDefinition.Scope.GROUP)) {
+
+			long groupId = (long)scopedConfiguration.getScopePK();
+
+			Group group = _groupLocalService.fetchGroup(groupId);
+
+			if (group == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						StringBundler.concat(
+							"Unable to export configuration ",
+							scopedConfiguration.getConfigurationId(),
+							" because group ", groupId, " does not exist"));
+				}
+
+				return false;
+			}
+
+			if (group.getCompanyId() == companyId) {
+				return true;
+			}
+
+			return false;
+		}
+
+		return false;
 	}
 
 	private PortalInstance _toPortalInstance(Company company) {
@@ -178,7 +354,51 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		}
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortalInstanceResourceImpl.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
 	@Reference
 	private CompanyService _companyService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	private static class ScopedConfiguration {
+
+		public ScopedConfiguration(
+			String configurationId, String encodedDictionary,
+			ExtendedObjectClassDefinition.Scope scope, Object scopePK) {
+
+			_configurationId = configurationId;
+			_encodedDictionary = encodedDictionary;
+			_scope = scope;
+			_scopePK = scopePK;
+		}
+
+		public String getConfigurationId() {
+			return _configurationId;
+		}
+
+		public String getEncodedDictionary() {
+			return _encodedDictionary;
+		}
+
+		public ExtendedObjectClassDefinition.Scope getScope() {
+			return _scope;
+		}
+
+		public Object getScopePK() {
+			return _scopePK;
+		}
+
+		private final String _configurationId;
+		private final String _encodedDictionary;
+		private final ExtendedObjectClassDefinition.Scope _scope;
+		private final Object _scopePK;
+
+	}
 
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/test/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImplTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/test/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImplTest.java
@@ -1,0 +1,295 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.portal.instances.internal.resource.v1_0;
+
+import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Hashtable;
+
+import org.apache.felix.cm.file.ConfigurationHandler;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge Avalos
+ */
+public class PortalInstanceResourceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		_portalInstanceResourceImpl = new PortalInstanceResourceImpl();
+	}
+
+	@Test
+	public void testGetScopedConfiguration() throws Exception {
+		_testGetScopedConfigurationCompanyScope();
+		_testGetScopedConfigurationGroupScope();
+		_testGetScopedConfigurationNoScope();
+		_testGetScopedConfigurationPortletInstanceScope();
+	}
+
+	@Test
+	public void testIsApplicable() throws Exception {
+		_testIsApplicableCompanyScopeDifferentCompany();
+		_testIsApplicableCompanyScopeMatchingCompany();
+		_testIsApplicableGroupScopeDifferentCompany();
+		_testIsApplicableGroupScopeGroupNotFound();
+		_testIsApplicableGroupScopeMatchingCompany();
+		_testIsApplicablePortletInstanceScope();
+	}
+
+	private String _encodedDictionary(String key, Object value)
+		throws Exception {
+
+		Hashtable<String, Object> properties = new Hashtable<>();
+
+		properties.put(key, value);
+
+		UnsyncByteArrayOutputStream unsyncByteArrayOutputStream =
+			new UnsyncByteArrayOutputStream();
+
+		ConfigurationHandler.write(unsyncByteArrayOutputStream, properties);
+
+		return unsyncByteArrayOutputStream.toString();
+	}
+
+	private Object _getScopedConfiguration(
+			String configurationId, String encodedDictionary)
+		throws Exception {
+
+		return ReflectionTestUtil.invoke(
+			_portalInstanceResourceImpl, "_getScopedConfiguration",
+			new Class<?>[] {String.class, String.class}, configurationId,
+			encodedDictionary);
+	}
+
+	private boolean _isApplicable(long companyId, Object scopedConfiguration)
+		throws Exception {
+
+		return (boolean)ReflectionTestUtil.invoke(
+			_portalInstanceResourceImpl, "_isApplicable",
+			new Class<?>[] {long.class, scopedConfiguration.getClass()},
+			companyId, scopedConfiguration);
+	}
+
+	private void _testGetScopedConfigurationCompanyScope() throws Exception {
+		Object scopedConfiguration = _getScopedConfiguration(
+			"test.configuration",
+			_encodedDictionary(
+				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
+				_COMPANY_ID));
+
+		Assert.assertEquals(
+			ExtendedObjectClassDefinition.Scope.COMPANY,
+			ReflectionTestUtil.invoke(
+				scopedConfiguration, "getScope", new Class<?>[0]));
+		Assert.assertEquals(
+			Long.valueOf(_COMPANY_ID),
+			ReflectionTestUtil.invoke(
+				scopedConfiguration, "getScopePK", new Class<?>[0]));
+	}
+
+	private void _testGetScopedConfigurationGroupScope() throws Exception {
+		Object scopedConfiguration = _getScopedConfiguration(
+			"test.configuration",
+			_encodedDictionary(
+				ExtendedObjectClassDefinition.Scope.GROUP.getPropertyKey(),
+				_GROUP_ID));
+
+		Assert.assertEquals(
+			ExtendedObjectClassDefinition.Scope.GROUP,
+			ReflectionTestUtil.invoke(
+				scopedConfiguration, "getScope", new Class<?>[0]));
+		Assert.assertEquals(
+			Long.valueOf(_GROUP_ID),
+			ReflectionTestUtil.invoke(
+				scopedConfiguration, "getScopePK", new Class<?>[0]));
+	}
+
+	private void _testGetScopedConfigurationNoScope() throws Exception {
+		Assert.assertNull(
+			_getScopedConfiguration(
+				"test.configuration", _encodedDictionary("otherKey", "value")));
+	}
+
+	private void _testGetScopedConfigurationPortletInstanceScope()
+		throws Exception {
+
+		Object scopedConfiguration = _getScopedConfiguration(
+			"test.configuration",
+			_encodedDictionary(
+				ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+					getPropertyKey(),
+				_PORTLET_INSTANCE_ID));
+
+		Assert.assertEquals(
+			ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE,
+			ReflectionTestUtil.invoke(
+				scopedConfiguration, "getScope", new Class<?>[0]));
+		Assert.assertEquals(
+			_PORTLET_INSTANCE_ID,
+			ReflectionTestUtil.invoke(
+				scopedConfiguration, "getScopePK", new Class<?>[0]));
+	}
+
+	private void _testIsApplicableCompanyScopeDifferentCompany()
+		throws Exception {
+
+		Assert.assertFalse(
+			_isApplicable(
+				_COMPANY_ID + 1,
+				_getScopedConfiguration(
+					"test.configuration",
+					_encodedDictionary(
+						ExtendedObjectClassDefinition.Scope.COMPANY.
+							getPropertyKey(),
+						_COMPANY_ID))));
+	}
+
+	private void _testIsApplicableCompanyScopeMatchingCompany()
+		throws Exception {
+
+		Assert.assertTrue(
+			_isApplicable(
+				_COMPANY_ID,
+				_getScopedConfiguration(
+					"test.configuration",
+					_encodedDictionary(
+						ExtendedObjectClassDefinition.Scope.COMPANY.
+							getPropertyKey(),
+						_COMPANY_ID))));
+	}
+
+	private void _testIsApplicableGroupScopeDifferentCompany()
+		throws Exception {
+
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getCompanyId()
+		).thenReturn(
+			_COMPANY_ID + 1
+		);
+
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		Mockito.when(
+			groupLocalService.fetchGroup(_GROUP_ID)
+		).thenReturn(
+			group
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_portalInstanceResourceImpl, "_groupLocalService",
+			groupLocalService);
+
+		Assert.assertFalse(
+			_isApplicable(
+				_COMPANY_ID,
+				_getScopedConfiguration(
+					"test.configuration",
+					_encodedDictionary(
+						ExtendedObjectClassDefinition.Scope.GROUP.
+							getPropertyKey(),
+						_GROUP_ID))));
+	}
+
+	private void _testIsApplicableGroupScopeGroupNotFound() throws Exception {
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		Mockito.when(
+			groupLocalService.fetchGroup(_GROUP_ID)
+		).thenReturn(
+			null
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_portalInstanceResourceImpl, "_groupLocalService",
+			groupLocalService);
+
+		Assert.assertFalse(
+			_isApplicable(
+				_COMPANY_ID,
+				_getScopedConfiguration(
+					"test.configuration",
+					_encodedDictionary(
+						ExtendedObjectClassDefinition.Scope.GROUP.
+							getPropertyKey(),
+						_GROUP_ID))));
+	}
+
+	private void _testIsApplicableGroupScopeMatchingCompany() throws Exception {
+		Group group = Mockito.mock(Group.class);
+
+		Mockito.when(
+			group.getCompanyId()
+		).thenReturn(
+			_COMPANY_ID
+		);
+
+		GroupLocalService groupLocalService = Mockito.mock(
+			GroupLocalService.class);
+
+		Mockito.when(
+			groupLocalService.fetchGroup(_GROUP_ID)
+		).thenReturn(
+			group
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_portalInstanceResourceImpl, "_groupLocalService",
+			groupLocalService);
+
+		Assert.assertTrue(
+			_isApplicable(
+				_COMPANY_ID,
+				_getScopedConfiguration(
+					"test.configuration",
+					_encodedDictionary(
+						ExtendedObjectClassDefinition.Scope.GROUP.
+							getPropertyKey(),
+						_GROUP_ID))));
+	}
+
+	private void _testIsApplicablePortletInstanceScope() throws Exception {
+		Assert.assertFalse(
+			_isApplicable(
+				_COMPANY_ID,
+				_getScopedConfiguration(
+					"test.configuration",
+					_encodedDictionary(
+						ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE.
+							getPropertyKey(),
+						_PORTLET_INSTANCE_ID))));
+	}
+
+	private static final long _COMPANY_ID = 12345L;
+
+	private static final long _GROUP_ID = 20116L;
+
+	private static final String _PORTLET_INSTANCE_ID = "test_portlet";
+
+	private static PortalInstanceResourceImpl _portalInstanceResourceImpl;
+
+}

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
@@ -330,6 +330,29 @@ public abstract class BasePortalInstanceResourceTestCase {
 	}
 
 	@Test
+	public void testPostPortalInstanceExport() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		PortalInstance portalInstance =
+			testPostPortalInstanceExport_addPortalInstance();
+
+		assertHttpResponseStatusCode(
+			204,
+			portalInstanceResource.postPortalInstanceExportHttpResponse(
+				portalInstance.getPortalInstanceId()));
+
+		assertHttpResponseStatusCode(
+			404,
+			portalInstanceResource.postPortalInstanceExportHttpResponse("-"));
+	}
+
+	protected PortalInstance testPostPortalInstanceExport_addPortalInstance()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testPutPortalInstanceActivate() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		PortalInstance portalInstance =
@@ -1302,4 +1325,4 @@ public abstract class BasePortalInstanceResourceTestCase {
 			PortalInstanceResource _portalInstanceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1869092667
+// LIFERAY-REST-BUILDER-HASH:946517544

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -8,11 +8,15 @@ package com.liferay.headless.portal.instances.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.portal.instances.client.dto.v1_0.Admin;
 import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.client.http.HttpInvoker;
 import com.liferay.headless.portal.instances.client.pagination.Page;
 import com.liferay.headless.portal.instances.client.problem.Problem;
+import com.liferay.headless.portal.instances.client.resource.v1_0.PortalInstanceResource;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.db.DB;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -20,15 +24,21 @@ import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.PrefsPropsTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
 import java.util.List;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -93,6 +103,15 @@ public class PortalInstanceResourceTest
 		_testPostPortalInstanceWithoutAdmin();
 		_testPostPortalInstanceWithAdmin();
 		_testPostPortalInstanceWithAdminAndCompanyStrangers();
+	}
+
+	@FeatureFlag("LPD-11342")
+	@Override
+	@Test
+	public void testPostPortalInstanceExport() throws Exception {
+		_testPostPortalInstanceExportForbidden();
+		_testPostPortalInstanceExportNonexistent();
+		_testPostPortalInstanceExportExisting();
 	}
 
 	@Override
@@ -371,6 +390,65 @@ public class PortalInstanceResourceTest
 		_testPatchPortalInstace(portalInstance, false, false, false);
 	}
 
+	private void _testPostPortalInstanceExportExisting() throws Exception {
+		Assume.assumeTrue(_db.isSupportsDBPartition());
+
+		HttpInvoker.HttpResponse httpResponse =
+			portalInstanceResource.postPortalInstanceExportHttpResponse(
+				_portalInstance.getPortalInstanceId());
+
+		Assert.assertEquals(204, httpResponse.getStatusCode());
+	}
+
+	private void _testPostPortalInstanceExportForbidden() throws Exception {
+		User user = UserTestUtil.addUser();
+
+		try {
+			_userLocalService.updatePassword(
+				user.getUserId(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				PropsValues.DEFAULT_ADMIN_PASSWORD, false);
+
+			PortalInstanceResource userPortalInstanceResource =
+				PortalInstanceResource.builder(
+				).authentication(
+					user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+				).endpoint(
+					testCompany.getVirtualHostname(),
+					PortalUtil.getPortalServerPort(false), "http"
+				).locale(
+					LocaleUtil.getDefault()
+				).build();
+
+			userPortalInstanceResource.postPortalInstanceExport(
+				_portalInstance.getPortalInstanceId());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+		finally {
+			_userLocalService.deleteUser(user.getUserId());
+		}
+	}
+
+	private void _testPostPortalInstanceExportNonexistent() throws Exception {
+		try {
+			portalInstanceResource.postPortalInstanceExport(
+				RandomTestUtil.randomString());
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
 	private void _testPostPortalInstanceWithAdmin() throws Exception {
 		PortalInstance randomPortalInstance = randomPortalInstance();
 
@@ -443,6 +521,9 @@ public class PortalInstanceResourceTest
 	private static CompanyLocalService _companyLocalService;
 
 	private static PortalInstance _portalInstance;
+
+	@Inject
+	private DB _db;
 
 	@Inject
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92617

## What Is Being Fixed

There was no API endpoint to export a portal instance's configuration. The export feature is required for the DB partition workflow and is gated behind feature flag `LPD-11342`.

## How It Is Being Fixed

A new `POST /portal-instances/{portalInstanceId}/export` endpoint is added to the Portal Instances headless API, returning `204 No Content`. The endpoint is restricted to omniadmin users and gated explicitly via `FeatureFlagManagerUtil.isEnabled` so it is inert without the flag.

When the feature flag is active, the implementation calls `CompanyLocalService.exportCompany` to export the company data and then iterates the system OSGi configurations, exporting only those scoped to the target company (`COMPANY` scope) or to a group belonging to that company (`GROUP` scope). `PORTLET_INSTANCE`-scoped configurations are excluded because their PK carries no company component and cannot be safely attributed to a single instance. A per-entry try-catch ensures one corrupt configuration does not abort the entire export.

The integration test covers the 403 (non-admin user), 404 (nonexistent instance), and 204 (existing instance) paths, with the 204 path guarded by `Assume.assumeTrue(_db.isSupportsDBPartition())`. A unit test (`PortalInstanceResourceImplTest`) exercises `_getScopedConfiguration` and `_isApplicable` via reflection across all scope variants and boundary conditions, providing CI coverage independent of the DB partition setup.

## PR Check

**pr-check: PASS** — tested on `ed5162a8587ed3f4d66e8f954bce7bcd4fad1a98`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ed5162a8587ed3f4d66e8f954bce7bcd4fad1a98"} -->