### PR TITLE
LPD-92610 Return 403 instead of 401 when the caller lacks the role

### DIFF
--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/InstanceConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/InstanceConfigurationResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
@@ -31,7 +32,6 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import jakarta.validation.ValidationException;
 
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.Response;
@@ -215,14 +215,14 @@ public class InstanceConfigurationResourceImpl
 		}
 	}
 
-	private void _checkPermission() {
+	private void _checkPermission() throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
 		if (!permissionChecker.isCompanyAdmin() &&
 			!permissionChecker.isOmniadmin()) {
 
-			throw new NotAuthorizedException(Response.Status.UNAUTHORIZED);
+			throw new PrincipalException.MustBeCompanyAdmin(permissionChecker);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SiteConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SiteConfigurationResourceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -35,7 +36,6 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import jakarta.validation.ValidationException;
 
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.Response;
@@ -243,7 +243,7 @@ public class SiteConfigurationResourceImpl
 		}
 	}
 
-	private void _checkPermission(long groupId) {
+	private void _checkPermission(long groupId) throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
@@ -251,7 +251,9 @@ public class SiteConfigurationResourceImpl
 			!permissionChecker.isGroupAdmin(groupId) &&
 			!permissionChecker.isOmniadmin()) {
 
-			throw new NotAuthorizedException(Response.Status.UNAUTHORIZED);
+			throw new PrincipalException.MustHavePermission(
+				permissionChecker, Group.class.getName(), groupId,
+				ActionKeys.UPDATE);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SystemConfigurationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-impl/src/main/java/com/liferay/headless/admin/configuration/internal/resource/v1_0/SystemConfigurationResourceImpl.java
@@ -19,6 +19,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
@@ -32,7 +33,6 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import jakarta.validation.ValidationException;
 
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.ServerErrorException;
 import jakarta.ws.rs.core.Response;
@@ -219,12 +219,12 @@ public class SystemConfigurationResourceImpl
 		}
 	}
 
-	private void _checkPermission() {
+	private void _checkPermission() throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
 		if (!permissionChecker.isOmniadmin()) {
-			throw new NotAuthorizedException(Response.Status.UNAUTHORIZED);
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/InstanceConfigurationResourceTest.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/InstanceConfigurationResourceTest.java
@@ -10,12 +10,18 @@ import com.liferay.headless.admin.configuration.client.dto.v1_0.InstanceConfigur
 import com.liferay.headless.admin.configuration.client.pagination.Page;
 import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
+import com.liferay.headless.admin.configuration.client.resource.v1_0.InstanceConfigurationResource;
 import com.liferay.headless.admin.configuration.test.configuration.TestConfiguration;
 import com.liferay.headless.admin.configuration.test.configuration.TestFactoryConfiguration;
 import com.liferay.headless.admin.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -28,6 +34,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,12 +68,34 @@ public class InstanceConfigurationResourceTest
 		}
 	}
 
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userInstanceConfigurationResource =
+			InstanceConfigurationResource.builder(
+			).authentication(
+				user.getEmailAddress(), password
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+	}
+
 	@Override
 	@Test
 	public void testGetInstanceConfiguration() throws Exception {
 		super.testGetInstanceConfiguration();
 
 		_testGetInstanceConfigurationFromConfigurationScreen();
+		_testGetInstanceConfigurationWithoutPermission();
 		_testGetInstanceConfigurationWithPasswordKey();
 	}
 
@@ -143,6 +172,8 @@ public class InstanceConfigurationResourceTest
 
 		assertEquals(randomInstanceConfiguration, getInstanceConfiguration);
 		assertValid(getInstanceConfiguration);
+
+		_testPutInstanceConfigurationWithoutPermission();
 	}
 
 	@Override
@@ -256,6 +287,22 @@ public class InstanceConfigurationResourceTest
 		assertValid(getInstanceConfiguration);
 	}
 
+	private void _testGetInstanceConfigurationWithoutPermission()
+		throws Exception {
+
+		try {
+			_userInstanceConfigurationResource.getInstanceConfiguration(
+				ConfigurationTestUtil.TEST_CONFIGURATION_PID);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+		}
+	}
+
 	private void _testGetInstanceConfigurationWithPasswordKey()
 		throws Exception {
 
@@ -285,10 +332,32 @@ public class InstanceConfigurationResourceTest
 		Assert.assertNull(properties.get("passwordStringKey"));
 	}
 
