### PR TITLE
LPD-96642 Add upgrade log assertion and portal-db-infrastructure smoke test

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -3571,7 +3571,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 
 							<trycatch property="exception.message">
 								<try>
-									<exec executable="/bin/bash" timeout="${test.class.playwright.setup.timeout}">
+									<exec executable="/bin/bash" failonerror="true" timeout="${test.class.playwright.setup.timeout}">
 										<arg value="modules/test/playwright/env/set_up.sh" />
 										<env key="APP_SERVER_TYPE" value="@{app.server.type}" />
 										<env key="DATABASE_TYPE" value="@{database.type}" />
@@ -3630,7 +3630,7 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 									</docker-execute>
 								</try>
 								<catch>
-									<echo>${exception.message}</echo>
+									<fail message="${exception.message}" />
 								</catch>
 								<finally>
 									<stop-docker-playwright />
@@ -3650,7 +3650,10 @@ ${poshi.runner.testsuite.testcase.name}</echo>
 									<split-testsuites-junit-report test.suites.report.filepath="${playwright.dir}/test-results/TEST-playwright.xml" />
 
 									<if>
-										<equals arg1="${playwright.project.name}" arg2="smoke" />
+										<or>
+											<equals arg1="${playwright.project.name}" arg2="smoke.main" />
+											<contains string="${playwright.project.name}" substring="upgrade" />
+										</or>
 										<then>
 											<ant dir="portal-kernel" inheritAll="false" target="test-class">
 												<property name="test.class" value="PortalLogAssertorTest" />

--- a/modules/test/playwright/env/common.sh
+++ b/modules/test/playwright/env/common.sh
@@ -1,5 +1,35 @@
 #!/bin/bash
 
