### PR TITLE
LPD-98573 Reserve upgrade connections and serialize class-name cleanup

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -9,6 +9,7 @@ import com.liferay.data.cleanup.internal.verify.util.PostUpgradeDataCleanupProce
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
@@ -90,129 +91,129 @@ public class ClassNamePostUpgradeDataCleanupProcess
 			tableNames.add(tableName);
 		}
 
-		processConcurrently(
-			classNames.toArray(new ClassName[0]),
-			className -> {
-				String value = className.getValue();
+		UnsafeConsumer<ClassName, Exception> unsafeConsumer = className -> {
+			String value = className.getValue();
 
-				if (!value.startsWith("com.liferay.")) {
+			if (!value.startsWith("com.liferay.")) {
+				return;
+			}
+
+			if (StringUtil.startsWith(
+					value,
+					ObjectDefinitionConstants.
+						CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION)) {
+
+				AtomicReference<ObjectDefinition> objectDefinition =
+					new AtomicReference<>();
+
+				String finalValue = value;
+
+				_companyLocalService.forEachCompanyId(
+					companyId -> {
+						if (objectDefinition.get() != null) {
+							return;
+						}
+
+						objectDefinition.set(
+							_objectDefinitionLocalService.
+								fetchObjectDefinitionByClassName(
+									companyId, finalValue));
+					});
+
+				if (objectDefinition.get() != null) {
 					return;
 				}
+			}
 
-				if (StringUtil.startsWith(
-						value,
-						ObjectDefinitionConstants.
-							CLASS_NAME_PREFIX_CUSTOM_OBJECT_DEFINITION)) {
+			int index = value.indexOf(StringPool.DASH);
 
-					AtomicReference<ObjectDefinition> objectDefinition =
-						new AtomicReference<>();
+			if ((index != -1) &&
+				StringUtil.startsWith(value, Layout.class.getName())) {
 
-					String finalValue = value;
+				value = value.substring(0, index);
+			}
 
-					_companyLocalService.forEachCompanyId(
-						companyId -> {
-							if (objectDefinition.get() != null) {
-								return;
-							}
+			boolean missingClass = false;
 
-							objectDefinition.set(
-								_objectDefinitionLocalService.
-									fetchObjectDefinitionByClassName(
-										companyId, finalValue));
-						});
+			for (String currentValue : value.split("[-_]")) {
+				if (models.contains(currentValue)) {
+					continue;
+				}
 
-					if (objectDefinition.get() != null) {
+				Class<?> clazz = null;
+
+				for (Bundle bundle : bundleContext.getBundles()) {
+					try {
+						clazz = bundle.loadClass(currentValue);
+
+						break;
+					}
+					catch (ClassNotFoundException classNotFoundException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(classNotFoundException);
+						}
+					}
+					catch (Exception exception) {
+						_log.error(exception);
+
 						return;
 					}
 				}
 
-				int index = value.indexOf(StringPool.DASH);
+				if (clazz == null) {
+					missingClass = true;
 
-				if ((index != -1) &&
-					StringUtil.startsWith(value, Layout.class.getName())) {
-
-					value = value.substring(0, index);
+					break;
 				}
+			}
 
-				boolean missingClass = false;
+			if (!missingClass) {
+				return;
+			}
 
-				for (String currentValue : value.split("[-_]")) {
-					if (models.contains(currentValue)) {
-						continue;
-					}
+			Set<String> usedTableNames = new HashSet<>();
 
-					Class<?> clazz = null;
+			for (String tableName : tableNames) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select 1 from " + tableName +
+								" where classNameId = ?")) {
 
-					for (Bundle bundle : bundleContext.getBundles()) {
-						try {
-							clazz = bundle.loadClass(currentValue);
+					preparedStatement.setLong(1, className.getClassNameId());
 
-							break;
-						}
-						catch (ClassNotFoundException classNotFoundException) {
-							if (_log.isDebugEnabled()) {
-								_log.debug(classNotFoundException);
-							}
-						}
-						catch (Exception exception) {
-							_log.error(exception);
+					try (ResultSet resultSet =
+							preparedStatement.executeQuery()) {
 
-							return;
-						}
-					}
-
-					if (clazz == null) {
-						missingClass = true;
-
-						break;
-					}
-				}
-
-				if (!missingClass) {
-					return;
-				}
-
-				Set<String> usedTableNames = new HashSet<>();
-
-				for (String tableName : tableNames) {
-					try (PreparedStatement preparedStatement =
-							connection.prepareStatement(
-								"select 1 from " + tableName +
-									" where classNameId = ?")) {
-
-						preparedStatement.setLong(
-							1, className.getClassNameId());
-
-						try (ResultSet resultSet =
-								preparedStatement.executeQuery()) {
-
-							if (resultSet.next()) {
-								usedTableNames.add(tableName);
-							}
+						if (resultSet.next()) {
+							usedTableNames.add(tableName);
 						}
 					}
 				}
+			}
 
-				if (usedTableNames.isEmpty()) {
-					_classNameLocalService.deleteClassName(className);
+			if (usedTableNames.isEmpty()) {
+				_classNameLocalService.deleteClassName(className);
 
-					DataCleanupLoggingUtil.logDelete(
-						_log, 1, dbInspector.normalizeName("ClassName_"),
-						StringBundler.concat(
-							"\"", value,
-							"\" is not defined in any deployed module and is ",
-							"not in use"));
-				}
-				else if (_log.isWarnEnabled()) {
-					_log.warn(
-						StringBundler.concat(
-							"Class name ", value,
-							" is not defined in any deployed module but is ",
-							"referenced in the next tables: ",
-							String.join(", ", new TreeSet<>(usedTableNames))));
-				}
-			},
-			null);
+				DataCleanupLoggingUtil.logDelete(
+					_log, 1, dbInspector.normalizeName("ClassName_"),
+					StringBundler.concat(
+						"\"", value,
+						"\" is not defined in any deployed module and is not ",
+						"in use"));
+			}
+			else if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Class name ", value,
+						" is not defined in any deployed module but is ",
+						"referenced in the next tables: ",
+						String.join(", ", new TreeSet<>(usedTableNames))));
+			}
+		};
+
+		for (ClassName className : classNames) {
+			unsafeConsumer.accept(className);
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/src/com/liferay/portal/kernel/db/UpgradeExecutorServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/UpgradeExecutorServiceUtil.java
@@ -64,9 +64,10 @@ public class UpgradeExecutorServiceUtil {
 		return threadPoolExecutor;
 	}
 
+	private static final int _RESERVED_CONNECTION_COUNT = 4;
+
 	private static final DCLSingleton<ExecutorService>
 		_dataExecutorServiceDCLSingleton = new DCLSingleton<>();
-	private static final int _RESERVED_CONNECTION_COUNT = 4;
 	private static final DCLSingleton<ExecutorService>
 		_schemaExecutorServiceDCLSingleton = new DCLSingleton<>();
 

--- a/portal-kernel/src/com/liferay/portal/kernel/db/UpgradeExecutorServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/db/UpgradeExecutorServiceUtil.java
@@ -30,7 +30,8 @@ public class UpgradeExecutorServiceUtil {
 		int jdbcDefaultMaximumPoolSize = GetterUtil.getInteger(
 			PropsUtil.get("jdbc.default.maximumPoolSize"));
 
-		return Math.max(1, (int)(0.9 * jdbcDefaultMaximumPoolSize));
+		return Math.max(
+			1, (jdbcDefaultMaximumPoolSize - _RESERVED_CONNECTION_COUNT) / 2);
 	}
 
 	public static ExecutorService getSchemaExecutorService() {
@@ -65,6 +66,7 @@ public class UpgradeExecutorServiceUtil {
 
 	private static final DCLSingleton<ExecutorService>
 		_dataExecutorServiceDCLSingleton = new DCLSingleton<>();
+	private static final int _RESERVED_CONNECTION_COUNT = 4;
 	private static final DCLSingleton<ExecutorService>
 		_schemaExecutorServiceDCLSingleton = new DCLSingleton<>();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98573

## What Is Being Fixed

Two concurrency problems during a database upgrade. First, the upgrade data executor sized its worker pool at 0.9 × jdbc.default.maximumPoolSize, so its workers held almost the entire connection pool; when a worker then called the counter or another local service — which needs an additional connection — none was available and the upgrade deadlocked. Second, ClassNamePostUpgradeDataCleanupProcess resolved class names concurrently by iterating the OSGi bundles and calling bundle.loadClass across worker threads, hitting OSGi classloading concurrency problems.

## How It Is Being Fixed

UpgradeExecutorServiceUtil now sizes the data executor at (jdbc.default.maximumPoolSize - 4) / 2, reserving connection-pool headroom so a worker's counter or local-service call can always obtain a connection, and reducing the worker count. ClassNamePostUpgradeDataCleanupProcess now resolves class names in a serial loop instead of processConcurrently, so the OSGi classloading runs on a single thread.

## Why Are There No Tests?

Both changes address upgrade-runtime concurrency that only manifests against a live OSGi runtime under concurrent upgrade load — a connection-pool-exhaustion deadlock and OSGi classloading contention across worker threads — neither reproducible in a focused unit test; the existing data-cleanup and upgrade integration suites exercise the affected processes.

## PR Check

**pr-check: PASS** — tested on `91f4ac542933e23506f190e56a87a3aad9703152`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "91f4ac542933e23506f190e56a87a3aad9703152"} -->