+	private void _testPutInstanceConfigurationWithoutPermission()
+		throws Exception {
+
+		InstanceConfiguration instanceConfiguration =
+			randomInstanceConfiguration();
+
+		try {
+			_userInstanceConfigurationResource.putInstanceConfiguration(
+				instanceConfiguration.getExternalReferenceCode(),
+				instanceConfiguration);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
 	private static final List<SafeCloseable> _safeCloseables =
 		new ArrayList<>();
 
 	@Inject
 	private static SettingsLocatorHelper _settingsLocatorHelper;
+
+	private InstanceConfigurationResource _userInstanceConfigurationResource;
 
 }

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/SiteConfigurationResourceTest.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/SiteConfigurationResourceTest.java
@@ -8,13 +8,19 @@ package com.liferay.headless.admin.configuration.resource.v1_0.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.configuration.client.dto.v1_0.SiteConfiguration;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
+import com.liferay.headless.admin.configuration.client.resource.v1_0.SiteConfigurationResource;
 import com.liferay.headless.admin.configuration.test.configuration.TestConfiguration;
 import com.liferay.headless.admin.configuration.test.configuration.TestFactoryConfiguration;
 import com.liferay.headless.admin.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -27,6 +33,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,12 +67,33 @@ public class SiteConfigurationResourceTest
 		}
 	}
 
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userSiteConfigurationResource = SiteConfigurationResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	@Override
 	@Test
 	public void testGetSiteSiteConfiguration() throws Exception {
 		super.testGetSiteSiteConfiguration();
 
 		_testGetSiteSiteConfigurationFromConfigurationScreen();
+		_testGetSiteSiteConfigurationWithoutPermission();
 		_testGetSiteSiteConfigurationWithPasswordKey();
 	}
 
@@ -114,6 +142,8 @@ public class SiteConfigurationResourceTest
 
 		assertEquals(randomSiteConfiguration, getSiteConfiguration);
 		assertValid(getSiteConfiguration);
+
+		_testPutSiteSiteConfigurationWithoutPermission();
 	}
 
 	@Override
@@ -217,6 +247,23 @@ public class SiteConfigurationResourceTest
 		assertValid(getSiteConfiguration);
 	}
 
+	private void _testGetSiteSiteConfigurationWithoutPermission()
+		throws Exception {
+
+		try {
+			_userSiteConfigurationResource.getSiteSiteConfiguration(
+				testGroup.getExternalReferenceCode(),
+				ConfigurationTestUtil.TEST_CONFIGURATION_PID);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+		}
+	}
+
 	private void _testGetSiteSiteConfigurationWithPasswordKey()
 		throws Exception {
 
@@ -246,10 +293,32 @@ public class SiteConfigurationResourceTest
 		Assert.assertNull(properties.get("passwordStringKey"));
 	}
 
+	private void _testPutSiteSiteConfigurationWithoutPermission()
+		throws Exception {
+
+		SiteConfiguration siteConfiguration = randomSiteConfiguration();
+
+		try {
+			_userSiteConfigurationResource.putSiteSiteConfiguration(
+				testGroup.getExternalReferenceCode(),
+				siteConfiguration.getExternalReferenceCode(),
+				siteConfiguration);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
 	private static final List<SafeCloseable> _safeCloseables =
 		new ArrayList<>();
 
 	@Inject
 	private static SettingsLocatorHelper _settingsLocatorHelper;
+
+	private SiteConfigurationResource _userSiteConfigurationResource;
 
 }

--- a/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/SystemConfigurationResourceTest.java
+++ b/modules/apps/headless/headless-admin-configuration/headless-admin-configuration-test/src/testIntegration/java/com/liferay/headless/admin/configuration/resource/v1_0/test/SystemConfigurationResourceTest.java
@@ -10,12 +10,18 @@ import com.liferay.headless.admin.configuration.client.dto.v1_0.SystemConfigurat
 import com.liferay.headless.admin.configuration.client.pagination.Page;
 import com.liferay.headless.admin.configuration.client.pagination.Pagination;
 import com.liferay.headless.admin.configuration.client.problem.Problem;
+import com.liferay.headless.admin.configuration.client.resource.v1_0.SystemConfigurationResource;
 import com.liferay.headless.admin.configuration.test.configuration.TestConfiguration;
 import com.liferay.headless.admin.configuration.test.configuration.TestFactoryConfiguration;
 import com.liferay.headless.admin.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.settings.SettingsLocatorHelper;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -28,6 +34,7 @@ import java.util.Map;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,12 +68,33 @@ public class SystemConfigurationResourceTest
 		}
 	}
 
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		String password = RandomTestUtil.randomString();
+
+		User user = UserTestUtil.addUser(testCompany, password);
+
+		_userSystemConfigurationResource = SystemConfigurationResource.builder(
+		).authentication(
+			user.getEmailAddress(), password
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
 	@Override
 	@Test
 	public void testGetSystemConfiguration() throws Exception {
 		super.testGetSystemConfiguration();
 
 		_testGetSystemConfigurationFromConfigurationScreen();
+		_testGetSystemConfigurationWithoutPermission();
 		_testGetSystemConfigurationWithPasswordKey();
 	}
 
@@ -140,6 +168,8 @@ public class SystemConfigurationResourceTest
 
 		assertEquals(randomSystemConfiguration, getSystemConfiguration);
 		assertValid(getSystemConfiguration);
+
+		_testPutSystemConfigurationWithoutPermission();
 	}
 
 	@Override
@@ -248,6 +278,22 @@ public class SystemConfigurationResourceTest
 		assertValid(getSystemConfiguration);
 	}
 
