### PR TITLE
LPD-98006 Guard counter cleanup cast to avoid DB2 SQLCODE=-420

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess.java
@@ -361,9 +361,9 @@ public class CounterDataCleanupPreupgradeProcess
 
 		if (dbType == DBType.DB2) {
 			return StringBundler.concat(
-				"select max(cast(", columnName, " as bigint)) as ", columnName,
-				" from ", tableName, " where regexp_like(", columnName,
-				", '^[0-9]{1,18}$')");
+				"select max(cast(case when regexp_like(", columnName,
+				", '^[0-9]{1,18}$') then ", columnName, " end as bigint)) as ",
+				columnName, " from ", tableName);
 		}
 		else if ((dbType == DBType.MARIADB) || (dbType == DBType.MYSQL)) {
 			return StringBundler.concat(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98006

## What Is Being Fixed

The counter data cleanup preupgrade process fails on DB2 with `SQLCODE=-420` whenever a Liferay table holds a name or primary-key value that is non-numeric or exceeds the `bigint` range. The integration test `CounterDataCleanupPreupgradeProcessTest#testUpgradeDLFileEntrySpecificCounterFilters` fails only on the DB2 leg of the `ci:test:upgrade` routine; every other database passes.

The DB2 branch of `CounterDataCleanupPreupgradeProcess._getMaxValueSQL` filters non-numeric and overflowing names with a `WHERE` clause while casting the column to `bigint` in the same query:

```sql
select max(cast(name as bigint)) as name from DLFileEntry where regexp_like(name, '^[0-9]{1,18}$')
```

DB2 does not guarantee that the `WHERE` predicate is evaluated before the `CAST` in the projection, so the cast reaches a value the filter should have excluded (for example `non-numeric` or `99999999999999999999`) and throws. This is a regression from LPD-93239, which moved the maximum computation server-side; before that change every value was read and parsed in Java with `Long.parseLong` inside a `try`/`catch` for `NumberFormatException`, which was database-portable.

## How It Is Being Fixed

The numeric filter is moved into a `CASE` expression inside the cast so the cast only ever receives a value that already matches `^[0-9]{1,18}$`, or `NULL`:

```sql
select max(cast(case when regexp_like(name, '^[0-9]{1,18}$') then name end as bigint)) as name from DLFileEntry
```

Non-matching rows evaluate to `NULL`, which `max()` ignores, so the result is identical on valid data. Because the cast can no longer be applied to a non-numeric or overflowing string, the failure cannot occur regardless of how DB2 orders predicate and projection evaluation.

## Why Are There No Tests?

The scenario is already covered by the existing integration test `CounterDataCleanupPreupgradeProcessTest#testUpgradeDLFileEntrySpecificCounterFilters`, which seeds a valid numeric name alongside a non-numeric name and an overflowing name and asserts the counter is reset to the valid value. That test is exactly what surfaces this failure on the DB2 leg of the `ci:test:upgrade` routine, so no new test is warranted; the change is a DB2 SQL-portability fix validated by the existing test on DB2 in CI.

## PR Check

**pr-check: PASS** — tested on `454b4a6f8d1606781eb0e3eef4f31928d3d1e115`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "454b4a6f8d1606781eb0e3eef4f31928d3d1e115"} -->
