### PR TITLE
LPD-93126 Prevent flaky file install log assertion in cleanup tests

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/BasePostUpgradeDataCleanupProcessTestCase.java
+++ b/modules/apps/data-cleanup/data-cleanup-test/src/testIntegration/java/com/liferay/data/cleanup/internal/verify/test/BasePostUpgradeDataCleanupProcessTestCase.java
@@ -92,19 +92,25 @@ public abstract class BasePostUpgradeDataCleanupProcessTestCase {
 			String logCaptureClass, String logLevel)
 		throws Exception {
 
-		initializeDataUnsafeRunnable.run();
+		try (LogCapture directoryWatcherLogCapture =
+				LoggerTestUtil.configureLog4JLogger(
+					"com.liferay.portal.file.install.internal.DirectoryWatcher",
+					LoggerTestUtil.OFF)) {
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				logCaptureClass, logLevel)) {
+			initializeDataUnsafeRunnable.run();
 
-			_runPostUpgradeDataCleanUpVerifyProcess();
+			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+					logCaptureClass, logLevel)) {
 
-			if (assertUnsafeConsumer != null) {
-				assertUnsafeConsumer.accept(logCapture);
+				_runPostUpgradeDataCleanUpVerifyProcess();
+
+				if (assertUnsafeConsumer != null) {
+					assertUnsafeConsumer.accept(logCapture);
+				}
 			}
-		}
-		finally {
-			cleanUpDataUnsafeRunnable.run();
+			finally {
+				cleanUpDataUnsafeRunnable.run();
+			}
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93126

## What Is Being Fixed

The `testVerifyDoesNotRunIfModulesNotStarted` method in the four
`*PostUpgradeDataCleanupProcessTest` integration tests (PortletPreferences,
ResourceAction, ClassName, ResourcePermission) intermittently fails on the
`ci:test:upgrade` routine. The failure is a concurrent log assertion: the
`fileinstall-directory-watcher` background thread logs an ERROR from
`com.liferay.portal.file.install.internal` while the test uninstalls and
refreshes a bundle, and the log assertor reports that unrelated cross-thread
ERROR as a failure even though the test's own assertion passed. Testray history
shows all four tests flaking with the identical signature, most recently on
2026-07-06.

## How It Is Being Fixed

The uninstall and refresh run inside the shared `test(...)` helper in
`BasePostUpgradeDataCleanupProcessTestCase`. The fix wraps that helper's body in
a `LogCapture` that silences the `DirectoryWatcher` logger for the duration of
the test. Because `configureLog4JLogger` sets `additive=false` on the target
logger's config, the watcher's transient ERROR no longer propagates to the root
logger where the concurrent-failure appender lives, and the level and
additivity are restored when the capture closes. Centralizing it in the base
helper covers all four verify tests and any future subclass with no
duplication, and is a no-op for the DB-only tests that never refresh a bundle.

## Why Are There No Tests?

This change only modifies the shared test helper to suppress an unrelated
background-thread log error that was causing flaky failures; the four existing
`testVerifyDoesNotRunIfModulesNotStarted` tests already exercise the modified
path. There is no product code change to cover with a new test.

## PR Check

**pr-check: PASS** — tested on `d82c0d8baf9cf8b313d73741971d113b18ae6b5d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "d82c0d8baf9cf8b313d73741971d113b18ae6b5d"} -->