+function assert_clean_upgrade_log {
+	if [ -z "${LIFERAY_HOME}" ]
+	then
+		echo "LIFERAY_HOME is not set."
+
+		exit 1
+	fi
+
+	local upgrade_log="${LIFERAY_HOME}/tools/portal-tools-db-upgrade-client/logs/upgrade.log"
+
+	if [ ! -f "${upgrade_log}" ]
+	then
+		echo "Unable to find upgrade log at ${upgrade_log}."
+
+		exit 1
+	fi
+
+	# WARN is excluded: EnvPropertiesUtil:54 emits a WARN on every clean upgrade run.
+	local upgrade_log_errors
+	upgrade_log_errors=$(grep -E "^[0-9]{4}-[0-9]{2}-[0-9]{2}[[:space:]]+[0-9]{2}:[0-9]{2}:[0-9]{2}([.,][0-9]{3})?[[:space:]]+(ERROR|FATAL)" "${upgrade_log}" || true)
+
+	if [ -n "${upgrade_log_errors}" ]
+	then
+		echo "Upgrade log contains ERROR or FATAL entries:"
+		printf "%s\n" "${upgrade_log_errors}"
+
+		exit 1
+	fi
+}
+
 function cluster_set_up {
 	default_set_up
 

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -155,6 +155,7 @@ import {config as osbFaroWebSettingsConfig} from './tests/osb-faro-web/settings/
 import {config as passwordPoliciesAdminWebFirstLoginConfig} from './tests/password-policies-admin-web/first-login/config';
 import {config as passwordPoliciesAdminWebConfig} from './tests/password-policies-admin-web/main/config';
 import {config as passwordPoliciesAdminWebSetupAdminConfig} from './tests/password-policies-admin-web/setup-admin/config';
+import {config as portalDbInfrastructureUpgradeConfig} from './tests/portal-db-infrastructure/upgrade/config';
 import {config as portalDefaultPermissionsWebConfig} from './tests/portal-default-permissions-web/main/config';
 import {config as portalImplMainConfig} from './tests/portal-impl/main/config';
 import {config as portalImplPortletConfig} from './tests/portal-impl/portlet/config';
@@ -395,6 +396,7 @@ export default defineConfig({
 		passwordPoliciesAdminWebConfig,
 		passwordPoliciesAdminWebFirstLoginConfig,
 		passwordPoliciesAdminWebSetupAdminConfig,
+		portalDbInfrastructureUpgradeConfig,
 		portalDefaultPermissionsWebConfig,
 		portalImplMainConfig,
 		portalImplPortletConfig,

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/config.ts
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-db-infrastructure.upgrade',
+	testDir: 'tests/portal-db-infrastructure/upgrade',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/portal-ext.properties
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/portal-ext.properties
@@ -1,0 +1,1 @@
+index.on.startup=true

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/set_up.sh
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/env/set_up.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+CURRENT_DIR_NAME=$(dirname "${BASH_SOURCE[0]}")
 
-echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
+echo "CURRENT_DIR_NAME=${CURRENT_DIR_NAME}"
 
-source ${CURRENT_DIR_NAME}/../../../../env/common.sh
+source "${CURRENT_DIR_NAME}/../../../../env/common.sh"
 
-DATA_ARCHIVE_TYPE="data-archive-object"
-PORTAL_VERSION="7.4.13.u33"
+DATA_ARCHIVE_TYPE="data-archive-portal"
+PORTAL_VERSION="6.2.5"
 
 function main {
 	set -ex
@@ -15,9 +15,9 @@ function main {
 	cd "${_PORTAL_PROJECT_DIR}"
 
 	ant -f build-test.xml \
-		-Ddata.archive.type=${DATA_ARCHIVE_TYPE} \
+		-Ddata.archive.type="${DATA_ARCHIVE_TYPE}" \
 		-Dkeep.cached.app.server.data=true \
-		-Dportal.version=${PORTAL_VERSION} \
+		-Dportal.version="${PORTAL_VERSION}" \
 		-Dskip.get.testcase.database.properties=true \
 		rebuild-legacy-database
 

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/portalSmokeUpgrade.spec.ts
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/portalSmokeUpgrade.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test as baseTest, Page, expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+
+const test = mergeTests(loginTest());
+
+const ARCHIVE_USER_EMAIL = 'user@liferay.com';
+const ARCHIVE_USER_PASSWORD = 'test';
+
+async function viewUpgradedPortalContent(page: Page) {
+	await test.step('View web content after upgrade', async () => {
+		await page.goto('/web/guest/web-content');
+
+		await expect(
+			page.getByText('Web Content Title', {exact: true})
+		).toBeVisible();
+
+		await expect(
+			page.getByText('Web Content Content', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View document after upgrade', async () => {
+		await page.goto('/web/guest/document');
+
+		await expect(page.getByText('Document1', {exact: true})).toBeVisible();
+	});
+
+	await test.step('View message boards after upgrade', async () => {
+		await page.goto('/web/guest/message-boards');
+
+		await expect(
+			page.getByText('Message Boards Subject', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View wiki after upgrade', async () => {
+		await page.goto('/web/guest/wiki');
+
+		await expect(
+			page.getByText('Wiki Front Page Content', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View blogs after upgrade', async () => {
+		await page.goto('/web/guest/blogs');
+
+		await expect(
+			page.getByText('Blogs Entry Title', {exact: true})
+		).toBeVisible();
+
+		await expect(
+			page.getByText('Blogs Entry Content', {exact: true})
+		).toBeVisible();
+	});
+
+	await test.step('View site page after upgrade', async () => {
+		await page.goto('/web/site-name/site-page');
+
+		await expect(page).toHaveTitle(/Site Page/);
+	});
+}
+
+test.describe.serial('View portal smoke upgrade', () => {
+	test(
+		'Can view upgraded portal content as admin',
+		{tag: '@LPD-96642'},
+		async ({page}) => {
+			await viewUpgradedPortalContent(page);
+		}
+	);
+
+	baseTest(
+		'Can view upgraded portal content as regular user',
+		{tag: '@LPD-96642'},
+		async ({page}) => {
+			await page.goto('/c/portal/login');
+
+			await page.getByLabel('Email Address').fill(ARCHIVE_USER_EMAIL);
+
+			await page.getByLabel('Password').fill(ARCHIVE_USER_PASSWORD);
+
+			await page.getByRole('button', {name: 'Sign In'}).click();
+
+			await expect(page).toHaveURL(/\/web\/guest/);
+
+			await viewUpgradedPortalContent(page);
+		}
+	);
+});

--- a/modules/test/playwright/tests/portal-db-infrastructure/upgrade/test.properties
+++ b/modules/test/playwright/tests/portal-db-infrastructure/upgrade/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Database Upgrade Framework


### PR DESCRIPTION
## Summary

- Adds `failonerror="true"` to the `set_up.sh` exec, promotes the `<catch>` block from `<echo>` to `<fail>`, and expands the CI gate condition to include `smoke.main` and any `upgrade`-prefixed project (`build-test-batch.xml`)
- Adds `assert_clean_upgrade_log` to `common.sh` — scans the upgrade client log for ERROR/FATAL entries and exits non-zero if any are found; WARN is excluded because `EnvPropertiesUtil` emits a WARN on every clean run
- Adds the `portal-db-infrastructure` upgrade Playwright project: rebuilds a 6.2.5 legacy database, runs the upgrade tool, asserts a clean upgrade log, then verifies six content types (web content, document, message boards, wiki, blogs, site page) as admin and as a legacy archive user

## Test plan

- [ ] `cd modules/test/playwright && yarn test tests/portal-db-infrastructure/upgrade/portalSmokeUpgrade.spec.ts`