### PR TITLE
LPD-97840 Fix unit test reference to removed DBUpgrader.isUpgradeClient

### DIFF
--- a/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/index/IndexStatusManagerImplRequireIndexReadWriteTest.java
+++ b/modules/apps/portal-search/portal-search/src/test/java/com/liferay/portal/search/internal/index/IndexStatusManagerImplRequireIndexReadWriteTest.java
@@ -6,8 +6,8 @@
 package com.liferay.portal.search.internal.index;
 
 import com.liferay.portal.events.StartupHelperUtil;
+import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
-import com.liferay.portal.tools.DBUpgrader;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -32,15 +32,16 @@ public class IndexStatusManagerImplRequireIndexReadWriteTest {
 
 	@Before
 	public void setUp() {
-		_dbUpgraderMockedStatic = Mockito.mockStatic(DBUpgrader.class);
 		_startupHelperUtilMockedStatic = Mockito.mockStatic(
 			StartupHelperUtil.class);
+		_upgradeProcessUtilMockedStatic = Mockito.mockStatic(
+			UpgradeProcessUtil.class);
 	}
 
 	@After
 	public void tearDown() {
-		_dbUpgraderMockedStatic.close();
 		_startupHelperUtilMockedStatic.close();
+		_upgradeProcessUtilMockedStatic.close();
 	}
 
 	@Test
@@ -105,8 +106,8 @@ public class IndexStatusManagerImplRequireIndexReadWriteTest {
 
 	@Test
 	public void testReadOnlyWhenIsUpgradeClient() {
-		_dbUpgraderMockedStatic.when(
-			DBUpgrader::isUpgradeClient
+		_upgradeProcessUtilMockedStatic.when(
+			UpgradeProcessUtil::isUpgradeClient
 		).thenReturn(
 			true
 		);
@@ -121,8 +122,8 @@ public class IndexStatusManagerImplRequireIndexReadWriteTest {
 
 		Assert.assertTrue(indexStatusManagerImpl.isIndexReadOnly());
 
-		_dbUpgraderMockedStatic.when(
-			DBUpgrader::isUpgradeClient
+		_upgradeProcessUtilMockedStatic.when(
+			UpgradeProcessUtil::isUpgradeClient
 		).thenReturn(
 			false
 		);
@@ -132,8 +133,8 @@ public class IndexStatusManagerImplRequireIndexReadWriteTest {
 
 	@Test
 	public void testReadOnlyWhenIsUpgrading() {
-		_dbUpgraderMockedStatic.when(
-			DBUpgrader::isUpgradeClient
+		_upgradeProcessUtilMockedStatic.when(
+			UpgradeProcessUtil::isUpgradeClient
 		).thenReturn(
 			false
 		);
@@ -163,7 +164,7 @@ public class IndexStatusManagerImplRequireIndexReadWriteTest {
 	protected IndexStatusManagerImpl indexStatusManagerImpl =
 		new IndexStatusManagerImpl();
 
-	private MockedStatic<DBUpgrader> _dbUpgraderMockedStatic;
 	private MockedStatic<StartupHelperUtil> _startupHelperUtilMockedStatic;
+	private MockedStatic<UpgradeProcessUtil> _upgradeProcessUtilMockedStatic;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97840

## What Is Being Fixed

The `:apps:portal-search:portal-search:test` unit task has failed to compile since around May 18. An earlier commit migrated `IndexStatusManagerImpl` (and other call sites) from `DBUpgrader.isUpgradeClient()` to `UpgradeProcessUtil.isUpgradeClient()` and removed the delegate method from `DBUpgrader`, but left `IndexStatusManagerImplRequireIndexReadWriteTest` still referencing the removed `DBUpgrader::isUpgradeClient`. That invalid method reference broke `compileTestJava`, taking the whole module's unit test task down with a "testRun ... was not executed" failure.

## How It Is Being Fixed

The test now mocks the static method on its current owning class. The `DBUpgrader` import and static mock are replaced with `UpgradeProcessUtil`, the field is renamed `_upgradeProcessUtilMockedStatic` to match the sibling `_startupHelperUtilMockedStatic` convention, and the three `DBUpgrader::isUpgradeClient` method references become `UpgradeProcessUtil::isUpgradeClient`. There is no production code change; the test exercises the same method through its new class.

## Why Are There No Tests?

This PR is itself a test fix. It repairs an existing unit test that stopped compiling after an API migration, so no production behavior changed and no new coverage is warranted. The repaired test — all five methods of `IndexStatusManagerImplRequireIndexReadWriteTest` — is the coverage, and it now compiles and passes.

## PR Check

**pr-check: PASS** — tested on `5781a1a118932b680dc179bb09756f89f76ffddd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5781a1a118932b680dc179bb09756f89f76ffddd"} -->
