### PR TITLE
LPD-80594 Navigate to site when site is set even if toggle is present

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -83,16 +83,15 @@ definition {
 
 	@summary = "Default summary"
 	macro gotoPortlet(site = null, portlet = null, category = null) {
-		if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
+		if (isSet(site)) {
+			var siteNameURL = StringUtil.replace(${site}, " ", "-");
+
+			var siteNameURL = StringUtil.lowerCase(${siteNameURL});
+
+			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+		}
+		else if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});
-
-			if (isSet(site)) {
-				var siteNameURL = StringUtil.replace(${site}, " ", "-");
-
-				var siteNameURL = StringUtil.lowerCase(${siteNameURL});
-
-				Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
-			}
 		}
 
 		ProductMenuHelper.openProductMenu();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-80594

## What Is Being Fixed

`ProductMenu.macro#gotoPortlet` checked for the absence of the product menu toggle before navigating to the specified site URL. When the toggle was present, the site navigation step was skipped entirely, even when a `site` argument was passed. This caused `LocalFile.DatabasePartitioningUpgrade#ExportAndAddDBPartitionWithUpgradedDB` and `LocalFile.VirtualInstances#CanAddAndDeletePortalInstance` to fail because they never landed on the correct site context.

## How It Is Being Fixed

The condition order in `gotoPortlet` is flipped: `isSet(site)` is now the primary branch and navigates directly to the site URL regardless of the toggle. The toggle absence check becomes an else-if branch for the case where no site is specified but the toggle is missing — the fallback that calls `ApplicationsMenu.gotoSite`.

## PR Check

**pr-check: PASS** — tested on `616f51e134653e5c5c279b80cce728c2a6627f1f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "616f51e134653e5c5c279b80cce728c2a6627f1f"} -->
