### PR TITLE
LPD-92617 Return the source company ID from the export response

### DIFF
--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/dto/v1_0/PortalInstanceExport.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-api/src/main/java/com/liferay/headless/portal/instances/dto/v1_0/PortalInstanceExport.java
@@ -99,31 +99,31 @@ public class PortalInstanceExport implements Serializable {
 	private Supplier<String> _exportedPartitionNameSupplier;
 
 	@io.swagger.v3.oas.annotations.media.Schema(
-		description = "The name of the source partition that was exported (e.g., lpartition_12345)."
+		description = "The ID of the source company that was exported (e.g., 12345)."
 	)
-	public String getSourcePartitionName() {
-		if (_sourcePartitionNameSupplier != null) {
-			sourcePartitionName = _sourcePartitionNameSupplier.get();
+	public Long getSourceCompanyId() {
+		if (_sourceCompanyIdSupplier != null) {
+			sourceCompanyId = _sourceCompanyIdSupplier.get();
 
-			_sourcePartitionNameSupplier = null;
+			_sourceCompanyIdSupplier = null;
 		}
 
-		return sourcePartitionName;
+		return sourceCompanyId;
 	}
 
-	public void setSourcePartitionName(String sourcePartitionName) {
-		this.sourcePartitionName = sourcePartitionName;
+	public void setSourceCompanyId(Long sourceCompanyId) {
+		this.sourceCompanyId = sourceCompanyId;
 
-		_sourcePartitionNameSupplier = null;
+		_sourceCompanyIdSupplier = null;
 	}
 
 	@JsonIgnore
-	public void setSourcePartitionName(
-		UnsafeSupplier<String, Exception> sourcePartitionNameUnsafeSupplier) {
+	public void setSourceCompanyId(
+		UnsafeSupplier<Long, Exception> sourceCompanyIdUnsafeSupplier) {
 
-		_sourcePartitionNameSupplier = () -> {
+		_sourceCompanyIdSupplier = () -> {
 			try {
-				return sourcePartitionNameUnsafeSupplier.get();
+				return sourceCompanyIdUnsafeSupplier.get();
 			}
 			catch (RuntimeException runtimeException) {
 				throw runtimeException;
@@ -135,13 +135,13 @@ public class PortalInstanceExport implements Serializable {
 	}
 
 	@GraphQLField(
-		description = "The name of the source partition that was exported (e.g., lpartition_12345)."
+		description = "The ID of the source company that was exported (e.g., 12345)."
 	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected String sourcePartitionName;
+	protected Long sourceCompanyId;
 
 	@JsonIgnore
-	private Supplier<String> _sourcePartitionNameSupplier;
+	private Supplier<Long> _sourceCompanyIdSupplier;
 
 	@Override
 	public boolean equals(Object object) {
@@ -187,20 +187,16 @@ public class PortalInstanceExport implements Serializable {
 			sb.append("\"");
 		}
 
-		String sourcePartitionName = getSourcePartitionName();
+		Long sourceCompanyId = getSourceCompanyId();
 
-		if (sourcePartitionName != null) {
+		if (sourceCompanyId != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"sourcePartitionName\": ");
+			sb.append("\"sourceCompanyId\": ");
 
-			sb.append("\"");
-
-			sb.append(_escape(sourcePartitionName));
-
-			sb.append("\"");
+			sb.append(sourceCompanyId);
 		}
 
 		sb.append("}");
@@ -304,4 +300,4 @@ public class PortalInstanceExport implements Serializable {
 	private Map<String, Serializable> _extendedProperties;
 
 }
-// LIFERAY-REST-BUILDER-HASH:1269064002
+// LIFERAY-REST-BUILDER-HASH:1945410648

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/dto/v1_0/PortalInstanceExport.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/dto/v1_0/PortalInstanceExport.java
@@ -46,26 +46,26 @@ public class PortalInstanceExport implements Cloneable, Serializable {
 
 	protected String exportedPartitionName;
 
-	public String getSourcePartitionName() {
-		return sourcePartitionName;
+	public Long getSourceCompanyId() {
+		return sourceCompanyId;
 	}
 
-	public void setSourcePartitionName(String sourcePartitionName) {
-		this.sourcePartitionName = sourcePartitionName;
+	public void setSourceCompanyId(Long sourceCompanyId) {
+		this.sourceCompanyId = sourceCompanyId;
 	}
 
-	public void setSourcePartitionName(
-		UnsafeSupplier<String, Exception> sourcePartitionNameUnsafeSupplier) {
+	public void setSourceCompanyId(
+		UnsafeSupplier<Long, Exception> sourceCompanyIdUnsafeSupplier) {
 
 		try {
-			sourcePartitionName = sourcePartitionNameUnsafeSupplier.get();
+			sourceCompanyId = sourceCompanyIdUnsafeSupplier.get();
 		}
 		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 	}
 
-	protected String sourcePartitionName;
+	protected Long sourceCompanyId;
 
 	@Override
 	public PortalInstanceExport clone() throws CloneNotSupportedException {
@@ -100,4 +100,4 @@ public class PortalInstanceExport implements Cloneable, Serializable {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-48228477
+// LIFERAY-REST-BUILDER-HASH:375632592

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/serdes/v1_0/PortalInstanceExportSerDes.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-client/src/main/java/com/liferay/headless/portal/instances/client/serdes/v1_0/PortalInstanceExportSerDes.java
@@ -60,18 +60,14 @@ public class PortalInstanceExportSerDes {
 			sb.append("\"");
 		}
 
-		if (portalInstanceExport.getSourcePartitionName() != null) {
+		if (portalInstanceExport.getSourceCompanyId() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"sourcePartitionName\": ");
+			sb.append("\"sourceCompanyId\": ");
 
-			sb.append("\"");
-
-			sb.append(_escape(portalInstanceExport.getSourcePartitionName()));
-
-			sb.append("\"");
+			sb.append(portalInstanceExport.getSourceCompanyId());
 		}
 
 		sb.append("}");
@@ -105,13 +101,13 @@ public class PortalInstanceExportSerDes {
 					portalInstanceExport.getExportedPartitionName()));
 		}
 
-		if (portalInstanceExport.getSourcePartitionName() == null) {
-			map.put("sourcePartitionName", null);
+		if (portalInstanceExport.getSourceCompanyId() == null) {
+			map.put("sourceCompanyId", null);
 		}
 		else {
 			map.put(
-				"sourcePartitionName",
-				String.valueOf(portalInstanceExport.getSourcePartitionName()));
+				"sourceCompanyId",
+				String.valueOf(portalInstanceExport.getSourceCompanyId()));
 		}
 
 		return map;
@@ -135,9 +131,7 @@ public class PortalInstanceExportSerDes {
 			if (Objects.equals(jsonParserFieldName, "exportedPartitionName")) {
 				return false;
 			}
-			else if (Objects.equals(
-						jsonParserFieldName, "sourcePartitionName")) {
-
+			else if (Objects.equals(jsonParserFieldName, "sourceCompanyId")) {
 				return false;
 			}
 
@@ -155,12 +149,10 @@ public class PortalInstanceExportSerDes {
 						(String)jsonParserFieldValue);
 				}
 			}
-			else if (Objects.equals(
-						jsonParserFieldName, "sourcePartitionName")) {
-
+			else if (Objects.equals(jsonParserFieldName, "sourceCompanyId")) {
 				if (jsonParserFieldValue != null) {
-					portalInstanceExport.setSourcePartitionName(
-						(String)jsonParserFieldValue);
+					portalInstanceExport.setSourceCompanyId(
+						Long.valueOf((String)jsonParserFieldValue));
 				}
 			}
 		}
@@ -244,4 +236,4 @@ public class PortalInstanceExportSerDes {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:650498961
+// LIFERAY-REST-BUILDER-HASH:2131645718

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/rest-openapi.yaml
@@ -61,10 +61,11 @@ components:
                     description:
                         The name of the schema created by the export (e.g., lexported_12345).
                     type: string
-                sourcePartitionName:
+                sourceCompanyId:
                     description:
-                        The name of the source partition that was exported (e.g., lpartition_12345).
-                    type: string
+                        The ID of the source company that was exported (e.g., 12345).
+                    format: int64
+                    type: integer
             type: object
         PortalInstanceImport:
             description:

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -180,7 +180,11 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 
 		return new PortalInstanceExport() {
 			{
-				setExportedPartitionName(() -> "lexported_" + companyId);
+				setExportedPartitionName(
+					() ->
+						DBPartitionUtil.
+							DATABASE_EXPORTED_PARTITION_SCHEMA_NAME_PREFIX +
+								companyId);
 				setSourceCompanyId(() -> companyId);
 			}
 		};

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-impl/src/main/java/com/liferay/headless/portal/instances/internal/resource/v1_0/PortalInstanceResourceImpl.java
@@ -181,10 +181,7 @@ public class PortalInstanceResourceImpl extends BasePortalInstanceResourceImpl {
 		return new PortalInstanceExport() {
 			{
 				setExportedPartitionName(() -> "lexported_" + companyId);
-				setSourcePartitionName(
-					() ->
-						PropsValues.DATABASE_PARTITION_SCHEMA_NAME_PREFIX +
-							companyId);
+				setSourceCompanyId(() -> companyId);
 			}
 		};
 	}

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/BasePortalInstanceResourceTestCase.java
@@ -616,10 +616,8 @@ public abstract class BasePortalInstanceResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals(
-					"sourcePartitionName", additionalAssertFieldName)) {
-
-				if (portalInstanceExport.getSourcePartitionName() == null) {
+			if (Objects.equals("sourceCompanyId", additionalAssertFieldName)) {
+				if (portalInstanceExport.getSourceCompanyId() == null) {
 					valid = false;
 				}
 
@@ -845,12 +843,10 @@ public abstract class BasePortalInstanceResourceTestCase {
 				continue;
 			}
 
-			if (Objects.equals(
-					"sourcePartitionName", additionalAssertFieldName)) {
-
+			if (Objects.equals("sourceCompanyId", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
-						portalInstanceExport1.getSourcePartitionName(),
-						portalInstanceExport2.getSourcePartitionName())) {
+						portalInstanceExport1.getSourceCompanyId(),
+						portalInstanceExport2.getSourceCompanyId())) {
 
 					return false;
 				}
@@ -1215,7 +1211,7 @@ public abstract class BasePortalInstanceResourceTestCase {
 		return new PortalInstanceExport() {
 			{
 				exportedPartitionName = RandomTestUtil.randomString();
-				sourcePartitionName = RandomTestUtil.randomString();
+				sourceCompanyId = RandomTestUtil.randomLong();
 			}
 		};
 	}
@@ -1431,4 +1427,4 @@ public abstract class BasePortalInstanceResourceTestCase {
 			PortalInstanceResource _portalInstanceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:483813011
+// LIFERAY-REST-BUILDER-HASH:-2057292312

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -577,8 +577,7 @@ public class PortalInstanceResourceTest
 					companyId,
 				portalInstanceExport.getExportedPartitionName());
 			Assert.assertEquals(
-				PropsValues.DATABASE_PARTITION_SCHEMA_NAME_PREFIX + companyId,
-				portalInstanceExport.getSourcePartitionName());
+				Long.valueOf(companyId), portalInstanceExport.getSourceCompanyId());
 
 			List<String> configurationIds = _getExportedConfigurationIds(
 				companyId);

--- a/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
+++ b/modules/apps/headless/headless-portal-instances/headless-portal-instances-test/src/testIntegration/java/com/liferay/headless/portal/instances/resource/v1_0/test/PortalInstanceResourceTest.java
@@ -168,8 +168,6 @@ public class PortalInstanceResourceTest
 
 		Assume.assumeTrue(db.isSupportsDBPartition());
 
-		Assume.assumeFalse(PropsValues.DATABASE_PARTITION_ENABLED);
-
 		_testPostPortalInstanceExport();
 		_testPostPortalInstanceExportWithNonexistentPortalInstance();
 		_testPostPortalInstanceExportWithoutOmniadminPermission();
@@ -537,6 +535,28 @@ public class PortalInstanceResourceTest
 	private void _testPostPortalInstanceExport() throws Exception {
 		long companyId = _portalInstance.getCompanyId();
 
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			try {
+				PortalInstanceExport portalInstanceExport =
+					portalInstanceResource.postPortalInstanceExport(
+						_portalInstance.getPortalInstanceId());
+
+				Assert.assertEquals(
+					DBPartitionUtil.
+						DATABASE_EXPORTED_PARTITION_SCHEMA_NAME_PREFIX +
+							companyId,
+					portalInstanceExport.getExportedPartitionName());
+				Assert.assertEquals(
+					Long.valueOf(companyId),
+					portalInstanceExport.getSourceCompanyId());
+			}
+			finally {
+				_dropExportedSchema(companyId);
+			}
+
+			return;
+		}
+
 		Configuration company1Configuration = _createScopedConfiguration(
 			HashMapDictionaryBuilder.<String, Object>put(
 				ExtendedObjectClassDefinition.Scope.COMPANY.getPropertyKey(),
@@ -577,7 +597,8 @@ public class PortalInstanceResourceTest
 					companyId,
 				portalInstanceExport.getExportedPartitionName());
 			Assert.assertEquals(
-				Long.valueOf(companyId), portalInstanceExport.getSourceCompanyId());
+				Long.valueOf(companyId),
+				portalInstanceExport.getSourceCompanyId());
 
 			List<String> configurationIds = _getExportedConfigurationIds(
 				companyId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92617

## What Is Being Fixed

The Portal Instances export endpoint returned `sourcePartitionName`, whose value (`lpartition_<companyId>`) only exists when database partitioning is enabled. With partitioning disabled the source is the shared schema, so the field was meaningless — even though the underlying export (`CompanyLocalService.exportCompany`) already supports both modes. The integration test likewise only exercised the partitioning-disabled path.

## How It Is Being Fixed

The export response now returns `sourceCompanyId` (an int64) instead of `sourcePartitionName`, so it is meaningful whether database partitioning is enabled or disabled; the OpenAPI definition was updated and REST Builder regenerated the DTOs, SerDes, and client. The hardcoded `lexported_` prefix in the implementation now uses `DBPartitionUtil.DATABASE_EXPORTED_PARTITION_SCHEMA_NAME_PREFIX`. Finally, the integration test was restructured to run against both database partitioning modes — asserting the exported schema name and source company ID in each — while keeping the configuration-filtering assertions on the partitioning-disabled path, where that logic actually runs.

## PR Check

**pr-check: PASS** — tested on `b76304036b7c8d4628574419e0f53a8aa124ac9b`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "b76304036b7c8d4628574419e0f53a8aa124ac9b"} -->
