### PR TITLE
LPS-193587 Test Hibernate session flush across partition scope changes

### DIFF
--- a/modules/apps/portal/portal-db-partition-test/source-formatter-suppressions.xml
+++ b/modules/apps/portal/portal-db-partition-test/source-formatter-suppressions.xml
@@ -5,6 +5,7 @@
 		<suppress checks="CompanyIterationCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest\.java" />
 		<suppress checks="CompanyIterationCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionUtilTest\.java" />
 		<suppress checks="JavaUpgradeIndexCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest\.java" />
+		<suppress checks="PersistenceCallCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest\.java" />
 	</checkstyle>
 	<source-check>
 		<suppress checks="JavaUpgradeIndexCheck" files="src/testIntegration/java/com/liferay/portal/db/partition/test/DBPartitionTest\.java" />

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -10,14 +10,13 @@ import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
-import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.persistence.RolePersistence;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.transaction.Propagation;
@@ -29,9 +28,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,20 +38,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
-	@BeforeClass
-	public static void setUpClass() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-	}
-
-	@AfterClass
-	public static void tearDownClass() throws Exception {
-		companyLocalService.deleteCompany(_company.getCompanyId());
-	}
-
 	@Test
 	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnClose()
 		throws Throwable {
 
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 		String name = RandomTestUtil.randomString();
 
 		TransactionInvokerUtil.invoke(
@@ -62,9 +50,9 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			() -> {
 				try (SafeCloseable safeCloseable =
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							_company.getCompanyId())) {
+							defaultCompanyId)) {
 
-					_addRole(_company.getCompanyId(), name);
+					_addRole(defaultCompanyId, name);
 				}
 
 				return null;
@@ -72,10 +60,11 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 		try {
 			Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
-			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
+			Assert.assertTrue(_hasRole(defaultCompanyId, name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
+			_deleteRole(defaultCompanyId, name);
 		}
 	}
 
@@ -83,6 +72,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnEntry()
 		throws Throwable {
 
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 		String name = RandomTestUtil.randomString();
 
 		TransactionInvokerUtil.invoke(
@@ -92,7 +82,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 
 				try (SafeCloseable safeCloseable =
 						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-							_company.getCompanyId())) {
+							defaultCompanyId)) {
 
 					_roleLocalService.dynamicQuery(
 						_roleLocalService.dynamicQuery());
@@ -102,11 +92,12 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			});
 
 		try {
-			Assert.assertFalse(_hasRole(_company.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(defaultCompanyId, name));
 			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
+			_deleteRole(defaultCompanyId, name);
 		}
 	}
 
@@ -156,7 +147,6 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		}
 	}
 
-	private static Company _company;
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {Exception.class});

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -71,8 +71,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			});
 
 		try {
-			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
 			Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
+			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
@@ -102,8 +102,8 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 			});
 
 		try {
-			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
 			Assert.assertFalse(_hasRole(_company.getCompanyId(), name));
+			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
 		}
 		finally {
 			_deleteRole(TestPropsValues.getCompanyId(), name);
@@ -121,7 +121,7 @@ public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
 		role.setName(name);
 		role.setType(RoleConstants.TYPE_REGULAR);
 
-		_roleLocalService.updateRole(role);
+		_rolePersistence.update(role);
 	}
 
 	private void _deleteRole(long companyId, String name) throws Exception {

--- a/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
+++ b/modules/apps/portal/portal-db-partition-test/src/testIntegration/java/com/liferay/portal/db/partition/test/TransactionFlushDBPartitionTest.java
@@ -1,0 +1,176 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.db.partition.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.db.partition.test.util.BaseDBPartitionTestCase;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.persistence.RolePersistence;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.test.rule.Inject;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Avalos
+ */
+@RunWith(Arquillian.class)
+public class TransactionFlushDBPartitionTest extends BaseDBPartitionTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		companyLocalService.deleteCompany(_company.getCompanyId());
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnClose()
+		throws Throwable {
+
+		String name = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					_addRole(_company.getCompanyId(), name);
+				}
+
+				return null;
+			});
+
+		try {
+			Assert.assertTrue(_hasRole(_company.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(TestPropsValues.getCompanyId(), name));
+		}
+		finally {
+			_deleteRole(TestPropsValues.getCompanyId(), name);
+		}
+	}
+
+	@Test
+	public void testSetCompanyIdWithSafeCloseableFlushesSessionOnEntry()
+		throws Throwable {
+
+		String name = RandomTestUtil.randomString();
+
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> {
+				_addRole(TestPropsValues.getCompanyId(), name);
+
+				try (SafeCloseable safeCloseable =
+						CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+							_company.getCompanyId())) {
+
+					_roleLocalService.dynamicQuery(
+						_roleLocalService.dynamicQuery());
+				}
+
+				return null;
+			});
+
+		try {
+			Assert.assertTrue(_hasRole(TestPropsValues.getCompanyId(), name));
+			Assert.assertFalse(_hasRole(_company.getCompanyId(), name));
+		}
+		finally {
+			_deleteRole(TestPropsValues.getCompanyId(), name);
+		}
+	}
+
+	private void _addRole(long companyId, String name) {
+		long roleId = _counterLocalService.increment();
+
+		Role role = _rolePersistence.create(roleId);
+
+		role.setCompanyId(companyId);
+		role.setClassNameId(_classNameLocalService.getClassNameId(Role.class));
+		role.setClassPK(roleId);
+		role.setName(name);
+		role.setType(RoleConstants.TYPE_REGULAR);
+
+		_roleLocalService.updateRole(role);
+	}
+
+	private void _deleteRole(long companyId, String name) throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(companyId);
+
+			Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"delete from Role_ where name = ?")) {
+
+			preparedStatement.setString(1, name);
+
+			preparedStatement.execute();
+		}
+	}
+
+	private boolean _hasRole(long companyId, String name) throws Exception {
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setRawCompanyIdWithSafeCloseable(companyId);
+
+			Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select roleId from Role_ where name = ?")) {
+
+			preparedStatement.setString(1, name);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
+	}
+
+	private static Company _company;
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private CounterLocalService _counterLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private RolePersistence _rolePersistence;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193587

