### PR TITLE
LPD-92616 Add POST /portal-instances/{portalInstanceId}/copy endpoint

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/dto/v1_0/PortalInstanceCopy.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/dto/v1_0/PortalInstanceCopy.java
@@ -1,0 +1,399 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.portal.instances.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Alberto Chaparro
+ * @generated
+ */
+@Generated("")
+@GraphQLName("PortalInstanceCopy")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PortalInstanceCopy")
+public class PortalInstanceCopy implements Serializable {
+
+	public static PortalInstanceCopy toDTO(String json) {
+		return ObjectMapperUtil.readValue(PortalInstanceCopy.class, json);
+	}
+
+	public static PortalInstanceCopy unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(PortalInstanceCopy.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Long getDestinationCompanyId() {
+		if (_destinationCompanyIdSupplier != null) {
+			destinationCompanyId = _destinationCompanyIdSupplier.get();
+
+			_destinationCompanyIdSupplier = null;
+		}
+
+		return destinationCompanyId;
+	}
+
+	public void setDestinationCompanyId(Long destinationCompanyId) {
+		this.destinationCompanyId = destinationCompanyId;
+
+		_destinationCompanyIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDestinationCompanyId(
+		UnsafeSupplier<Long, Exception> destinationCompanyIdUnsafeSupplier) {
+
+		_destinationCompanyIdSupplier = () -> {
+			try {
+				return destinationCompanyIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long destinationCompanyId;
+
+	@JsonIgnore
+	private Supplier<Long> _destinationCompanyIdSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getName() {
+		if (_nameSupplier != null) {
+			name = _nameSupplier.get();
+
+			_nameSupplier = null;
+		}
+
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+
+		_nameSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		_nameSupplier = () -> {
+			try {
+				return nameUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String name;
+
+	@JsonIgnore
+	private Supplier<String> _nameSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getVirtualHost() {
+		if (_virtualHostSupplier != null) {
+			virtualHost = _virtualHostSupplier.get();
+
+			_virtualHostSupplier = null;
+		}
+
+		return virtualHost;
+	}
+
+	public void setVirtualHost(String virtualHost) {
+		this.virtualHost = virtualHost;
+
+		_virtualHostSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setVirtualHost(
+		UnsafeSupplier<String, Exception> virtualHostUnsafeSupplier) {
+
+		_virtualHostSupplier = () -> {
+			try {
+				return virtualHostUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String virtualHost;
+
+	@JsonIgnore
+	private Supplier<String> _virtualHostSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getWebId() {
+		if (_webIdSupplier != null) {
+			webId = _webIdSupplier.get();
+
+			_webIdSupplier = null;
+		}
+
+		return webId;
+	}
+
+	public void setWebId(String webId) {
+		this.webId = webId;
+
+		_webIdSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setWebId(
+		UnsafeSupplier<String, Exception> webIdUnsafeSupplier) {
+
+		_webIdSupplier = () -> {
+			try {
+				return webIdUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String webId;
+
+	@JsonIgnore
+	private Supplier<String> _webIdSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PortalInstanceCopy)) {
+			return false;
+		}
+
+		PortalInstanceCopy portalInstanceCopy = (PortalInstanceCopy)object;
+
+		return Objects.equals(toString(), portalInstanceCopy.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		Long destinationCompanyId = getDestinationCompanyId();
+
+		if (destinationCompanyId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"destinationCompanyId\": ");
+
+			sb.append(destinationCompanyId);
+		}
+
+		String name = getName();
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		String virtualHost = getVirtualHost();
+
+		if (virtualHost != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"virtualHost\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(virtualHost));
+
+			sb.append("\"");
+		}
+
+		String webId = getWebId();
+
+		if (webId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"webId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(webId));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.portal.instances.dto.v1_0.PortalInstanceCopy",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-530038322

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.portal.instances.resource.v1_0;
 
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.dto.v1_0.PortalInstanceCopy;
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstanceExport;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -56,6 +57,11 @@ public interface PortalInstanceResource {
 		throws Exception;
 
 	public PortalInstance postPortalInstance(PortalInstance portalInstance)
+		throws Exception;
+
+	public PortalInstance postPortalInstanceCopy(
+			String portalInstanceId, String idempotencyKey,
+			PortalInstanceCopy portalInstanceCopy)
 		throws Exception;
 
 	public PortalInstanceExport postPortalInstanceExport(
@@ -156,4 +162,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:944767513
+// LIFERAY-REST-BUILDER-HASH:1125951493

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/resource/v1_0/PortalInstanceResource.java
@@ -60,8 +60,7 @@ public interface PortalInstanceResource {
 		throws Exception;
 
 	public PortalInstance postPortalInstanceCopy(
-			String portalInstanceId, String idempotencyKey,
-			PortalInstanceCopy portalInstanceCopy)
+			String portalInstanceId, PortalInstanceCopy portalInstanceCopy)
 		throws Exception;
 
 	public PortalInstanceExport postPortalInstanceExport(
@@ -162,4 +161,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:1125951493
+// LIFERAY-REST-BUILDER-HASH:1839424290

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/resources/com/liferay/headless/portal/instances/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.2
+version 4.1.0

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/dto/v1_0/PortalInstanceCopy.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/dto/v1_0/PortalInstanceCopy.java
@@ -1,0 +1,142 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.portal.instances.client.dto.v1_0;
+
+import com.liferay.headless.portal.instances.client.function.UnsafeSupplier;
+import com.liferay.headless.portal.instances.client.serdes.v1_0.PortalInstanceCopySerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * @author Alberto Chaparro
+ * @generated
+ */
+@Generated("")
+public class PortalInstanceCopy implements Cloneable, Serializable {
+
+	public static PortalInstanceCopy toDTO(String json) {
+		return PortalInstanceCopySerDes.toDTO(json);
+	}
+
+	public Long getDestinationCompanyId() {
+		return destinationCompanyId;
+	}
+
+	public void setDestinationCompanyId(Long destinationCompanyId) {
+		this.destinationCompanyId = destinationCompanyId;
+	}
+
+	public void setDestinationCompanyId(
+		UnsafeSupplier<Long, Exception> destinationCompanyIdUnsafeSupplier) {
+
+		try {
+			destinationCompanyId = destinationCompanyIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long destinationCompanyId;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	public String getVirtualHost() {
+		return virtualHost;
+	}
+
+	public void setVirtualHost(String virtualHost) {
+		this.virtualHost = virtualHost;
+	}
+
+	public void setVirtualHost(
+		UnsafeSupplier<String, Exception> virtualHostUnsafeSupplier) {
+
+		try {
+			virtualHost = virtualHostUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String virtualHost;
+
+	public String getWebId() {
+		return webId;
+	}
+
+	public void setWebId(String webId) {
+		this.webId = webId;
+	}
+
+	public void setWebId(
+		UnsafeSupplier<String, Exception> webIdUnsafeSupplier) {
+
+		try {
+			webId = webIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String webId;
+
+	@Override
+	public PortalInstanceCopy clone() throws CloneNotSupportedException {
+		return (PortalInstanceCopy)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PortalInstanceCopy)) {
+			return false;
+		}
+
+		PortalInstanceCopy portalInstanceCopy = (PortalInstanceCopy)object;
+
+		return Objects.equals(toString(), portalInstanceCopy.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PortalInstanceCopySerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1292188389

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.portal.instances.client.resource.v1_0;
 
 import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstanceCopy;
 import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstanceExport;
 import com.liferay.headless.portal.instances.client.http.HttpInvoker;
 import com.liferay.headless.portal.instances.client.pagination.Page;
@@ -68,6 +69,16 @@ public interface PortalInstanceResource {
 
 	public HttpInvoker.HttpResponse postPortalInstanceHttpResponse(
 			PortalInstance portalInstance)
+		throws Exception;
+
+	public PortalInstance postPortalInstanceCopy(
+			String portalInstanceId, String idempotencyKey,
+			PortalInstanceCopy portalInstanceCopy)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postPortalInstanceCopyHttpResponse(
+			String portalInstanceId, String idempotencyKey,
+			PortalInstanceCopy portalInstanceCopy)
 		throws Exception;
 
 	public PortalInstanceExport postPortalInstanceExport(
@@ -733,6 +744,117 @@ public interface PortalInstanceResource {
 			return httpInvoker.invoke();
 		}
 
+		public PortalInstance postPortalInstanceCopy(
+				String portalInstanceId, String idempotencyKey,
+				PortalInstanceCopy portalInstanceCopy)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postPortalInstanceCopyHttpResponse(
+					portalInstanceId, idempotencyKey, portalInstanceCopy);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return PortalInstanceSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postPortalInstanceCopyHttpResponse(
+				String portalInstanceId, String idempotencyKey,
+				PortalInstanceCopy portalInstanceCopy)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(portalInstanceCopy.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/copy");
+
+			httpInvoker.path("portalInstanceId", portalInstanceId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public PortalInstanceExport postPortalInstanceExport(
 				String portalInstanceId)
 			throws Exception {
@@ -1067,4 +1189,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-795160208
+// LIFERAY-REST-BUILDER-HASH:-505100657

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/resource/v1_0/PortalInstanceResource.java
@@ -72,13 +72,11 @@ public interface PortalInstanceResource {
 		throws Exception;
 
 	public PortalInstance postPortalInstanceCopy(
-			String portalInstanceId, String idempotencyKey,
-			PortalInstanceCopy portalInstanceCopy)
+			String portalInstanceId, PortalInstanceCopy portalInstanceCopy)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse postPortalInstanceCopyHttpResponse(
-			String portalInstanceId, String idempotencyKey,
-			PortalInstanceCopy portalInstanceCopy)
+			String portalInstanceId, PortalInstanceCopy portalInstanceCopy)
 		throws Exception;
 
 	public PortalInstanceExport postPortalInstanceExport(
@@ -745,13 +743,12 @@ public interface PortalInstanceResource {
 		}
 
 		public PortalInstance postPortalInstanceCopy(
-				String portalInstanceId, String idempotencyKey,
-				PortalInstanceCopy portalInstanceCopy)
+				String portalInstanceId, PortalInstanceCopy portalInstanceCopy)
 			throws Exception {
 
 			HttpInvoker.HttpResponse httpResponse =
 				postPortalInstanceCopyHttpResponse(
-					portalInstanceId, idempotencyKey, portalInstanceCopy);
+					portalInstanceId, portalInstanceCopy);
 
 			String content = httpResponse.getContent();
 
@@ -813,8 +810,7 @@ public interface PortalInstanceResource {
 		}
 
 		public HttpInvoker.HttpResponse postPortalInstanceCopyHttpResponse(
-				String portalInstanceId, String idempotencyKey,
-				PortalInstanceCopy portalInstanceCopy)
+				String portalInstanceId, PortalInstanceCopy portalInstanceCopy)
 			throws Exception {
 
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
@@ -1189,4 +1185,4 @@ public interface PortalInstanceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-505100657
+// LIFERAY-REST-BUILDER-HASH:919553357

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/serdes/v1_0/PortalInstanceCopySerDes.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/serdes/v1_0/PortalInstanceCopySerDes.java
@@ -1,0 +1,296 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.portal.instances.client.serdes.v1_0;
+
+import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstanceCopy;
+import com.liferay.headless.portal.instances.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Alberto Chaparro
+ * @generated
+ */
+@Generated("")
+public class PortalInstanceCopySerDes {
+
+	public static PortalInstanceCopy toDTO(String json) {
+		PortalInstanceCopyJSONParser portalInstanceCopyJSONParser =
+			new PortalInstanceCopyJSONParser();
+
+		return portalInstanceCopyJSONParser.parseToDTO(json);
+	}
+
+	public static PortalInstanceCopy[] toDTOs(String json) {
+		PortalInstanceCopyJSONParser portalInstanceCopyJSONParser =
+			new PortalInstanceCopyJSONParser();
+
+		return portalInstanceCopyJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(PortalInstanceCopy portalInstanceCopy) {
+		if (portalInstanceCopy == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (portalInstanceCopy.getDestinationCompanyId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"destinationCompanyId\": ");
+
+			sb.append(portalInstanceCopy.getDestinationCompanyId());
+		}
+
+		if (portalInstanceCopy.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(portalInstanceCopy.getName()));
+
+			sb.append("\"");
+		}
+
+		if (portalInstanceCopy.getVirtualHost() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"virtualHost\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(portalInstanceCopy.getVirtualHost()));
+
+			sb.append("\"");
+		}
+
+		if (portalInstanceCopy.getWebId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"webId\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(portalInstanceCopy.getWebId()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PortalInstanceCopyJSONParser portalInstanceCopyJSONParser =
+			new PortalInstanceCopyJSONParser();
+
+		return portalInstanceCopyJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		PortalInstanceCopy portalInstanceCopy) {
+
+		if (portalInstanceCopy == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (portalInstanceCopy.getDestinationCompanyId() == null) {
+			map.put("destinationCompanyId", null);
+		}
+		else {
+			map.put(
+				"destinationCompanyId",
+				String.valueOf(portalInstanceCopy.getDestinationCompanyId()));
+		}
+
+		if (portalInstanceCopy.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(portalInstanceCopy.getName()));
+		}
+
+		if (portalInstanceCopy.getVirtualHost() == null) {
+			map.put("virtualHost", null);
+		}
+		else {
+			map.put(
+				"virtualHost",
+				String.valueOf(portalInstanceCopy.getVirtualHost()));
+		}
+
+		if (portalInstanceCopy.getWebId() == null) {
+			map.put("webId", null);
+		}
+		else {
+			map.put("webId", String.valueOf(portalInstanceCopy.getWebId()));
+		}
+
+		return map;
+	}
+
+	public static class PortalInstanceCopyJSONParser
+		extends BaseJSONParser<PortalInstanceCopy> {
+
+		@Override
+		protected PortalInstanceCopy createDTO() {
+			return new PortalInstanceCopy();
+		}
+
+		@Override
+		protected PortalInstanceCopy[] createDTOArray(int size) {
+			return new PortalInstanceCopy[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "destinationCompanyId")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "virtualHost")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "webId")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			PortalInstanceCopy portalInstanceCopy, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "destinationCompanyId")) {
+				if (jsonParserFieldValue != null) {
+					portalInstanceCopy.setDestinationCompanyId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					portalInstanceCopy.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "virtualHost")) {
+				if (jsonParserFieldValue != null) {
+					portalInstanceCopy.setVirtualHost(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "webId")) {
+				if (jsonParserFieldValue != null) {
+					portalInstanceCopy.setWebId((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-305157922

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -248,11 +248,6 @@ paths:
                     required: true
                     schema:
                         type: string
-                -   in: header
-                    name: idempotency-key
-                    required: false
-                    schema:
-                        type: string
             requestBody:
                 content:
                     application/json:

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -53,6 +53,18 @@ components:
                 virtualHost:
                     type: string
             type: object
+        PortalInstanceCopy:
+            properties:
+                destinationCompanyId:
+                    format: int64
+                    type: integer
+                name:
+                    type: string
+                virtualHost:
+                    type: string
+                webId:
+                    type: string
+            type: object
         PortalInstanceExport:
             description:
                 The result of exporting a portal instance.
@@ -224,6 +236,42 @@ paths:
                         application/xml: {}
                     description:
                         default response
+            tags: ["PortalInstance"]
+    /portal-instances/{portalInstanceId}/copy:
+        post:
+            description:
+                Copies the portal instance
+            operationId: postPortalInstanceCopy
+            parameters:
+                -   in: path
+                    name: portalInstanceId
+                    required: true
+                    schema:
+                        type: string
+                -   in: header
+                    name: idempotency-key
+                    required: false
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/PortalInstanceCopy"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/PortalInstanceCopy"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/PortalInstance"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/PortalInstance"
+                    description:
+                        Portal instance successfully copied
             tags: ["PortalInstance"]
     /portal-instances/{portalInstanceId}/deactivate:
         # @review

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.headless.portal.instances.internal.resource.v1_0;
 
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.dto.v1_0.PortalInstanceCopy;
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstanceExport;
 import com.liferay.headless.portal.instances.resource.v1_0.PortalInstanceResource;
 import com.liferay.petra.function.UnsafeFunction;
@@ -203,6 +204,46 @@ public abstract class BasePortalInstanceResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public PortalInstance postPortalInstance(PortalInstance portalInstance)
+		throws Exception {
+
+		return new PortalInstance();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-portal-instances/v1.0/portal-instances/{portalInstanceId}/copy' -d $'{"destinationCompanyId": ___, "name": ___, "virtualHost": ___, "webId": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Copies the portal instance"
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "portalInstanceId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(name = "PortalInstance")
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/portal-instances/{portalInstanceId}/copy")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public PortalInstance postPortalInstanceCopy(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("portalInstanceId")
+			String portalInstanceId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.HeaderParam("idempotency-key")
+			String idempotencyKey,
+			PortalInstanceCopy portalInstanceCopy)
 		throws Exception {
 
 		return new PortalInstance();
@@ -754,4 +795,4 @@ public abstract class BasePortalInstanceResourceImpl
 		LogFactoryUtil.getLog(BasePortalInstanceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:-2056159458
+// LIFERAY-REST-BUILDER-HASH:2036013466

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/BasePortalInstanceResourceImpl.java
@@ -240,9 +240,6 @@ public abstract class BasePortalInstanceResourceImpl
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("portalInstanceId")
 			String portalInstanceId,
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.HeaderParam("idempotency-key")
-			String idempotencyKey,
 			PortalInstanceCopy portalInstanceCopy)
 		throws Exception {
 
@@ -795,4 +792,4 @@ public abstract class BasePortalInstanceResourceImpl
 		LogFactoryUtil.getLog(BasePortalInstanceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:2036013466
+// LIFERAY-REST-BUILDER-HASH:-746806919

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -179,7 +179,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		}
 		catch (Exception exception) {
 			_log.error(
-				"Unable to copy portal instance " + portalInstanceId,
+				"Unable to copy portal instance \"" + portalInstanceId + "\"",
 				exception);
 
 			throw exception;

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -468,5 +468,4 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 	}
 
-
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -42,12 +42,9 @@ import jakarta.ws.rs.BadRequestException;
 
 import java.util.ArrayList;
 import java.util.Dictionary;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.felix.cm.file.ConfigurationHandler;
 
@@ -157,8 +154,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 	@Override
 	public PortalInstance postPortalInstanceCopy(
-			String portalInstanceId, String idempotencyKey,
-			PortalInstanceCopy portalInstanceCopy)
+			String portalInstanceId, PortalInstanceCopy portalInstanceCopy)
 		throws Exception {
 
 		if (!FeatureFlagManagerUtil.isEnabled(
@@ -178,101 +174,16 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
 		}
 
-		String scopedIdempotencyKey = null;
-		IdempotencyEntry placeholder = null;
+		Company sourceCompany = _companyService.getCompanyByWebId(
+			portalInstanceId);
 
-		if (Validator.isNotNull(idempotencyKey)) {
-			scopedIdempotencyKey =
-				contextUser.getUserId() + ":" + idempotencyKey;
-
-			placeholder = new IdempotencyEntry(
-				null, _IDEMPOTENCY_PLACEHOLDER_TTL_MS);
-
-			while (true) {
-				IdempotencyEntry existing = _idempotencyCache.putIfAbsent(
-					scopedIdempotencyKey, placeholder);
-
-				if (existing == null) {
-					break;
-				}
-
-				if (!existing.isExpired()) {
-					PortalInstance cached = existing.getPortalInstance();
-
-					if (cached == null) {
-						throw new BadRequestException(
-							"A request with the same idempotency key is " +
-								"already in progress");
-					}
-
-					return cached;
-				}
-
-				if (_idempotencyCache.replace(
-						scopedIdempotencyKey, existing, placeholder)) {
-
-					break;
-				}
-			}
-		}
-
-		try {
-			Company sourceCompany = _companyService.getCompanyByWebId(
-				portalInstanceId);
-
-			PortalInstance portalInstance = _toPortalInstance(
-				_companyService.copyDBPartitionCompany(
-					sourceCompany.getCompanyId(),
-					portalInstanceCopy.getDestinationCompanyId(),
-					portalInstanceCopy.getName(),
-					portalInstanceCopy.getVirtualHost(),
-					portalInstanceCopy.getWebId()));
-
-			if (Validator.isNotNull(scopedIdempotencyKey)) {
-				if (_idempotencyCache.size() >= _IDEMPOTENCY_CACHE_MAX_SIZE) {
-					Set<Map.Entry<String, IdempotencyEntry>> entries =
-						_idempotencyCache.entrySet();
-
-					entries.removeIf(
-						entry -> {
-							IdempotencyEntry value = entry.getValue();
-
-							return value.isExpired();
-						});
-
-					if (_idempotencyCache.size() >=
-							_IDEMPOTENCY_CACHE_MAX_SIZE) {
-
-						Iterator<Map.Entry<String, IdempotencyEntry>> iterator =
-							entries.iterator();
-
-						while (iterator.hasNext()) {
-							Map.Entry<String, IdempotencyEntry> entry =
-								iterator.next();
-
-							IdempotencyEntry value = entry.getValue();
-
-							if (value.getPortalInstance() != null) {
-								iterator.remove();
-
-								break;
-							}
-						}
-					}
-				}
-
-				_idempotencyCache.put(
-					scopedIdempotencyKey,
-					new IdempotencyEntry(portalInstance, _IDEMPOTENCY_TTL_MS));
-			}
-
-			return portalInstance;
-		}
-		finally {
-			if (placeholder != null) {
-				_idempotencyCache.remove(scopedIdempotencyKey, placeholder);
-			}
-		}
+		return _toPortalInstance(
+			_companyService.copyDBPartitionCompany(
+				sourceCompany.getCompanyId(),
+				portalInstanceCopy.getDestinationCompanyId(),
+				portalInstanceCopy.getName(),
+				portalInstanceCopy.getVirtualHost(),
+				portalInstanceCopy.getWebId()));
 	}
 
 	@Override
@@ -510,17 +421,9 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		}
 	}
 
-	private static final int _IDEMPOTENCY_CACHE_MAX_SIZE = 1000;
-
-	private static final long _IDEMPOTENCY_PLACEHOLDER_TTL_MS = 30 * 60 * 1000;
-
-	private static final long _IDEMPOTENCY_TTL_MS = 5 * 60 * 1000;
-
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstanceResourceImpl.class);
 
-	private static final ConcurrentHashMap<String, IdempotencyEntry>
-		_idempotencyCache = new ConcurrentHashMap<>();
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
@@ -530,31 +433,6 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
-
-	private static class IdempotencyEntry {
-
-		public IdempotencyEntry(PortalInstance portalInstance, long ttlMs) {
-			_portalInstance = portalInstance;
-
-			_expiryTime = System.currentTimeMillis() + ttlMs;
-		}
-
-		public PortalInstance getPortalInstance() {
-			return _portalInstance;
-		}
-
-		public boolean isExpired() {
-			if (System.currentTimeMillis() > _expiryTime) {
-				return true;
-			}
-
-			return false;
-		}
-
-		private final long _expiryTime;
-		private final PortalInstance _portalInstance;
-
-	}
 
 	private static class ScopedConfiguration {
 
@@ -590,5 +468,6 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		private final Object _scopePK;
 
 	}
+
 
 }

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.portal.instances.internal.resource.v1_0;
 
 import com.liferay.headless.portal.instances.dto.v1_0.Admin;
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.dto.v1_0.PortalInstanceCopy;
 import com.liferay.headless.portal.instances.dto.v1_0.PortalInstanceExport;
 import com.liferay.headless.portal.instances.resource.v1_0.PortalInstanceResource;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
@@ -37,11 +38,16 @@ import com.liferay.portal.security.auth.EmailAddressValidatorFactory;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.portal.vulcan.pagination.Page;
 
+import jakarta.ws.rs.BadRequestException;
+
 import java.util.ArrayList;
 import java.util.Dictionary;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.felix.cm.file.ConfigurationHandler;
 
@@ -147,6 +153,126 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 					finalCompanyId, portalInstance.getPortalInstanceId(),
 					portalInstance.getVirtualHost(), portalInstance.getDomain(),
 					0, true)));
+	}
+
+	@Override
+	public PortalInstance postPortalInstanceCopy(
+			String portalInstanceId, String idempotencyKey,
+			PortalInstanceCopy portalInstanceCopy)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-11342")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		if (portalInstanceCopy == null) {
+			throw new BadRequestException("Copy configuration is required");
+		}
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (!permissionChecker.isOmniadmin()) {
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
+		}
+
+		String scopedIdempotencyKey = null;
+		IdempotencyEntry placeholder = null;
+
+		if (Validator.isNotNull(idempotencyKey)) {
+			scopedIdempotencyKey =
+				contextUser.getUserId() + ":" + idempotencyKey;
+
+			placeholder = new IdempotencyEntry(
+				null, _IDEMPOTENCY_PLACEHOLDER_TTL_MS);
+
+			while (true) {
+				IdempotencyEntry existing = _idempotencyCache.putIfAbsent(
+					scopedIdempotencyKey, placeholder);
+
+				if (existing == null) {
+					break;
+				}
+
+				if (!existing.isExpired()) {
+					PortalInstance cached = existing.getPortalInstance();
+
+					if (cached == null) {
+						throw new BadRequestException(
+							"A request with the same idempotency key is " +
+								"already in progress");
+					}
+
+					return cached;
+				}
+
+				if (_idempotencyCache.replace(
+						scopedIdempotencyKey, existing, placeholder)) {
+
+					break;
+				}
+			}
+		}
+
+		try {
+			Company sourceCompany = _companyService.getCompanyByWebId(
+				portalInstanceId);
+
+			PortalInstance portalInstance = _toPortalInstance(
+				_companyService.copyDBPartitionCompany(
+					sourceCompany.getCompanyId(),
+					portalInstanceCopy.getDestinationCompanyId(),
+					portalInstanceCopy.getName(),
+					portalInstanceCopy.getVirtualHost(),
+					portalInstanceCopy.getWebId()));
+
+			if (Validator.isNotNull(scopedIdempotencyKey)) {
+				if (_idempotencyCache.size() >= _IDEMPOTENCY_CACHE_MAX_SIZE) {
+					Set<Map.Entry<String, IdempotencyEntry>> entries =
+						_idempotencyCache.entrySet();
+
+					entries.removeIf(
+						entry -> {
+							IdempotencyEntry value = entry.getValue();
+
+							return value.isExpired();
+						});
+
+					if (_idempotencyCache.size() >=
+							_IDEMPOTENCY_CACHE_MAX_SIZE) {
+
+						Iterator<Map.Entry<String, IdempotencyEntry>> iterator =
+							entries.iterator();
+
+						while (iterator.hasNext()) {
+							Map.Entry<String, IdempotencyEntry> entry =
+								iterator.next();
+
+							IdempotencyEntry value = entry.getValue();
+
+							if (value.getPortalInstance() != null) {
+								iterator.remove();
+
+								break;
+							}
+						}
+					}
+				}
+
+				_idempotencyCache.put(
+					scopedIdempotencyKey,
+					new IdempotencyEntry(portalInstance, _IDEMPOTENCY_TTL_MS));
+			}
+
+			return portalInstance;
+		}
+		finally {
+			if (placeholder != null) {
+				_idempotencyCache.remove(scopedIdempotencyKey, placeholder);
+			}
+		}
 	}
 
 	@Override
@@ -384,8 +510,17 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		}
 	}
 
+	private static final int _IDEMPOTENCY_CACHE_MAX_SIZE = 1000;
+
+	private static final long _IDEMPOTENCY_PLACEHOLDER_TTL_MS = 30 * 60 * 1000;
+
+	private static final long _IDEMPOTENCY_TTL_MS = 5 * 60 * 1000;
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstanceResourceImpl.class);
+
+	private static final ConcurrentHashMap<String, IdempotencyEntry>
+		_idempotencyCache = new ConcurrentHashMap<>();
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
@@ -395,6 +530,31 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 	@Reference
 	private GroupLocalService _groupLocalService;
+
+	private static class IdempotencyEntry {
+
+		public IdempotencyEntry(PortalInstance portalInstance, long ttlMs) {
+			_portalInstance = portalInstance;
+
+			_expiryTime = System.currentTimeMillis() + ttlMs;
+		}
+
+		public PortalInstance getPortalInstance() {
+			return _portalInstance;
+		}
+
+		public boolean isExpired() {
+			if (System.currentTimeMillis() > _expiryTime) {
+				return true;
+			}
+
+			return false;
+		}
+
+		private final long _expiryTime;
+		private final PortalInstance _portalInstance;
+
+	}
 
 	private static class ScopedConfiguration {
 

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -159,11 +159,11 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 		_checkFeatureFlag();
 
+		_checkPermission();
+
 		if (portalInstanceCopy == null) {
 			throw new BadRequestException("Copy configuration is required");
 		}
-
-		_checkPermission();
 
 		Company sourceCompany = _companyService.getCompanyByWebId(
 			portalInstanceId);
@@ -179,7 +179,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		}
 		catch (Exception exception) {
 			_log.error(
-				"Unable to copy portal instance \"" + portalInstanceId + "\"",
+				"Unable to copy portal instance " + portalInstanceId,
 				exception);
 
 			throw exception;

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -157,33 +157,33 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 			String portalInstanceId, PortalInstanceCopy portalInstanceCopy)
 		throws Exception {
 
-		if (!FeatureFlagManagerUtil.isEnabled(
-				contextCompany.getCompanyId(), "LPD-11342")) {
-
-			throw new UnsupportedOperationException();
-		}
+		_checkFeatureFlag();
 
 		if (portalInstanceCopy == null) {
 			throw new BadRequestException("Copy configuration is required");
 		}
 
-		PermissionChecker permissionChecker =
-			PermissionThreadLocal.getPermissionChecker();
-
-		if (!permissionChecker.isOmniadmin()) {
-			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
-		}
+		_checkPermission();
 
 		Company sourceCompany = _companyService.getCompanyByWebId(
 			portalInstanceId);
 
-		return _toPortalInstance(
-			_companyService.copyDBPartitionCompany(
-				sourceCompany.getCompanyId(),
-				portalInstanceCopy.getDestinationCompanyId(),
-				portalInstanceCopy.getName(),
-				portalInstanceCopy.getVirtualHost(),
-				portalInstanceCopy.getWebId()));
+		try {
+			return _toPortalInstance(
+				_companyService.copyDBPartitionCompany(
+					sourceCompany.getCompanyId(),
+					portalInstanceCopy.getDestinationCompanyId(),
+					portalInstanceCopy.getName(),
+					portalInstanceCopy.getVirtualHost(),
+					portalInstanceCopy.getWebId()));
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to copy portal instance " + portalInstanceId,
+				exception);
+
+			throw exception;
+		}
 	}
 
 	@Override
@@ -423,7 +423,6 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		PortalInstanceResourceImpl.class);
-
 
 	@Reference
 	private CompanyLocalService _companyLocalService;

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
@@ -331,6 +331,25 @@ public abstract class BasePortalInstanceResourceTestCase {
 	}
 
 	@Test
+	public void testPostPortalInstanceCopy() throws Exception {
+		PortalInstance randomPortalInstance = randomPortalInstance();
+
+		PortalInstance postPortalInstance =
+			testPostPortalInstanceCopy_addPortalInstance(randomPortalInstance);
+
+		assertEquals(randomPortalInstance, postPortalInstance);
+		assertValid(postPortalInstance);
+	}
+
+	protected PortalInstance testPostPortalInstanceCopy_addPortalInstance(
+			PortalInstance portalInstance)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testPutPortalInstanceActivate() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		PortalInstance portalInstance =

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -501,13 +501,13 @@ public class PortalInstanceResourceTest
 		try {
 			assertValid(copiedPortalInstance);
 
+			Assert.assertNotEquals(
+				_portalInstance.getCompanyId(),
+				copiedPortalInstance.getCompanyId());
 			Assert.assertEquals(
 				randomId, copiedPortalInstance.getPortalInstanceId());
 			Assert.assertEquals(
 				virtualHost, copiedPortalInstance.getVirtualHost());
-			Assert.assertNotEquals(
-				_portalInstance.getCompanyId(),
-				copiedPortalInstance.getCompanyId());
 		}
 		finally {
 			_deletePortalInstance(copiedPortalInstance);

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -8,6 +8,7 @@ package com.liferay.headless.portal.instances.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.portal.instances.client.dto.v1_0.Admin;
 import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstance;
+import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstanceCopy;
 import com.liferay.headless.portal.instances.client.dto.v1_0.PortalInstanceExport;
 import com.liferay.headless.portal.instances.client.pagination.Page;
 import com.liferay.headless.portal.instances.client.problem.Problem;
@@ -122,6 +123,18 @@ public class PortalInstanceResourceTest
 		_testPostPortalInstanceWithoutAdmin();
 		_testPostPortalInstanceWithAdmin();
 		_testPostPortalInstanceWithAdminAndCompanyStrangers();
+	}
+
+	@FeatureFlag("LPD-11342")
+	@Override
+	@Test
+	public void testPostPortalInstanceCopy() throws Exception {
+		_testPostPortalInstanceCopyExisting();
+		_testPostPortalInstanceCopyForbidden(null);
+		_testPostPortalInstanceCopyForbidden(RandomTestUtil.randomString());
+		_testPostPortalInstanceCopyForbiddenOnReplay();
+		_testPostPortalInstanceCopyIdempotent();
+		_testPostPortalInstanceCopyNonexistent();
 	}
 
 	@FeatureFlag("LPD-11342")
@@ -469,6 +482,222 @@ public class PortalInstanceResourceTest
 		_testPatchPortalInstace(portalInstance, false, false, false);
 	}
 
+	private void _testPostPortalInstanceCopyExisting() throws Exception {
+		Assume.assumeTrue(_db.isSupportsDBPartition());
+
+		String randomId = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
+		String virtualHost =
+			randomId + "." +
+				StringUtil.toLowerCase(RandomTestUtil.randomString(3));
+
+		PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
+
+		portalInstanceCopy.setName(randomId);
+		portalInstanceCopy.setVirtualHost(virtualHost);
+		portalInstanceCopy.setWebId(randomId);
+
+		PortalInstance copiedPortalInstance =
+			portalInstanceResource.postPortalInstanceCopy(
+				_portalInstance.getPortalInstanceId(), null,
+				portalInstanceCopy);
+
+		try {
+			assertValid(copiedPortalInstance);
+
+			Assert.assertNotEquals(
+				_portalInstance.getCompanyId(),
+				copiedPortalInstance.getCompanyId());
+			Assert.assertEquals(
+				randomId, copiedPortalInstance.getPortalInstanceId());
+			Assert.assertEquals(
+				virtualHost, copiedPortalInstance.getVirtualHost());
+		}
+		finally {
+			_deletePortalInstance(copiedPortalInstance);
+		}
+	}
+
+	private void _testPostPortalInstanceCopyForbidden(String idempotencyKey)
+		throws Exception {
+
+		User user = UserTestUtil.addUser(false);
+
+		try {
+			user = _userLocalService.updatePassword(
+				user.getUserId(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				PropsValues.DEFAULT_ADMIN_PASSWORD, false, true);
+
+			Company company = _companyLocalService.fetchCompany(
+				TestPropsValues.getCompanyId());
+
+			PortalInstanceResource userPortalInstanceResource =
+				PortalInstanceResource.builder(
+				).authentication(
+					user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD
+				).endpoint(
+					company.getVirtualHostname(),
+					PortalUtil.getPortalServerPort(false), "http"
+				).locale(
+					LocaleUtil.getDefault()
+				).build();
+
+			PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
+
+			portalInstanceCopy.setName(RandomTestUtil.randomString());
+			portalInstanceCopy.setVirtualHost(RandomTestUtil.randomString());
+			portalInstanceCopy.setWebId(RandomTestUtil.randomString());
+
+			try {
+				userPortalInstanceResource.postPortalInstanceCopy(
+					_portalInstance.getPortalInstanceId(), idempotencyKey,
+					portalInstanceCopy);
+
+				Assert.fail();
+			}
+			catch (Problem.ProblemException problemException) {
+				Problem problem = problemException.getProblem();
+
+				Assert.assertEquals("FORBIDDEN", problem.getStatus());
+			}
+		}
+		finally {
+			_userLocalService.deleteUser(user.getUserId());
+		}
+	}
+
+	private void _testPostPortalInstanceCopyForbiddenOnReplay()
+		throws Exception {
+
+		Assume.assumeTrue(_db.isSupportsDBPartition());
+
+		String idempotencyKey = RandomTestUtil.randomString();
+
+		String randomId = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
+		String virtualHost =
+			randomId + "." +
+				StringUtil.toLowerCase(RandomTestUtil.randomString(3));
+
+		PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
+
+		portalInstanceCopy.setName(randomId);
+		portalInstanceCopy.setVirtualHost(virtualHost);
+		portalInstanceCopy.setWebId(randomId);
+
+		PortalInstance portalInstance =
+			portalInstanceResource.postPortalInstanceCopy(
+				_portalInstance.getPortalInstanceId(), idempotencyKey,
+				portalInstanceCopy);
+
+		try {
+			User user = UserTestUtil.addUser(false);
+
+			try {
+				user = _userLocalService.updatePassword(
+					user.getUserId(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+					PropsValues.DEFAULT_ADMIN_PASSWORD, false, true);
+
+				Company company = _companyLocalService.fetchCompany(
+					TestPropsValues.getCompanyId());
+
+				PortalInstanceResource userPortalInstanceResource =
+					PortalInstanceResource.builder(
+					).authentication(
+						user.getEmailAddress(),
+						PropsValues.DEFAULT_ADMIN_PASSWORD
+					).endpoint(
+						company.getVirtualHostname(),
+						PortalUtil.getPortalServerPort(false), "http"
+					).locale(
+						LocaleUtil.getDefault()
+					).build();
+
+				try {
+					userPortalInstanceResource.postPortalInstanceCopy(
+						_portalInstance.getPortalInstanceId(), idempotencyKey,
+						portalInstanceCopy);
+
+					Assert.fail();
+				}
+				catch (Problem.ProblemException problemException) {
+					Problem problem = problemException.getProblem();
+
+					Assert.assertEquals("FORBIDDEN", problem.getStatus());
+				}
+			}
+			finally {
+				_userLocalService.deleteUser(user.getUserId());
+			}
+		}
+		finally {
+			_deletePortalInstance(portalInstance);
+		}
+	}
+
+	private void _testPostPortalInstanceCopyIdempotent() throws Exception {
+		Assume.assumeTrue(_db.isSupportsDBPartition());
+
+		String randomId = StringUtil.toLowerCase(RandomTestUtil.randomString());
+
+		String virtualHost =
+			randomId + "." +
+				StringUtil.toLowerCase(RandomTestUtil.randomString(3));
+
+		int companyCount = _companyLocalService.getCompaniesCount();
+
+		String idempotencyKey = RandomTestUtil.randomString();
+
+		PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
+
+		portalInstanceCopy.setName(randomId);
+		portalInstanceCopy.setVirtualHost(virtualHost);
+		portalInstanceCopy.setWebId(randomId);
+
+		PortalInstance firstPortalInstance =
+			portalInstanceResource.postPortalInstanceCopy(
+				_portalInstance.getPortalInstanceId(), idempotencyKey,
+				portalInstanceCopy);
+
+		try {
+			PortalInstance secondPortalInstance =
+				portalInstanceResource.postPortalInstanceCopy(
+					_portalInstance.getPortalInstanceId(), idempotencyKey,
+					portalInstanceCopy);
+
+			Assert.assertEquals(
+				firstPortalInstance.getCompanyId(),
+				secondPortalInstance.getCompanyId());
+
+			Assert.assertEquals(
+				companyCount + 1, _companyLocalService.getCompaniesCount());
+		}
+		finally {
+			_deletePortalInstance(firstPortalInstance);
+		}
+	}
+
+	private void _testPostPortalInstanceCopyNonexistent() throws Exception {
+		PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
+
+		portalInstanceCopy.setName(RandomTestUtil.randomString());
+		portalInstanceCopy.setVirtualHost(RandomTestUtil.randomString());
+		portalInstanceCopy.setWebId(RandomTestUtil.randomString());
+
+		try {
+			portalInstanceResource.postPortalInstanceCopy(
+				RandomTestUtil.randomString(), null, portalInstanceCopy);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertNull(problem.getTitle());
+		}
+	}
+
 	private void _testPostPortalInstanceExport() throws Exception {
 		long companyId = _portalInstance.getCompanyId();
 
@@ -587,6 +816,7 @@ public class PortalInstanceResourceTest
 		}
 	}
 
+
 	private void _testPostPortalInstanceWithAdmin() throws Exception {
 		PortalInstance randomPortalInstance = randomPortalInstance();
 
@@ -662,6 +892,9 @@ public class PortalInstanceResourceTest
 
 	@Inject
 	private ConfigurationAdmin _configurationAdmin;
+
+	@Inject
+	private DB _db;
 
 	@Inject
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -501,13 +501,13 @@ public class PortalInstanceResourceTest
 		try {
 			assertValid(copiedPortalInstance);
 
-			Assert.assertNotEquals(
-				_portalInstance.getCompanyId(),
-				copiedPortalInstance.getCompanyId());
 			Assert.assertEquals(
 				randomId, copiedPortalInstance.getPortalInstanceId());
 			Assert.assertEquals(
 				virtualHost, copiedPortalInstance.getVirtualHost());
+			Assert.assertNotEquals(
+				_portalInstance.getCompanyId(),
+				copiedPortalInstance.getCompanyId());
 		}
 		finally {
 			_deletePortalInstance(copiedPortalInstance);
@@ -566,7 +566,11 @@ public class PortalInstanceResourceTest
 		portalInstanceCopy.setVirtualHost(RandomTestUtil.randomString());
 		portalInstanceCopy.setWebId(RandomTestUtil.randomString());
 
-		try {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
+					"WebApplicationExceptionMapper",
+				LoggerTestUtil.ERROR)) {
+
 			portalInstanceResource.postPortalInstanceCopy(
 				RandomTestUtil.randomString(), portalInstanceCopy);
 

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -702,7 +702,6 @@ public class PortalInstanceResourceTest
 		}
 	}
 
-
 	private void _testPostPortalInstanceWithAdmin() throws Exception {
 		PortalInstance randomPortalInstance = randomPortalInstance();
 

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -130,10 +130,7 @@ public class PortalInstanceResourceTest
 	@Test
 	public void testPostPortalInstanceCopy() throws Exception {
 		_testPostPortalInstanceCopyExisting();
-		_testPostPortalInstanceCopyForbidden(null);
-		_testPostPortalInstanceCopyForbidden(RandomTestUtil.randomString());
-		_testPostPortalInstanceCopyForbiddenOnReplay();
-		_testPostPortalInstanceCopyIdempotent();
+		_testPostPortalInstanceCopyForbidden();
 		_testPostPortalInstanceCopyNonexistent();
 	}
 
@@ -499,8 +496,7 @@ public class PortalInstanceResourceTest
 
 		PortalInstance copiedPortalInstance =
 			portalInstanceResource.postPortalInstanceCopy(
-				_portalInstance.getPortalInstanceId(), null,
-				portalInstanceCopy);
+				_portalInstance.getPortalInstanceId(), portalInstanceCopy);
 
 		try {
 			assertValid(copiedPortalInstance);
@@ -518,9 +514,7 @@ public class PortalInstanceResourceTest
 		}
 	}
 
-	private void _testPostPortalInstanceCopyForbidden(String idempotencyKey)
-		throws Exception {
-
+	private void _testPostPortalInstanceCopyForbidden() throws Exception {
 		User user = UserTestUtil.addUser(false);
 
 		try {
@@ -550,8 +544,7 @@ public class PortalInstanceResourceTest
 
 			try {
 				userPortalInstanceResource.postPortalInstanceCopy(
-					_portalInstance.getPortalInstanceId(), idempotencyKey,
-					portalInstanceCopy);
+					_portalInstance.getPortalInstanceId(), portalInstanceCopy);
 
 				Assert.fail();
 			}
@@ -566,117 +559,6 @@ public class PortalInstanceResourceTest
 		}
 	}
 
-	private void _testPostPortalInstanceCopyForbiddenOnReplay()
-		throws Exception {
-
-		Assume.assumeTrue(_db.isSupportsDBPartition());
-
-		String idempotencyKey = RandomTestUtil.randomString();
-
-		String randomId = StringUtil.toLowerCase(RandomTestUtil.randomString());
-
-		String virtualHost =
-			randomId + "." +
-				StringUtil.toLowerCase(RandomTestUtil.randomString(3));
-
-		PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
-
-		portalInstanceCopy.setName(randomId);
-		portalInstanceCopy.setVirtualHost(virtualHost);
-		portalInstanceCopy.setWebId(randomId);
-
-		PortalInstance portalInstance =
-			portalInstanceResource.postPortalInstanceCopy(
-				_portalInstance.getPortalInstanceId(), idempotencyKey,
-				portalInstanceCopy);
-
-		try {
-			User user = UserTestUtil.addUser(false);
-
-			try {
-				user = _userLocalService.updatePassword(
-					user.getUserId(), PropsValues.DEFAULT_ADMIN_PASSWORD,
-					PropsValues.DEFAULT_ADMIN_PASSWORD, false, true);
-
-				Company company = _companyLocalService.fetchCompany(
-					TestPropsValues.getCompanyId());
-
-				PortalInstanceResource userPortalInstanceResource =
-					PortalInstanceResource.builder(
-					).authentication(
-						user.getEmailAddress(),
-						PropsValues.DEFAULT_ADMIN_PASSWORD
-					).endpoint(
-						company.getVirtualHostname(),
-						PortalUtil.getPortalServerPort(false), "http"
-					).locale(
-						LocaleUtil.getDefault()
-					).build();
-
-				try {
-					userPortalInstanceResource.postPortalInstanceCopy(
-						_portalInstance.getPortalInstanceId(), idempotencyKey,
-						portalInstanceCopy);
-
-					Assert.fail();
-				}
-				catch (Problem.ProblemException problemException) {
-					Problem problem = problemException.getProblem();
-
-					Assert.assertEquals("FORBIDDEN", problem.getStatus());
-				}
-			}
-			finally {
-				_userLocalService.deleteUser(user.getUserId());
-			}
-		}
-		finally {
-			_deletePortalInstance(portalInstance);
-		}
-	}
-
-	private void _testPostPortalInstanceCopyIdempotent() throws Exception {
-		Assume.assumeTrue(_db.isSupportsDBPartition());
-
-		String randomId = StringUtil.toLowerCase(RandomTestUtil.randomString());
-
-		String virtualHost =
-			randomId + "." +
-				StringUtil.toLowerCase(RandomTestUtil.randomString(3));
-
-		int companyCount = _companyLocalService.getCompaniesCount();
-
-		String idempotencyKey = RandomTestUtil.randomString();
-
-		PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
-
-		portalInstanceCopy.setName(randomId);
-		portalInstanceCopy.setVirtualHost(virtualHost);
-		portalInstanceCopy.setWebId(randomId);
-
-		PortalInstance firstPortalInstance =
-			portalInstanceResource.postPortalInstanceCopy(
-				_portalInstance.getPortalInstanceId(), idempotencyKey,
-				portalInstanceCopy);
-
-		try {
-			PortalInstance secondPortalInstance =
-				portalInstanceResource.postPortalInstanceCopy(
-					_portalInstance.getPortalInstanceId(), idempotencyKey,
-					portalInstanceCopy);
-
-			Assert.assertEquals(
-				firstPortalInstance.getCompanyId(),
-				secondPortalInstance.getCompanyId());
-
-			Assert.assertEquals(
-				companyCount + 1, _companyLocalService.getCompaniesCount());
-		}
-		finally {
-			_deletePortalInstance(firstPortalInstance);
-		}
-	}
-
 	private void _testPostPortalInstanceCopyNonexistent() throws Exception {
 		PortalInstanceCopy portalInstanceCopy = new PortalInstanceCopy();
 
@@ -686,7 +568,7 @@ public class PortalInstanceResourceTest
 
 		try {
 			portalInstanceResource.postPortalInstanceCopy(
-				RandomTestUtil.randomString(), null, portalInstanceCopy);
+				RandomTestUtil.randomString(), portalInstanceCopy);
 
 			Assert.fail();
 		}

--- a/portal-impl/src/com/liferay/portal/service/http/CompanyServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/CompanyServiceHttp.java
@@ -129,6 +129,50 @@ public class CompanyServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.model.Company
+			copyDBPartitionCompany(
+				HttpPrincipal httpPrincipal, long fromCompanyId,
+				Long toCompanyId, String name, String virtualHostname,
+				String webId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				CompanyServiceUtil.class, "copyDBPartitionCompany",
+				_copyDBPartitionCompanyParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, fromCompanyId, toCompanyId, name, virtualHostname,
+				webId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.model.Company)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static com.liferay.portal.kernel.model.Company deleteCompany(
 			HttpPrincipal httpPrincipal, long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -136,7 +180,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "deleteCompany",
-				_deleteCompanyParameterTypes2);
+				_deleteCompanyParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -175,7 +219,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "deleteLogo",
-				_deleteLogoParameterTypes3);
+				_deleteLogoParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -214,7 +258,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "forEachCompany",
-				_forEachCompanyParameterTypes4);
+				_forEachCompanyParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, unsafeConsumer);
@@ -246,7 +290,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanies",
-				_getCompaniesParameterTypes5);
+				_getCompaniesParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey);
 
@@ -279,7 +323,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyById",
-				_getCompanyByIdParameterTypes6);
+				_getCompanyByIdParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId);
@@ -320,7 +364,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyByVirtualHost",
-				_getCompanyByVirtualHostParameterTypes7);
+				_getCompanyByVirtualHostParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, virtualHost);
@@ -360,7 +404,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "getCompanyByWebId",
-				_getCompanyByWebIdParameterTypes8);
+				_getCompanyByWebIdParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, webId);
 
@@ -399,7 +443,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "removePreferences",
-				_removePreferencesParameterTypes9);
+				_removePreferencesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, keys);
@@ -436,7 +480,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateCompany",
-				_updateCompanyParameterTypes10);
+				_updateCompanyParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, virtualHost, mx, maxUsers, active);
@@ -480,7 +524,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateCompany",
-				_updateCompanyParameterTypes11);
+				_updateCompanyParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, virtualHost, mx, homeURL, hasLogo,
@@ -532,7 +576,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateCompany",
-				_updateCompanyParameterTypes12);
+				_updateCompanyParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, virtualHost, mx, homeURL, hasLogo,
@@ -576,7 +620,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateDisplay",
-				_updateDisplayParameterTypes13);
+				_updateDisplayParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, languageId, timeZoneId);
@@ -612,7 +656,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes14);
+				_updateLogoParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, bytes);
@@ -653,7 +697,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateLogo",
-				_updateLogoParameterTypes15);
+				_updateLogoParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, inputStream);
@@ -694,7 +738,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updatePreferences",
-				_updatePreferencesParameterTypes16);
+				_updatePreferencesParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, unicodeProperties);
@@ -732,7 +776,7 @@ public class CompanyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				CompanyServiceUtil.class, "updateSecurity",
-				_updateSecurityParameterTypes17);
+				_updateSecurityParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, authType, autoLogin, sendPassword,
@@ -773,35 +817,39 @@ public class CompanyServiceHttp {
 		boolean.class, String.class, String.class, String.class, String.class,
 		String.class, String.class
 	};
