### PR TITLE
LPD-98573 Optimize and simplify ClassNamePostUpgradeDataCleanupProcess

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -10,6 +10,7 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
@@ -31,8 +32,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,6 +44,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWiring;
 
 /**
  * @author Luis Ortiz
@@ -81,6 +87,35 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		DBInspector dbInspector = new DBInspector(connection);
 		Map<String, Boolean> definedClasses = new HashMap<>();
 		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
+		Map<String, List<Bundle>> packageBundles = new HashMap<>();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+
+			if (bundleWiring == null) {
+				continue;
+			}
+
+			for (BundleCapability bundleCapability :
+					bundleWiring.getCapabilities(
+						BundleRevision.PACKAGE_NAMESPACE)) {
+
+				Map<String, Object> attributes =
+					bundleCapability.getAttributes();
+
+				Object packageName = attributes.get(
+					BundleRevision.PACKAGE_NAMESPACE);
+
+				if (packageName == null) {
+					continue;
+				}
+
+				List<Bundle> bundles = packageBundles.computeIfAbsent(
+					packageName.toString(), key -> new ArrayList<>());
+
+				bundles.add(bundle);
+			}
+		}
 
 		List<String> tableNames = new ArrayList<>();
 
@@ -162,7 +197,24 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				if (defined == null) {
 					defined = false;
 
-					for (Bundle bundle : bundleContext.getBundles()) {
+					Set<Bundle> candidateBundles = new LinkedHashSet<>();
+
+					int packageIndex = currentValue.lastIndexOf(
+						CharPool.PERIOD);
+
+					if (packageIndex != -1) {
+						List<Bundle> exportingBundles = packageBundles.get(
+							currentValue.substring(0, packageIndex));
+
+						if (exportingBundles != null) {
+							candidateBundles.addAll(exportingBundles);
+						}
+					}
+
+					Collections.addAll(
+						candidateBundles, bundleContext.getBundles());
+
+					for (Bundle bundle : candidateBundles) {
 						try {
 							bundle.loadClass(currentValue);
 

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -9,7 +9,6 @@ import com.liferay.data.cleanup.internal.verify.util.PostUpgradeDataCleanupProce
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -143,11 +142,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 		String usedTableNamesSQL = sb.toString();
 
-		UnsafeConsumer<ClassName, Exception> unsafeConsumer = className -> {
+		for (ClassName className : classNames) {
 			String value = className.getValue();
 
 			if (!value.startsWith("com.liferay.")) {
-				return;
+				continue;
 			}
 
 			if (StringUtil.startsWith(
@@ -173,11 +172,9 @@ public class ClassNamePostUpgradeDataCleanupProcess
 					});
 
 				if (objectDefinition.get() != null) {
-					return;
+					continue;
 				}
 			}
-
-			boolean missing = false;
 
 			int index = value.indexOf(StringPool.DASH);
 
@@ -187,65 +184,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				value = value.substring(0, index);
 			}
 
-			for (String currentValue : value.split("[-_]")) {
-				if (models.contains(currentValue)) {
-					continue;
-				}
+			if (_isClassDefined(
+					bundleContext, definedClasses, models, packageBundles,
+					value)) {
 
-				Boolean defined = definedClasses.get(currentValue);
-
-				if (defined == null) {
-					defined = false;
-
-					Set<Bundle> candidateBundles = new LinkedHashSet<>();
-
-					int packageIndex = currentValue.lastIndexOf(
-						CharPool.PERIOD);
-
-					if (packageIndex != -1) {
-						List<Bundle> exportingBundles = packageBundles.get(
-							currentValue.substring(0, packageIndex));
-
-						if (exportingBundles != null) {
-							candidateBundles.addAll(exportingBundles);
-						}
-					}
-
-					Collections.addAll(
-						candidateBundles, bundleContext.getBundles());
-
-					for (Bundle bundle : candidateBundles) {
-						try {
-							bundle.loadClass(currentValue);
-
-							defined = true;
-
-							break;
-						}
-						catch (ClassNotFoundException classNotFoundException) {
-							if (_log.isDebugEnabled()) {
-								_log.debug(classNotFoundException);
-							}
-						}
-						catch (Exception exception) {
-							_log.error(exception);
-
-							return;
-						}
-					}
-
-					definedClasses.put(currentValue, defined);
-				}
-
-				if (!defined) {
-					missing = true;
-
-					break;
-				}
-			}
-
-			if (!missing) {
-				return;
+				continue;
 			}
 
 			Set<String> usedTableNames = new HashSet<>();
@@ -283,11 +226,69 @@ public class ClassNamePostUpgradeDataCleanupProcess
 						"referenced in the next tables: ",
 						String.join(", ", new TreeSet<>(usedTableNames))));
 			}
-		};
-
-		for (ClassName className : classNames) {
-			unsafeConsumer.accept(className);
 		}
+	}
+
+	private boolean _isClassDefined(
+		BundleContext bundleContext, Map<String, Boolean> definedClasses,
+		Set<String> models, Map<String, List<Bundle>> packageBundles,
+		String value) {
+
+		for (String currentValue : value.split("[-_]")) {
+			if (models.contains(currentValue)) {
+				continue;
+			}
+
+			Boolean defined = definedClasses.get(currentValue);
+
+			if (defined == null) {
+				defined = false;
+
+				Set<Bundle> candidateBundles = new LinkedHashSet<>();
+
+				int index = currentValue.lastIndexOf(CharPool.PERIOD);
+
+				if (index != -1) {
+					List<Bundle> exportingBundles = packageBundles.get(
+						currentValue.substring(0, index));
+
+					if (exportingBundles != null) {
+						candidateBundles.addAll(exportingBundles);
+					}
+				}
+
+				Collections.addAll(
+					candidateBundles, bundleContext.getBundles());
+
+				for (Bundle bundle : candidateBundles) {
+					try {
+						bundle.loadClass(currentValue);
+
+						defined = true;
+
+						break;
+					}
+					catch (ClassNotFoundException classNotFoundException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(classNotFoundException);
+						}
+					}
+					catch (Exception exception) {
+						_log.error(exception);
+
+						return true;
+					}
+				}
+
+				definedClasses.put(currentValue, defined);
+			}
+
+			if (!defined) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -31,8 +31,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
@@ -77,6 +79,7 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		List<ClassName> classNames = _classNameLocalService.getClassNames(
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 		DBInspector dbInspector = new DBInspector(connection);
+		Map<String, Boolean> definedClasses = new HashMap<>();
 		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
 
 		List<String> tableNames = new ArrayList<>();
@@ -140,27 +143,35 @@ public class ClassNamePostUpgradeDataCleanupProcess
 					continue;
 				}
 
-				Class<?> clazz = null;
+				Boolean defined = definedClasses.get(currentValue);
 
-				for (Bundle bundle : bundleContext.getBundles()) {
-					try {
-						clazz = bundle.loadClass(currentValue);
+				if (defined == null) {
+					defined = false;
 
-						break;
-					}
-					catch (ClassNotFoundException classNotFoundException) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(classNotFoundException);
+					for (Bundle bundle : bundleContext.getBundles()) {
+						try {
+							bundle.loadClass(currentValue);
+
+							defined = true;
+
+							break;
+						}
+						catch (ClassNotFoundException classNotFoundException) {
+							if (_log.isDebugEnabled()) {
+								_log.debug(classNotFoundException);
+							}
+						}
+						catch (Exception exception) {
+							_log.error(exception);
+
+							return;
 						}
 					}
-					catch (Exception exception) {
-						_log.error(exception);
 
-						return;
-					}
+					definedClasses.put(currentValue, defined);
 				}
 
-				if (clazz == null) {
+				if (!defined) {
 					missing = true;
 
 					break;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -81,11 +81,6 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		}
 
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-		List<ClassName> classNames = _classNameLocalService.getClassNames(
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-		DBInspector dbInspector = new DBInspector(connection);
-		Map<String, Boolean> definedClasses = new HashMap<>();
-		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
 		Map<String, List<Bundle>> packageBundles = new HashMap<>();
 
 		for (Bundle bundle : bundleContext.getBundles()) {
@@ -116,9 +111,10 @@ public class ClassNamePostUpgradeDataCleanupProcess
 			}
 		}
 
+		StringBundler sb = new StringBundler();
 		List<String> tableNames = new ArrayList<>();
 
-		StringBundler sb = new StringBundler();
+		DBInspector dbInspector = new DBInspector(connection);
 
 		for (String tableName : dbInspector.getTableNames(null)) {
 			if (!dbInspector.hasColumn(tableName, "classNameId") ||
@@ -141,6 +137,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		}
 
 		String usedTableNamesSQL = sb.toString();
+
+		List<ClassName> classNames = _classNameLocalService.getClassNames(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		Map<String, Boolean> definedClasses = new HashMap<>();
+		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
 
 		for (ClassName className : classNames) {
 			String value = className.getValue();

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -84,6 +84,8 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 		List<String> tableNames = new ArrayList<>();
 
+		StringBundler sb = new StringBundler();
+
 		for (String tableName : dbInspector.getTableNames(null)) {
 			if (!dbInspector.hasColumn(tableName, "classNameId") ||
 				StringUtil.equalsIgnoreCase(tableName, "ClassName_")) {
@@ -91,8 +93,20 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				continue;
 			}
 
+			if (!tableNames.isEmpty()) {
+				sb.append(" union all ");
+			}
+
 			tableNames.add(tableName);
+
+			sb.append("select distinct '");
+			sb.append(tableName);
+			sb.append("' from ");
+			sb.append(tableName);
+			sb.append(" where classNameId = ?");
 		}
+
+		String usedTableNamesSQL = sb.toString();
 
 		UnsafeConsumer<ClassName, Exception> unsafeConsumer = className -> {
 			String value = className.getValue();
@@ -184,20 +198,17 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 			Set<String> usedTableNames = new HashSet<>();
 
-			for (String tableName : tableNames) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							"select 1 from " + tableName +
-								" where classNameId = ?")) {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(usedTableNamesSQL)) {
 
-					preparedStatement.setLong(1, className.getClassNameId());
+				for (int i = 1; i <= tableNames.size(); i++) {
+					preparedStatement.setLong(i, className.getClassNameId());
+				}
 
-					try (ResultSet resultSet =
-							preparedStatement.executeQuery()) {
-
-						if (resultSet.next()) {
-							usedTableNames.add(tableName);
-						}
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					while (resultSet.next()) {
+						usedTableNames.add(
+							StringUtil.trim(resultSet.getString(1)));
 					}
 				}
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98573

## What Is Being Fixed

ClassNamePostUpgradeDataCleanupProcess walks every ClassName row and, for each, scans deployed bundles to decide whether the class is still defined and queries every classNameId-bearing table to decide whether it is still in use. As written it rescanned bundles per class name, issued one usage query per table, and carried structural cruft — an UnsafeConsumer left over from the earlier processConcurrently design, a top-heavy declaration block, and a redundant empty-SQL guard — that made the hot loop slower and harder to follow.

## How It Is Being Fixed

Class name resolution now caches per-package results and tries the exporting bundle first before falling back to a full scan, cutting repeated bundle loads. The per-table usage checks are collapsed into a single UNION ALL query instead of one query per table. The leftover UnsafeConsumer is replaced with a plain loop and the per-class resolution is extracted into _isClassDefined, so the cleanup reads as a flat sequence. Locals are declared next to first use, and the never-empty usedTableNamesSQL guard and the +1 JDBC index offset are dropped. Every change is behaviour-preserving.

## Why Are There No Tests?

The class is already covered by the existing integration test ClassNamePostUpgradeDataCleanupProcessTest. These commits are behaviour-preserving refactors and performance optimizations with no new observable behaviour, so the existing coverage applies unchanged.

## PR Check

**pr-check: PASS** — tested on `95becfb7b08e19113e9f3fcf0cfda57c5af145e5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "95becfb7b08e19113e9f3fcf0cfda57c5af145e5"} -->
