### PR TITLE
LPD-98573 Optimize and simplify ClassNamePostUpgradeDataCleanupProcess

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -31,8 +31,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
@@ -77,6 +79,7 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		List<ClassName> classNames = _classNameLocalService.getClassNames(
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 		DBInspector dbInspector = new DBInspector(connection);
+		Map<String, Boolean> definedClasses = new HashMap<>();
 		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
 
 		List<String> tableNames = new ArrayList<>();
@@ -140,27 +143,35 @@ public class ClassNamePostUpgradeDataCleanupProcess
 					continue;
 				}
 
-				Class<?> clazz = null;
+				Boolean defined = definedClasses.get(currentValue);
 
-				for (Bundle bundle : bundleContext.getBundles()) {
-					try {
-						clazz = bundle.loadClass(currentValue);
+				if (defined == null) {
+					defined = false;
 
-						break;
-					}
-					catch (ClassNotFoundException classNotFoundException) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(classNotFoundException);
+					for (Bundle bundle : bundleContext.getBundles()) {
+						try {
+							bundle.loadClass(currentValue);
+
+							defined = true;
+
+							break;
+						}
+						catch (ClassNotFoundException classNotFoundException) {
+							if (_log.isDebugEnabled()) {
+								_log.debug(classNotFoundException);
+							}
+						}
+						catch (Exception exception) {
+							_log.error(exception);
+
+							return;
 						}
 					}
-					catch (Exception exception) {
-						_log.error(exception);
 
-						return;
-					}
+					definedClasses.put(currentValue, defined);
 				}
 
-				if (clazz == null) {
+				if (!defined) {
 					missing = true;
 
 					break;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -84,6 +84,8 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 		List<String> tableNames = new ArrayList<>();
 
+		StringBundler sb = new StringBundler();
+
 		for (String tableName : dbInspector.getTableNames(null)) {
 			if (!dbInspector.hasColumn(tableName, "classNameId") ||
 				StringUtil.equalsIgnoreCase(tableName, "ClassName_")) {
@@ -91,8 +93,20 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				continue;
 			}
 
+			if (!tableNames.isEmpty()) {
+				sb.append(" union all ");
+			}
+
 			tableNames.add(tableName);
+
+			sb.append("select distinct '");
+			sb.append(tableName);
+			sb.append("' from ");
+			sb.append(tableName);
+			sb.append(" where classNameId = ?");
 		}
+
+		String usedTableNamesSQL = sb.toString();
 
 		UnsafeConsumer<ClassName, Exception> unsafeConsumer = className -> {
 			String value = className.getValue();
@@ -184,20 +198,17 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 			Set<String> usedTableNames = new HashSet<>();
 
-			for (String tableName : tableNames) {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							"select 1 from " + tableName +
-								" where classNameId = ?")) {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(usedTableNamesSQL)) {
 
-					preparedStatement.setLong(1, className.getClassNameId());
+				for (int i = 1; i <= tableNames.size(); i++) {
+					preparedStatement.setLong(i, className.getClassNameId());
+				}
 
-					try (ResultSet resultSet =
-							preparedStatement.executeQuery()) {
-
-						if (resultSet.next()) {
-							usedTableNames.add(tableName);
-						}
+				try (ResultSet resultSet = preparedStatement.executeQuery()) {
+					while (resultSet.next()) {
+						usedTableNames.add(
+							StringUtil.trim(resultSet.getString(1)));
 					}
 				}
 			}

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -10,6 +10,7 @@ import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
@@ -31,8 +32,10 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,6 +44,9 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.wiring.BundleCapability;
+import org.osgi.framework.wiring.BundleRevision;
+import org.osgi.framework.wiring.BundleWiring;
 
 /**
  * @author Luis Ortiz
@@ -81,6 +87,35 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		DBInspector dbInspector = new DBInspector(connection);
 		Map<String, Boolean> definedClasses = new HashMap<>();
 		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
+		Map<String, List<Bundle>> packageNameBundlesMap = new HashMap<>();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+
+			if (bundleWiring == null) {
+				continue;
+			}
+
+			for (BundleCapability bundleCapability :
+					bundleWiring.getCapabilities(
+						BundleRevision.PACKAGE_NAMESPACE)) {
+
+				Map<String, Object> attributes =
+					bundleCapability.getAttributes();
+
+				Object packageName = attributes.get(
+					BundleRevision.PACKAGE_NAMESPACE);
+
+				if (packageName == null) {
+					continue;
+				}
+
+				List<Bundle> bundles = packageNameBundlesMap.computeIfAbsent(
+					packageName.toString(), key -> new ArrayList<>());
+
+				bundles.add(bundle);
+			}
+		}
 
 		List<String> tableNames = new ArrayList<>();
 
@@ -162,7 +197,25 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				if (defined == null) {
 					defined = false;
 
-					for (Bundle bundle : bundleContext.getBundles()) {
+					Set<Bundle> candidateBundles = new LinkedHashSet<>();
+
+					int packageIndex = currentValue.lastIndexOf(
+						CharPool.PERIOD);
+
+					if (packageIndex != -1) {
+						List<Bundle> exportingBundles =
+							packageNameBundlesMap.get(
+								currentValue.substring(0, packageIndex));
+
+						if (exportingBundles != null) {
+							candidateBundles.addAll(exportingBundles);
+						}
+					}
+
+					Collections.addAll(
+						candidateBundles, bundleContext.getBundles());
+
+					for (Bundle bundle : candidateBundles) {
 						try {
 							bundle.loadClass(currentValue);
 

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -9,7 +9,6 @@ import com.liferay.data.cleanup.internal.verify.util.PostUpgradeDataCleanupProce
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -143,11 +142,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 		String usedTableNamesSQL = sb.toString();
 
-		UnsafeConsumer<ClassName, Exception> unsafeConsumer = className -> {
+		for (ClassName className : classNames) {
 			String value = className.getValue();
 
 			if (!value.startsWith("com.liferay.")) {
-				return;
+				continue;
 			}
 
 			if (StringUtil.startsWith(
@@ -173,11 +172,9 @@ public class ClassNamePostUpgradeDataCleanupProcess
 					});
 
 				if (objectDefinition.get() != null) {
-					return;
+					continue;
 				}
 			}
-
-			boolean missing = false;
 
 			int index = value.indexOf(StringPool.DASH);
 
@@ -187,66 +184,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				value = value.substring(0, index);
 			}
 
-			for (String currentValue : value.split("[-_]")) {
-				if (models.contains(currentValue)) {
-					continue;
-				}
+			if (_isClassDefined(
+					bundleContext, definedClasses, models,
+					packageNameBundlesMap, value)) {
 
-				Boolean defined = definedClasses.get(currentValue);
-
-				if (defined == null) {
-					defined = false;
-
-					Set<Bundle> candidateBundles = new LinkedHashSet<>();
-
-					int packageIndex = currentValue.lastIndexOf(
-						CharPool.PERIOD);
-
-					if (packageIndex != -1) {
-						List<Bundle> exportingBundles =
-							packageNameBundlesMap.get(
-								currentValue.substring(0, packageIndex));
-
-						if (exportingBundles != null) {
-							candidateBundles.addAll(exportingBundles);
-						}
-					}
-
-					Collections.addAll(
-						candidateBundles, bundleContext.getBundles());
-
-					for (Bundle bundle : candidateBundles) {
-						try {
-							bundle.loadClass(currentValue);
-
-							defined = true;
-
-							break;
-						}
-						catch (ClassNotFoundException classNotFoundException) {
-							if (_log.isDebugEnabled()) {
-								_log.debug(classNotFoundException);
-							}
-						}
-						catch (Exception exception) {
-							_log.error(exception);
-
-							return;
-						}
-					}
-
-					definedClasses.put(currentValue, defined);
-				}
-
-				if (!defined) {
-					missing = true;
-
-					break;
-				}
-			}
-
-			if (!missing) {
-				return;
+				continue;
 			}
 
 			Set<String> usedTableNames = new HashSet<>();
@@ -284,11 +226,74 @@ public class ClassNamePostUpgradeDataCleanupProcess
 						"referenced in the next tables: ",
 						String.join(", ", new TreeSet<>(usedTableNames))));
 			}
-		};
-
-		for (ClassName className : classNames) {
-			unsafeConsumer.accept(className);
 		}
+	}
+
+	private boolean _isClassDefined(
+		BundleContext bundleContext, Map<String, Boolean> definedClasses,
+		Set<String> models, Map<String, List<Bundle>> packageNameBundlesMap,
+		String value) {
+
+		for (String currentValue : value.split("[-_]")) {
+			if (models.contains(currentValue)) {
+				continue;
+			}
+
+			Boolean defined = definedClasses.get(currentValue);
+
+			if (defined != null) {
+				if (defined) {
+					continue;
+				}
+
+				return false;
+			}
+
+			Set<Bundle> candidateBundles = new LinkedHashSet<>();
+
+			int index = currentValue.lastIndexOf(CharPool.PERIOD);
+
+			if (index != -1) {
+				List<Bundle> exportingBundles = packageNameBundlesMap.get(
+					currentValue.substring(0, index));
+
+				if (exportingBundles != null) {
+					candidateBundles.addAll(exportingBundles);
+				}
+			}
+
+			Collections.addAll(candidateBundles, bundleContext.getBundles());
+
+			defined = false;
+
+			for (Bundle bundle : candidateBundles) {
+				try {
+					bundle.loadClass(currentValue);
+
+					defined = true;
+
+					break;
+				}
+				catch (ClassNotFoundException classNotFoundException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(classNotFoundException);
+					}
+				}
+				catch (Exception exception) {
+					_log.error(exception);
+
+					return true;
+				}
+			}
+
+			definedClasses.put(currentValue, defined);
+
+			if (!defined) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -81,11 +81,6 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		}
 
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-		List<ClassName> classNames = _classNameLocalService.getClassNames(
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-		DBInspector dbInspector = new DBInspector(connection);
-		Map<String, Boolean> definedClasses = new HashMap<>();
-		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
 		Map<String, List<Bundle>> packageNameBundlesMap = new HashMap<>();
 
 		for (Bundle bundle : bundleContext.getBundles()) {
@@ -116,9 +111,10 @@ public class ClassNamePostUpgradeDataCleanupProcess
 			}
 		}
 
+		StringBundler sb = new StringBundler();
 		List<String> tableNames = new ArrayList<>();
 
-		StringBundler sb = new StringBundler();
+		DBInspector dbInspector = new DBInspector(connection);
 
 		for (String tableName : dbInspector.getTableNames(null)) {
 			if (!dbInspector.hasColumn(tableName, "classNameId") ||
@@ -141,6 +137,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		}
 
 		String usedTableNamesSQL = sb.toString();
+
+		List<ClassName> classNames = _classNameLocalService.getClassNames(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		Map<String, Boolean> definedClasses = new HashMap<>();
+		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
 
 		for (ClassName className : classNames) {
 			String value = className.getValue();

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -15,7 +15,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ClassName;
@@ -204,9 +203,7 @@ public class ClassNamePostUpgradeDataCleanupProcess
 	}
 
 	private Map<String, List<Bundle>> _getPackageNameBundlesMap() {
-		if (CompanyThreadLocal.getNonsystemCompanyId() !=
-				PortalInstancePool.getDefaultCompanyId()) {
-
+		if (!CompanyThreadLocal.isDefaultCompany()) {
 			return _packageNameBundlesMap;
 		}
 

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -69,7 +69,7 @@ public class ClassNamePostUpgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled()) {
+			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
 				_log.warn(
 					StringBundler.concat(
 						ClassNamePostUpgradeDataCleanupProcess.class.

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -15,12 +15,14 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
@@ -81,40 +83,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		}
 
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-		Map<String, List<Bundle>> packageNameBundlesMap = new HashMap<>();
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
-
-			if (bundleWiring == null) {
-				continue;
-			}
-
-			for (BundleCapability bundleCapability :
-					bundleWiring.getCapabilities(
-						BundleRevision.PACKAGE_NAMESPACE)) {
-
-				Map<String, Object> attributes =
-					bundleCapability.getAttributes();
-
-				Object packageName = attributes.get(
-					BundleRevision.PACKAGE_NAMESPACE);
-
-				if (packageName == null) {
-					continue;
-				}
-
-				List<Bundle> bundles = packageNameBundlesMap.computeIfAbsent(
-					packageName.toString(), key -> new ArrayList<>());
-
-				bundles.add(bundle);
-			}
-		}
+		DBInspector dbInspector = new DBInspector(connection);
+		_packageNameBundlesMap = _getPackageNameBundlesMap();
 
 		StringBundler sb = new StringBundler();
 		List<String> tableNames = new ArrayList<>();
-
-		DBInspector dbInspector = new DBInspector(connection);
 
 		for (String tableName : dbInspector.getTableNames(null)) {
 			if (!dbInspector.hasColumn(tableName, "classNameId") ||
@@ -187,7 +160,7 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 			if (_isClassDefined(
 					bundleContext, definedClasses, models,
-					packageNameBundlesMap, value)) {
+					_packageNameBundlesMap, value)) {
 
 				continue;
 			}
@@ -228,6 +201,48 @@ public class ClassNamePostUpgradeDataCleanupProcess
 						String.join(", ", new TreeSet<>(usedTableNames))));
 			}
 		}
+	}
+
+	private Map<String, List<Bundle>> _getPackageNameBundlesMap() {
+		if (CompanyThreadLocal.getNonsystemCompanyId() !=
+				PortalInstancePool.getDefaultCompanyId()) {
+
+			return _packageNameBundlesMap;
+		}
+
+		Map<String, List<Bundle>> packageNameBundlesMap = new HashMap<>();
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
+
+			if (bundleWiring == null) {
+				continue;
+			}
+
+			for (BundleCapability bundleCapability :
+					bundleWiring.getCapabilities(
+						BundleRevision.PACKAGE_NAMESPACE)) {
+
+				Map<String, Object> attributes =
+					bundleCapability.getAttributes();
+
+				Object packageName = attributes.get(
+					BundleRevision.PACKAGE_NAMESPACE);
+
+				if (packageName == null) {
+					continue;
+				}
+
+				List<Bundle> bundles = packageNameBundlesMap.computeIfAbsent(
+					packageName.toString(), key -> new ArrayList<>());
+
+				bundles.add(bundle);
+			}
+		}
+
+		return packageNameBundlesMap;
 	}
 
 	private boolean _isClassDefined(
@@ -299,6 +314,8 @@ public class ClassNamePostUpgradeDataCleanupProcess
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ClassNamePostUpgradeDataCleanupProcess.class);
+
+	private static Map<String, List<Bundle>> _packageNameBundlesMap;
 
 	private final ClassNameLocalService _classNameLocalService;
 	private final CompanyLocalService _companyLocalService;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PortletPreferencesPostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PortletPreferencesPostUpgradeDataCleanupProcess.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -49,7 +50,7 @@ public class PortletPreferencesPostUpgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled()) {
+			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
 				_log.warn(
 					StringBundler.concat(
 						PortletPreferencesPostUpgradeDataCleanupProcess.class.

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
@@ -43,7 +44,7 @@ public class ResourceActionPostUpgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled()) {
+			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
 				_log.warn(
 					StringBundler.concat(
 						ResourceActionPostUpgradeDataCleanupProcess.class.

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -47,7 +48,7 @@ public class ResourcePermissionPostupgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled()) {
+			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
 				_log.warn(
 					StringBundler.concat(
 						ResourcePermissionPostupgradeDataCleanupProcess.class.

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/StorePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/StorePostUpgradeDataCleanupProcess.java
@@ -6,7 +6,6 @@
 package com.liferay.data.cleanup.internal.verify;
 
 import com.liferay.document.library.kernel.store.Store;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 /**
@@ -20,9 +19,7 @@ public class StorePostUpgradeDataCleanupProcess
 	}
 
 	public void cleanUp() throws Exception {
-		if (PortalInstancePool.getDefaultCompanyId() !=
-				CompanyThreadLocal.getCompanyId()) {
-
+		if (!CompanyThreadLocal.isDefaultCompany()) {
 			return;
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
@@ -22,17 +22,15 @@ public class SchemaUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		long companyId = CompanyThreadLocal.getCompanyId();
-		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
-
 		if (!PropsValues.DATABASE_PARTITION_ENABLED ||
-			(companyId == defaultCompanyId)) {
+			CompanyThreadLocal.isDefaultCompany()) {
 
 			return;
 		}
 
 		DatabaseMetaData databaseMetaData = connection.getMetaData();
 		DBInspector dbInspector = new DBInspector(connection);
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 
 		try (ResultSet resultSet = databaseMetaData.getTables(
 				dbInspector.getCatalog(), dbInspector.getSchema(), null,

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_3/QuartzDBPartitionUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_3/QuartzDBPartitionUpgradeProcess.java
@@ -8,7 +8,6 @@ package com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_3;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -19,9 +18,7 @@ public class QuartzDBPartitionUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (PortalUtil.getDefaultCompanyId() !=
-				CompanyThreadLocal.getCompanyId()) {
-
+		if (!CompanyThreadLocal.isDefaultCompany()) {
 			return;
 		}
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationDBPartitionUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationDBPartitionUpgradeProcess.java
@@ -37,9 +37,7 @@ public class ConfigurationDBPartitionUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (CompanyThreadLocal.getCompanyId() ==
-				PortalInstancePool.getDefaultCompanyId()) {
-
+		if (CompanyThreadLocal.isDefaultCompany()) {
 			try (PreparedStatement preparedStatement =
 					connection.prepareStatement(
 						"select configurationId, dictionary from " +

--- a/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTable.java
@@ -22,9 +22,7 @@ public class UpgradePartitionedControlTable extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (CompanyThreadLocal.getCompanyId() !=
-				PortalInstancePool.getDefaultCompanyId()) {
-
+		if (!CompanyThreadLocal.isDefaultCompany()) {
 			return;
 		}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -13,7 +13,6 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
@@ -213,9 +212,7 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 
 		Set<String> viewNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
-		if (CompanyThreadLocal.getNonsystemCompanyId() ==
-				PortalInstancePool.getDefaultCompanyId()) {
-
+		if (CompanyThreadLocal.isDefaultCompany()) {
 			return viewNames;
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -106,6 +106,16 @@ public class CompanyThreadLocal {
 		return companyId;
 	}
 
+	public static boolean isDefaultCompany() {
+		if (getNonsystemCompanyId() ==
+				PortalInstancePool.getDefaultCompanyId()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	public static boolean isInitializingPortalInstance() {
 		return _initializingPortalInstance.get();
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 10.1.0
+version 10.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98573

## What Is Being Fixed

The post-upgrade data cleanup processes did expensive, JVM-global work on every database partition: `ClassNamePostUpgradeDataCleanupProcess` rebuilt the OSGi package-to-bundles index and re-resolved class names against the bundles once per partition, ran a per-table usage query per table, and every cleanup process logged the "unsatisfied references" warning once per partition. The "is this the default partition" check was also duplicated inline across several DB-partition upgrade and verify processes with subtly inconsistent accessors.

## How It Is Being Fixed

The class name process is reworked so the heavy resolution is done once and reused: class-name resolution is cached, the per-table usage check is collapsed into a single union query, class names are resolved against the exporting bundle first, the class-definition check is extracted into a method, and locals are declared next to first use. The package-name-to-bundles map is now built only on the default company (which runs first and serially under partitioning) and reused across the remaining partitions.

The default-partition check is centralized as a new `CompanyThreadLocal.isDefaultCompany()` helper, and the duplicated inline checks across `ClassNamePostUpgradeDataCleanupProcess`, `StorePostUpgradeDataCleanupProcess`, `ConfigurationDBPartitionUpgradeProcess`, `QuartzDBPartitionUpgradeProcess`, `SchemaUpgradeProcess`, `UpgradePartitionedControlTable`, and `PreupgradeVerifyDatabaseState` are switched to it. The unsatisfied-references warning is gated to the default company so it is logged once instead of once per partition, and the `security.auth` package version is bumped for the new API.

## Why Are There No Tests?

These are refactors of existing `data-cleanup` code with no behavior change, covered by the existing integration tests in `data-cleanup-test`.

## PR Check

**pr-check: PASS** — tested on `bbf1749ba26fbc429e34f61af9150c8e989fa96e`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |

Full Portal Build was verified via targeted `portal-impl`/`portal-kernel` `ant compile` plus per-module force-recompiles, because `ant all` OOMs in this local checkout. Baseline caught a missing `com.liferay.portal.kernel.security.auth` version bump, fixed in the `Semantic Versioning` commit.

<!-- pr-check {"result": "success", "sha": "bbf1749ba26fbc429e34f61af9150c8e989fa96e"} -->