-	private static final Class<?>[] _deleteCompanyParameterTypes2 =
+	private static final Class<?>[] _copyDBPartitionCompanyParameterTypes2 =
+		new Class[] {
+			long.class, Long.class, String.class, String.class, String.class
+		};
+	private static final Class<?>[] _deleteCompanyParameterTypes3 =
 		new Class[] {long.class};
-	private static final Class<?>[] _deleteLogoParameterTypes3 = new Class[] {
+	private static final Class<?>[] _deleteLogoParameterTypes4 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _forEachCompanyParameterTypes4 =
+	private static final Class<?>[] _forEachCompanyParameterTypes5 =
 		new Class[] {com.liferay.petra.function.UnsafeConsumer.class};
-	private static final Class<?>[] _getCompaniesParameterTypes5 =
+	private static final Class<?>[] _getCompaniesParameterTypes6 =
 		new Class[] {};
-	private static final Class<?>[] _getCompanyByIdParameterTypes6 =
+	private static final Class<?>[] _getCompanyByIdParameterTypes7 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getCompanyByVirtualHostParameterTypes7 =
+	private static final Class<?>[] _getCompanyByVirtualHostParameterTypes8 =
 		new Class[] {String.class};
-	private static final Class<?>[] _getCompanyByWebIdParameterTypes8 =
+	private static final Class<?>[] _getCompanyByWebIdParameterTypes9 =
 		new Class[] {String.class};
-	private static final Class<?>[] _removePreferencesParameterTypes9 =
+	private static final Class<?>[] _removePreferencesParameterTypes10 =
 		new Class[] {long.class, String[].class};
-	private static final Class<?>[] _updateCompanyParameterTypes10 =
+	private static final Class<?>[] _updateCompanyParameterTypes11 =
 		new Class[] {
 			long.class, String.class, String.class, int.class, boolean.class
 		};
-	private static final Class<?>[] _updateCompanyParameterTypes11 =
+	private static final Class<?>[] _updateCompanyParameterTypes12 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, boolean.class,
 			byte[].class, String.class, String.class, String.class,
 			String.class, String.class, String.class, String.class,
 			String.class, String.class
 		};