+	private void _testGetSystemConfigurationWithoutPermission()
+		throws Exception {
+
+		try {
+			_userSystemConfigurationResource.getSystemConfiguration(
+				ConfigurationTestUtil.TEST_CONFIGURATION_PID);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+		}
+	}
+
 	private void _testGetSystemConfigurationWithPasswordKey() throws Exception {
 		PropsUtil.set(
 			PropsKeys.MODULE_FRAMEWORK_EXPORT_PASSWORD_ATTRIBUTES, "true");
@@ -275,10 +321,31 @@ public class SystemConfigurationResourceTest
 		Assert.assertNull(properties.get("passwordStringKey"));
 	}
 
+	private void _testPutSystemConfigurationWithoutPermission()
+		throws Exception {
+
+		SystemConfiguration systemConfiguration = randomSystemConfiguration();
+
+		try {
+			_userSystemConfigurationResource.putSystemConfiguration(
+				systemConfiguration.getExternalReferenceCode(),
+				systemConfiguration);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
+		}
+	}
+
 	private static final List<SafeCloseable> _safeCloseables =
 		new ArrayList<>();
 
 	@Inject
 	private static SettingsLocatorHelper _settingsLocatorHelper;
+
+	private SystemConfigurationResource _userSystemConfigurationResource;
 
 }

--- a/modules/apps/headless/headless-admin-server/headless-admin-server-impl/src/main/java/com/liferay/headless/admin/server/internal/resource/v1_0/DatabaseSchemaExportResourceImpl.java
+++ b/modules/apps/headless/headless-admin-server/headless-admin-server-impl/src/main/java/com/liferay/headless/admin/server/internal/resource/v1_0/DatabaseSchemaExportResourceImpl.java
@@ -12,13 +12,12 @@ import com.liferay.portal.db.migration.schema.exporter.DBMigrationSchemaExportRe
 import com.liferay.portal.db.migration.schema.exporter.DBMigrationSchemaExporter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.BadRequestException;
-import jakarta.ws.rs.NotAuthorizedException;
-import jakarta.ws.rs.core.Response;
 
 import java.io.IOException;
 
@@ -85,12 +84,12 @@ public class DatabaseSchemaExportResourceImpl
 		return resultDatabaseSchemaExport;
 	}
 
-	private void _checkPermission() {
+	private void _checkPermission() throws Exception {
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
 		if (!permissionChecker.isOmniadmin()) {
-			throw new NotAuthorizedException(Response.Status.UNAUTHORIZED);
+			throw new PrincipalException.MustBeOmniadmin(permissionChecker);
 		}
 	}
 

--- a/modules/apps/headless/headless-admin-server/headless-admin-server-test/src/testIntegration/java/com/liferay/headless/admin/server/resource/v1_0/test/DatabaseSchemaExportResourceTest.java
+++ b/modules/apps/headless/headless-admin-server/headless-admin-server-test/src/testIntegration/java/com/liferay/headless/admin/server/resource/v1_0/test/DatabaseSchemaExportResourceTest.java
@@ -123,11 +123,7 @@ public class DatabaseSchemaExportResourceTest
 				LocaleUtil.getDefault()
 			).build();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				"com.liferay.portal.vulcan.internal.jaxrs.exception.mapper." +
-					"WebApplicationExceptionMapper",
-				LoggerTestUtil.ERROR)) {
-
+		try {
 			userDatabaseSchemaExportResource.postDatabaseSchemaExport(
 				new DatabaseSchemaExport() {
 					{
@@ -141,7 +137,7 @@ public class DatabaseSchemaExportResourceTest
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals("UNAUTHORIZED", problem.getStatus());
+			Assert.assertEquals("FORBIDDEN", problem.getStatus());
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92610

## What Is Being Fixed

Four headless resource endpoints — the system, instance, and site configuration resources and the database schema export resource — rejected an authenticated user who lacked the required administrator role by throwing `NotAuthorizedException`, which maps to HTTP 401 (Unauthorized). A 401 signals that the caller is not authenticated, but these callers are authenticated and simply lack the privilege, so the response was misleading. The correct signal is 403 (Forbidden).

## How It Is Being Fixed

Each `_checkPermission` guard now throws the `PrincipalException` subclass that matches the privilege it enforces: `MustBeOmniadmin` where the guard is omniadmin-only (system configuration and database schema export), `MustBeCompanyAdmin` where a company administrator is also allowed (instance configuration), and `MustHavePermission` on the site's `Group` with the `UPDATE` action where a company or site administrator is allowed (site configuration). Vulcan's `PrincipalExceptionMapper` turns any of these into 403 on writes and 404 on GET reads, the latter keeping with the portal convention of not revealing a resource to a caller who cannot access it. Because `PrincipalException` is a checked exception (unlike the previous `NotAuthorizedException`), each `_checkPermission` now declares `throws Exception`. Integration coverage was added to all four resource tests, asserting 403 on writes and 404 on reads for a non-administrator user.

## PR Check

**pr-check: PASS** — tested on `1700b0e1063698c3d2062f5f64e72a1a7b3d22a1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "1700b0e1063698c3d2062f5f64e72a1a7b3d22a1"} -->
