### PR TITLE
LPD-96468 Register CMS site initializer upgrades as initialization

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
+++ b/modules/apps/site/site-cms-site-initializer/src/main/java/com/liferay/site/cms/site/initializer/internal/upgrade/registry/SiteCMSSiteInitializerUpgradeStepRegistrator.java
@@ -36,8 +36,10 @@ public class SiteCMSSiteInitializerUpgradeStepRegistrator
 
 	@Override
 	public void register(Registry registry) {
+		registry.registerInitialization();
+
 		registry.register(
-			"0.0.0", "1.0.0",
+			"0.0.1", "1.0.0",
 			new CMSDefaultPermissionsUpgradeProcess(
 				_filterFactory, _groupLocalService,
 				_objectDefinitionLocalService, _objectEntryFolderLocalService));

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -805,6 +805,11 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(38, 7, 4),
 			new LayoutSetRemoveUnusedSettingsUpgradeProcess());
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 5),
+			UpgradeModulesFactory.create(
+				new String[] {"com.liferay.site.cms.site.initializer"}, null));
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96468

## What Is Being Fixed

The Poshi test UpgradeLifecycle#UpgradeProcessAndVerifyProcessDoNotRunOnStaleDB fails across all database vendors with `"UpgradeProcess" is present in console`. The site-cms-site-initializer module registers three data-migration upgrade processes from 0.0.0 but never marks them as initialization, so on any boot where the module has no Release_ row — including a clean database — the executor still runs them (a null release forces execution) and logs "Upgrading ...". The test forbids this: no UpgradeProcess may run when the portal starts on a clean database or a database that already exists when property upgrade.database.auto.run is set to false.

## How It Is Being Fixed

The registrar now follows Liferay's documented pattern for adding a first upgrade step to a pre-existing module. SiteCMSSiteInitializerUpgradeStepRegistrator calls registry.registerInitialization(), which reserves a 0.0.0-to-latest DummyUpgradeStep so a clean or newly-created installation initializes its Release_ at the final version without running any migration, and the real steps now register from 0.0.1 instead of 0.0.0. The module shipped about two years before its first upgrade process (LPD-17809 in 2024 vs LPD-84614 and LPD-94507 in 2026), so genuine old installations hold CMS data the processes must still migrate; com.liferay.site.cms.site.initializer is therefore added to a new UpgradeModulesFactory entry in PortalUpgradeProcessRegistryImpl, which seeds those installs' Release_ to 0.0.1 during the portal upgrade so the executor walks the real 0.0.1-to-3.0.0 path. Adding registerInitialization() alone, with the steps still rooted at 0.0.0, would have been regressive: old installs would take the one-hop dummy edge and silently skip the migration.

## Why Are There No Tests?

This change fixes a test-detected regression, and the coverage is the existing test the ticket is about: the Poshi upgrade test UpgradeLifecycle#UpgradeProcessAndVerifyProcessDoNotRunOnStaleDB (previously failing, now expected to pass) plus the existing CMSObjectRelationshipEdgeUpgradeProcessTest and CMSDefaultPermissionsUpgradeProcessTest integration tests that continue to exercise the real migrations on the old-install path. The scenario requires the full portal upgrade runtime across database vendors and is not meaningfully unit-testable, so no new test is added.

## PR Check

**pr-check: PASS** — tested on `327c84a910d02423ee499cce56b63a627d4d137d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS (obviated by Full Portal Build) |
| Integration Test Compile | PASS (obviated by Full Portal Build) |
| Cross-Module Compile | PASS (no consumers) |
| Baseline | PASS (advisory; no exported-API change) |
| Java Unit Tests | N/A (no counterpart test) |

<!-- pr-check {"result": "success", "sha": "327c84a910d02423ee499cce56b63a627d4d137d"} -->