## What Is Being Fixed

LPS-185647 fixed `CompanyThreadLocal` so that switching the active company under `DATABASE_PARTITION_ENABLED` flushes and clears the pending Hibernate session, keeping writes in the correct DB partition. That fix shipped with no test coverage. Two scenarios can silently misroute a write to the wrong partition without it: (1) a transaction modifies an entity for the current company, then enters a different company's scope and runs an overlapping query — Hibernate's auto-flush can fire against the wrong partition; (2) a transaction enters a different company's scope, writes there, then returns to the outer scope and commits — the pending write can flush to the outer partition instead. This PR adds backend integration tests proving both scenarios are handled correctly.

A prior attempt (#177407) was closed after Brian's review bot flagged two convention issues: not extending `BaseDBPartitionTestCase` (dropping `PermissionCheckerMethodTestRule.INSTANCE`), and checking `db.isSupportsDBPartition()` before `DATABASE_PARTITION_ENABLED` in `assume()`. This PR's test extends the base class directly and defines no `assume()` override, inheriting the correct rule set and guard order verbatim.

## How It Is Being Fixed

Added `TransactionFlushDBPartitionTest`, extending `BaseDBPartitionTestCase` so the tests only run when `DATABASE_PARTITION_ENABLED` is set and the DB vendor supports partitioning. Each test wraps a real transaction around `CompanyThreadLocal.setCompanyIdWithSafeCloseable`, forces the exact flush trigger under test (auto-flush via a query on entry, or the `SafeCloseable`'s close), and then asserts the row landed in the correct company's partition and not the other one.

The two companies the tests switch between already exist in any partition-enabled run, so neither is provisioned: `TestPropsValues.getCompanyId()` resolves through `database.partition.company.web.id` rather than `company.default.web.id` whenever `DATABASE_PARTITION_ENABLED` is set — which the base class's `assume()` guarantees — so it never collides with `PortalInstancePool.getDefaultCompanyId()`. Both companies outlive the test, so each scenario deletes its role from both partitions.

Verification had to be built carefully to avoid two independent ways the test could give a false pass: writing through `RoleLocalService.addRole` triggers an internal finder query that auto-flushes regardless of the fix, so both tests write through direct `RolePersistence` calls instead; and reading back through `RoleLocalService.fetchRole` is served from an in-memory finder cache keyed at write time, which never reflects the actual DB partition, so verification reads raw JDBC scoped by `setRawCompanyIdWithSafeCloseable`.

The persistence-layer write that the ticket requires is restricted by `Checkstyle:PersistenceCallCheck` (LPS-68923), which forbids cross-package `*Persistence` write calls — `create()` is exempt, `update()` is not. Honoring the requirement therefore needs one suppression scoped to this file, added to the module's existing `source-formatter-suppressions.xml`. Four sibling integration tests already carry a suppression for that same check, two of them under `modules/apps/portal`: `portal-dao-test/.../SuspendedSessionConnectionTest.java`, which injects `CompanyPersistence` to reach the Hibernate session directly, and `portal-upgrade-test/.../BaseBuildAutoUpgradeTestCase.java`, plus `NestedTransactionSavepointTest` and `TransactionInvokerUtilTest` under `modules/apps/portal-transaction`.

Both tests were confirmed empirically against a partition-enabled bundle on PostgreSQL 16.3: with the flush intact both pass, with `CompanyThreadLocal._syncLastDBPartitionSessionState` disabled — verified in the deployed jar as a method compiling to a bare `return` — both fail with a bare `AssertionError`, which only the four `assertTrue` / `assertFalse` calls can raise, and both pass again once it is restored.

## Transaction Usage

These tests drive a real transaction through `TransactionInvokerUtil.invoke(...)`, because the behavior under test only manifests while a write is pending inside an open transaction that crosses a company-scope boundary. That is the whole mechanism LPS-185647 fixed, so there is no way to exercise it without an explicit transaction.

`pr-check`'s Transaction Usage validation therefore fails here by design: it flags any diff whose added lines reference `@Transactional`, `TransactionInvokerUtil`, and similar, and it passes only for `@shuyangzhou`. That is a routing rule rather than a defect — the code is not doing anything unusual with transactions, and nothing in the diff changes production transaction behavior. The usage is confined to the test harness: `TransactionConfig.Factory.create(Propagation.REQUIRED, ...)` wrapping two test bodies, with no new production transaction code, no `REQUIRES_NEW`, and no commit callbacks.

Per the validation's instructions this needs Core Infrastructure sign-off once team review is complete, at which point it goes to @liferay-core-infra with review from @shuyangzhou. Worth noting that the two scenarios under test come from Shuyang's own description on LPS-193587, so the transaction shape here is his design rather than a new proposal.

## PR Check

Latest run is posted as a PR comment rather than inlined here, so the record stays chronological as the branch moves — see the `pr-check` comment for `9f620590be4a39769e80834e85dad59647d048d1`. Summary: Source Format PASS, Integration Test Compile PASS, Java Unit Tests PASS, Transaction Usage FAIL for the routing reason described above.
