### PR TITLE
LPD-96717 Warn on close only for dirty autoCommit arrivals

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/dao/db/BaseDBProcess.java
@@ -556,7 +556,7 @@ public abstract class BaseDBProcess implements DBProcess {
 		Boolean autoCommit = _autoCommits.remove(connection);
 
 		if (autoCommit != null) {
-			if (_log.isWarnEnabled()) {
+			if (!autoCommit && _log.isWarnEnabled()) {
 				_log.warn(
 					"Closing a connection that still has an autoCommit " +
 						"override");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96717

## What Is Being Fixed

`PortalLogAssertorTest#testScanXMLLog` fails on any WARN/ERROR/FATAL log event and has no whitelist. During a DB2 11.1 upgrade batch, `BaseDBProcess` logged `WARN "Closing a connection that still has an autoCommit override"`, which tripped the scan. The warning was firing for every claimed worker connection still registered at close time, including clean-arrival connections whose transaction was simply never flushed because a worker aborted mid-batch — normal rollback recovery, not an upstream connection leak.

## How It Is Being Fixed

`BaseDBProcess._closeConnection` stores each claimed connection's arrival `autoCommit` value: `true` for a clean acquire and `false` for a dirty arrival, which is the actual upstream-leak signal the warning was meant to surface. The warning is now emitted only when the stored value is `false`, so a clean-arrival connection is rolled back and its `autoCommit` restored silently. The rollback and `setAutoCommit` restore still run in both cases, so the connection is left in a clean state regardless.

## Why Are There No Tests?

The change only narrows a WARN log condition in an upgrade-framework path. The failing `PortalLogAssertorTest` runs over a full DB2 11.1 upgrade batch that cannot be reproduced on a local checkout, so no proportionate automated test exists.

## PR Check

**pr-check: PASS** — tested on `6aa73d5a216ba046951d27ad8ee1b43b934d43cd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6aa73d5a216ba046951d27ad8ee1b43b934d43cd"} -->