-	private static final Class<?>[] _updateCompanyParameterTypes12 =
+	private static final Class<?>[] _updateCompanyParameterTypes13 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, boolean.class,
 			byte[].class, String.class, String.class, String.class,
@@ -811,23 +859,23 @@ public class CompanyServiceHttp {
 			java.util.List.class,
 			com.liferay.portal.kernel.util.UnicodeProperties.class
 		};
-	private static final Class<?>[] _updateDisplayParameterTypes13 =
+	private static final Class<?>[] _updateDisplayParameterTypes14 =
 		new Class[] {long.class, String.class, String.class};
-	private static final Class<?>[] _updateLogoParameterTypes14 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes15 = new Class[] {
 		long.class, byte[].class
 	};
-	private static final Class<?>[] _updateLogoParameterTypes15 = new Class[] {
+	private static final Class<?>[] _updateLogoParameterTypes16 = new Class[] {
 		long.class, java.io.InputStream.class
 	};
-	private static final Class<?>[] _updatePreferencesParameterTypes16 =
+	private static final Class<?>[] _updatePreferencesParameterTypes17 =
 		new Class[] {
 			long.class, com.liferay.portal.kernel.util.UnicodeProperties.class
 		};
-	private static final Class<?>[] _updateSecurityParameterTypes17 =
+	private static final Class<?>[] _updateSecurityParameterTypes18 =
 		new Class[] {
 			long.class, String.class, boolean.class, boolean.class,
 			boolean.class, boolean.class, boolean.class, boolean.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:141410279
+// LIFERAY-SERVICE-BUILDER-HASH:-1396176073

--- a/portal-impl/src/com/liferay/portal/service/http/packageinfo
+++ b/portal-impl/src/com/liferay/portal/service/http/packageinfo
@@ -1,1 +1,1 @@
-version 32.0.0
+version 32.1.0

--- a/portal-impl/src/com/liferay/portal/service/impl/CompanyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/CompanyServiceImpl.java
@@ -6,8 +6,12 @@
 package com.liferay.portal.service.impl;
 
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouterUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebService;
 import com.liferay.portal.kernel.jsonwebservice.JSONWebServiceMode;
 import com.liferay.portal.kernel.model.Address;
@@ -20,6 +24,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.service.base.CompanyServiceBaseImpl;
@@ -106,6 +111,41 @@ public class CompanyServiceImpl extends CompanyServiceBaseImpl {
 			defaultAdminPassword, defaultAdminScreenName,
 			defaultAdminEmailAddress, defaultAdminFirstName,
 			defaultAdminMiddleName, defaultAdminLastName);
+	}
+
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
+	@Override
+	public Company copyDBPartitionCompany(
+			long fromCompanyId, Long toCompanyId, String name,
+			String virtualHostname, String webId)
+		throws PortalException {
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (!permissionChecker.isOmniadmin()) {
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
+		}
+
+		Company company = companyLocalService.copyDBPartitionCompany(
+			fromCompanyId, toCompanyId, name, virtualHostname, webId);
+
+		if (AuditRouterUtil.isDeployed()) {
+			long userId = getUserId();
+
+			AuditRouterUtil.route(
+				new AuditMessage(
+					0, company.getCompanyId(), userId,
+					PortalUtil.getUserName(userId, StringPool.BLANK), null,
+					JSONUtil.put(
+						"virtualHostname", company.getVirtualHostname()
+					).put(
+						"webId", company.getWebId()
+					),
+					Company.class.getName(),
+					String.valueOf(company.getCompanyId()), "COPY", null));
+		}
+
+		return company;
 	}
 
 	@JSONWebService(mode = JSONWebServiceMode.IGNORE)

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 188.0.0
+Bundle-Version: 188.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyService.java
@@ -91,6 +91,12 @@ public interface CompanyService extends BaseService {
 		throws PortalException;
 
 	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
+	public Company copyDBPartitionCompany(
+			long fromCompanyId, Long toCompanyId, String name,
+			String virtualHostname, String webId)
+		throws PortalException;
+
+	@JSONWebService(mode = JSONWebServiceMode.IGNORE)
 	public Company deleteCompany(long companyId) throws PortalException;
 
 	/**
@@ -323,4 +329,4 @@ public interface CompanyService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1458182639
+// LIFERAY-SERVICE-BUILDER-HASH:-1486043867

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceUtil.java
@@ -80,6 +80,15 @@ public class CompanyServiceUtil {
 			defaultAdminMiddleName, defaultAdminLastName);
 	}
 
+	public static Company copyDBPartitionCompany(
+			long fromCompanyId, Long toCompanyId, String name,
+			String virtualHostname, String webId)
+		throws PortalException {
+
+		return getService().copyDBPartitionCompany(
+			fromCompanyId, toCompanyId, name, virtualHostname, webId);
+	}
+
 	public static Company deleteCompany(long companyId) throws PortalException {
 		return getService().deleteCompany(companyId);
 	}
@@ -379,4 +388,4 @@ public class CompanyServiceUtil {
 	private static volatile CompanyService _service;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1918821816
+// LIFERAY-SERVICE-BUILDER-HASH:-107478631

--- a/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/CompanyServiceWrapper.java
@@ -78,6 +78,17 @@ public class CompanyServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.model.Company copyDBPartitionCompany(
+			long fromCompanyId, java.lang.Long toCompanyId,
+			java.lang.String name, java.lang.String virtualHostname,
+			java.lang.String webId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _companyService.copyDBPartitionCompany(
+			fromCompanyId, toCompanyId, name, virtualHostname, webId);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.model.Company deleteCompany(long companyId)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -415,4 +426,4 @@ public class CompanyServiceWrapper
 	private CompanyService _companyService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:274451923
+// LIFERAY-SERVICE-BUILDER-HASH:1992249360

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 54.0.0
+version 54.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92616

## What Is Being Fixed

The Portal Instances headless API had no endpoint to copy a DB-partition portal instance.

## How It Is Being Fixed

`POST /portal-instances/{portalInstanceId}/copy` is added, gated behind feature flag `LPD-11342`. The request body is a `PortalInstanceCopy` DTO carrying `destinationCompanyId`, `name`, `virtualHost`, and `webId`.

**Permission** — the omni-admin check runs before delegating to the service layer. Non-admin callers receive 403.

**Service layer** — `CompanyService.copyDBPartitionCompany` re-checks omni-admin, delegates to `CompanyLocalService`, and routes a `COPY` audit event with `virtualHostname` and `webId` in the payload when `AuditRouter` is deployed.

**Tests** — integration tests cover: successful copy, 403 for non-admin callers, and 404 for a non-existent source portal instance.

**Idempotency-Key** — not implemented in this endpoint. Idempotency support will be addressed as part of the async `BackgroundTask` redesign (LPD-93380).