### PR TITLE
LPD-98573 Revert the isDefaultCompany upgrade refactor

### DIFF
--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ClassNamePostUpgradeDataCleanupProcess.java
@@ -9,7 +9,7 @@ import com.liferay.data.cleanup.internal.verify.util.PostUpgradeDataCleanupProce
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.service.ObjectDefinitionLocalService;
-import com.liferay.petra.string.CharPool;
+import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.db.BaseDBProcess;
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
@@ -32,21 +31,14 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.wiring.BundleCapability;
-import org.osgi.framework.wiring.BundleRevision;
-import org.osgi.framework.wiring.BundleWiring;
 
 /**
  * @author Luis Ortiz
@@ -69,7 +61,7 @@ public class ClassNamePostUpgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
+			if (_log.isWarnEnabled()) {
 				_log.warn(
 					StringBundler.concat(
 						ClassNamePostUpgradeDataCleanupProcess.class.
@@ -82,10 +74,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 		}
 
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+		List<ClassName> classNames = _classNameLocalService.getClassNames(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 		DBInspector dbInspector = new DBInspector(connection);
-		_packageNameBundlesMap = _getPackageNameBundlesMap();
+		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
 
-		StringBundler sb = new StringBundler();
 		List<String> tableNames = new ArrayList<>();
 
 		for (String tableName : dbInspector.getTableNames(null)) {
@@ -95,31 +88,14 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				continue;
 			}
 
-			if (!tableNames.isEmpty()) {
-				sb.append(" union all ");
-			}
-
 			tableNames.add(tableName);
-
-			sb.append("select distinct '");
-			sb.append(tableName);
-			sb.append("' from ");
-			sb.append(tableName);
-			sb.append(" where classNameId = ?");
 		}
 
-		String usedTableNamesSQL = sb.toString();
-
-		List<ClassName> classNames = _classNameLocalService.getClassNames(
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-		Map<String, Boolean> definedClasses = new HashMap<>();
-		Set<String> models = new HashSet<>(ModelHintsUtil.getModels());
-
-		for (ClassName className : classNames) {
+		UnsafeConsumer<ClassName, Exception> unsafeConsumer = className -> {
 			String value = className.getValue();
 
 			if (!value.startsWith("com.liferay.")) {
-				continue;
+				return;
 			}
 
 			if (StringUtil.startsWith(
@@ -145,9 +121,11 @@ public class ClassNamePostUpgradeDataCleanupProcess
 					});
 
 				if (objectDefinition.get() != null) {
-					continue;
+					return;
 				}
 			}
+
+			boolean missing = false;
 
 			int index = value.indexOf(StringPool.DASH);
 
@@ -157,26 +135,58 @@ public class ClassNamePostUpgradeDataCleanupProcess
 				value = value.substring(0, index);
 			}
 
-			if (_isClassDefined(
-					bundleContext, definedClasses, models,
-					_packageNameBundlesMap, value)) {
+			for (String currentValue : value.split("[-_]")) {
+				if (models.contains(currentValue)) {
+					continue;
+				}
 
-				continue;
+				Class<?> clazz = null;
+
+				for (Bundle bundle : bundleContext.getBundles()) {
+					try {
+						clazz = bundle.loadClass(currentValue);
+
+						break;
+					}
+					catch (ClassNotFoundException classNotFoundException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(classNotFoundException);
+						}
+					}
+					catch (Exception exception) {
+						_log.error(exception);
+
+						return;
+					}
+				}
+
+				if (clazz == null) {
+					missing = true;
+
+					break;
+				}
+			}
+
+			if (!missing) {
+				return;
 			}
 
 			Set<String> usedTableNames = new HashSet<>();
 
-			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(usedTableNamesSQL)) {
+			for (String tableName : tableNames) {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							"select 1 from " + tableName +
+								" where classNameId = ?")) {
 
-				for (int i = 1; i <= tableNames.size(); i++) {
-					preparedStatement.setLong(i, className.getClassNameId());
-				}
+					preparedStatement.setLong(1, className.getClassNameId());
 
-				try (ResultSet resultSet = preparedStatement.executeQuery()) {
-					while (resultSet.next()) {
-						usedTableNames.add(
-							StringUtil.trim(resultSet.getString(1)));
+					try (ResultSet resultSet =
+							preparedStatement.executeQuery()) {
+
+						if (resultSet.next()) {
+							usedTableNames.add(tableName);
+						}
 					}
 				}
 			}
@@ -199,120 +209,15 @@ public class ClassNamePostUpgradeDataCleanupProcess
 						"referenced in the next tables: ",
 						String.join(", ", new TreeSet<>(usedTableNames))));
 			}
+		};
+
+		for (ClassName className : classNames) {
+			unsafeConsumer.accept(className);
 		}
-	}
-
-	private Map<String, List<Bundle>> _getPackageNameBundlesMap() {
-		if (!CompanyThreadLocal.isDefaultCompany()) {
-			return _packageNameBundlesMap;
-		}
-
-		Map<String, List<Bundle>> packageNameBundlesMap = new HashMap<>();
-
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-		for (Bundle bundle : bundleContext.getBundles()) {
-			BundleWiring bundleWiring = bundle.adapt(BundleWiring.class);
-
-			if (bundleWiring == null) {
-				continue;
-			}
-
-			for (BundleCapability bundleCapability :
-					bundleWiring.getCapabilities(
-						BundleRevision.PACKAGE_NAMESPACE)) {
-
-				Map<String, Object> attributes =
-					bundleCapability.getAttributes();
-
-				Object packageName = attributes.get(
-					BundleRevision.PACKAGE_NAMESPACE);
-
-				if (packageName == null) {
-					continue;
-				}
-
-				List<Bundle> bundles = packageNameBundlesMap.computeIfAbsent(
-					packageName.toString(), key -> new ArrayList<>());
-
-				bundles.add(bundle);
-			}
-		}
-
-		return packageNameBundlesMap;
-	}
-
-	private boolean _isClassDefined(
-		BundleContext bundleContext, Map<String, Boolean> definedClasses,
-		Set<String> models, Map<String, List<Bundle>> packageNameBundlesMap,
-		String value) {
-
-		for (String currentValue : value.split("[-_]")) {
-			if (models.contains(currentValue)) {
-				continue;
-			}
-
-			Boolean defined = definedClasses.get(currentValue);
-
-			if (defined != null) {
-				if (defined) {
-					continue;
-				}
-
-				return false;
-			}
-
-			Set<Bundle> candidateBundles = new LinkedHashSet<>();
-
-			int index = currentValue.lastIndexOf(CharPool.PERIOD);
-
-			if (index != -1) {
-				List<Bundle> exportingBundles = packageNameBundlesMap.get(
-					currentValue.substring(0, index));
-
-				if (exportingBundles != null) {
-					candidateBundles.addAll(exportingBundles);
-				}
-			}
-
-			Collections.addAll(candidateBundles, bundleContext.getBundles());
-
-			defined = false;
-
-			for (Bundle bundle : candidateBundles) {
-				try {
-					bundle.loadClass(currentValue);
-
-					defined = true;
-
-					break;
-				}
-				catch (ClassNotFoundException classNotFoundException) {
-					if (_log.isDebugEnabled()) {
-						_log.debug(classNotFoundException);
-					}
-				}
-				catch (Exception exception) {
-					_log.error(exception);
-
-					return true;
-				}
-			}
-
-			definedClasses.put(currentValue, defined);
-
-			if (!defined) {
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ClassNamePostUpgradeDataCleanupProcess.class);
-
-	private static Map<String, List<Bundle>> _packageNameBundlesMap;
 
 	private final ClassNameLocalService _classNameLocalService;
 	private final CompanyLocalService _companyLocalService;

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PortletPreferencesPostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/PortletPreferencesPostUpgradeDataCleanupProcess.java
@@ -13,7 +13,6 @@ import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -50,7 +49,7 @@ public class PortletPreferencesPostUpgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
+			if (_log.isWarnEnabled()) {
 				_log.warn(
 					StringBundler.concat(
 						PortletPreferencesPostUpgradeDataCleanupProcess.class.

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourceActionPostUpgradeDataCleanupProcess.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ResourceAction;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.upgrade.data.cleanup.util.DataCleanupLoggingUtil;
@@ -44,7 +43,7 @@ public class ResourceActionPostUpgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
+			if (_log.isWarnEnabled()) {
 				_log.warn(
 					StringBundler.concat(
 						ResourceActionPostUpgradeDataCleanupProcess.class.

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/ResourcePermissionPostupgradeDataCleanupProcess.java
@@ -15,7 +15,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
@@ -48,7 +47,7 @@ public class ResourcePermissionPostupgradeDataCleanupProcess
 	@Override
 	public void cleanUp() throws Exception {
 		if (!PostUpgradeDataCleanupProcessUtil.isEveryLiferayBundleResolved()) {
-			if (_log.isWarnEnabled() && CompanyThreadLocal.isDefaultCompany()) {
+			if (_log.isWarnEnabled()) {
 				_log.warn(
 					StringBundler.concat(
 						ResourcePermissionPostupgradeDataCleanupProcess.class.

--- a/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/StorePostUpgradeDataCleanupProcess.java
+++ b/modules/apps/data-cleanup/data-cleanup-impl/src/main/java/com/liferay/data/cleanup/internal/verify/StorePostUpgradeDataCleanupProcess.java
@@ -6,6 +6,7 @@
 package com.liferay.data.cleanup.internal.verify;
 
 import com.liferay.document.library.kernel.store.Store;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 
 /**
@@ -19,7 +20,9 @@ public class StorePostUpgradeDataCleanupProcess
 	}
 
 	public void cleanUp() throws Exception {
-		if (!CompanyThreadLocal.isDefaultCompany()) {
+		if (PortalInstancePool.getDefaultCompanyId() !=
+				CompanyThreadLocal.getCompanyId()) {
+
 			return;
 		}
 

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/upgrade/v9_2_2/SchemaUpgradeProcess.java
@@ -22,15 +22,17 @@ public class SchemaUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		long companyId = CompanyThreadLocal.getCompanyId();
+		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
+
 		if (!PropsValues.DATABASE_PARTITION_ENABLED ||
-			CompanyThreadLocal.isDefaultCompany()) {
+			(companyId == defaultCompanyId)) {
 
 			return;
 		}
 
 		DatabaseMetaData databaseMetaData = connection.getMetaData();
 		DBInspector dbInspector = new DBInspector(connection);
-		long defaultCompanyId = PortalInstancePool.getDefaultCompanyId();
 
 		try (ResultSet resultSet = databaseMetaData.getTables(
 				dbInspector.getCatalog(), dbInspector.getSchema(), null,

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_3/QuartzDBPartitionUpgradeProcess.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/upgrade/v1_0_3/QuartzDBPartitionUpgradeProcess.java
@@ -8,6 +8,7 @@ package com.liferay.portal.scheduler.quartz.internal.upgrade.v1_0_3;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
@@ -18,7 +19,9 @@ public class QuartzDBPartitionUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (!CompanyThreadLocal.isDefaultCompany()) {
+		if (PortalUtil.getDefaultCompanyId() !=
+				CompanyThreadLocal.getCompanyId()) {
+
 			return;
 		}
 

--- a/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationDBPartitionUpgradeProcess.java
+++ b/modules/apps/static/portal-configuration/portal-configuration-persistence-impl/src/main/java/com/liferay/portal/configuration/persistence/internal/upgrade/v2_0_0/ConfigurationDBPartitionUpgradeProcess.java
@@ -37,7 +37,9 @@ public class ConfigurationDBPartitionUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (CompanyThreadLocal.isDefaultCompany()) {
+		if (CompanyThreadLocal.getCompanyId() ==
+				PortalInstancePool.getDefaultCompanyId()) {
+
 			try (PreparedStatement preparedStatement =
 					connection.prepareStatement(
 						"select configurationId, dictionary from " +

--- a/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTable.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/UpgradePartitionedControlTable.java
@@ -22,7 +22,9 @@ public class UpgradePartitionedControlTable extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		if (!CompanyThreadLocal.isDefaultCompany()) {
+		if (CompanyThreadLocal.getCompanyId() !=
+				PortalInstancePool.getDefaultCompanyId()) {
+
 			return;
 		}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -13,6 +13,7 @@ import com.liferay.portal.events.StartupHelperUtil;
 import com.liferay.portal.kernel.dao.db.DBInspector;
 import com.liferay.portal.kernel.db.DBResourceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ReleaseConstants;
@@ -212,7 +213,9 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 
 		Set<String> viewNames = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
-		if (CompanyThreadLocal.isDefaultCompany()) {
+		if (CompanyThreadLocal.getNonsystemCompanyId() ==
+				PortalInstancePool.getDefaultCompanyId()) {
+
 			return viewNames;
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/CompanyThreadLocal.java
@@ -106,16 +106,6 @@ public class CompanyThreadLocal {
 		return companyId;
 	}
 
-	public static boolean isDefaultCompany() {
-		if (getNonsystemCompanyId() ==
-				PortalInstancePool.getDefaultCompanyId()) {
-
-			return true;
-		}
-
-		return false;
-	}
-
 	public static boolean isInitializingPortalInstance() {
 		return _initializingPortalInstance.get();
 	}


### PR DESCRIPTION
Reverts the 2026-07-24 batch of LPD-98573 (10 commits, *"Cache class name resolution to avoid repeat bundle scans"* → *"Semantic Versioning"*).

**Why:** bisected edge of a `ci:test:upgrade` regression. The functional-upgrade suite was green through the 2026-07-24 build (master `b4d38dda9d78e`) and began failing on 2026-07-25 (`dadf51d421ea`) across **all** databases — the major upgrade finishes `unresolved`, leaving the `journal` / `layout` / `layout-page-template` schemas unapplied, which cascades to Declarative Service unsatisfied components and `MainServlet` NPEs on every page.

The 4 earlier LPD-98573 commits from 2026-07-20 are intentionally kept (they were present in the passing builds).

Opening to validate on CI whether the revert restores a green upgrade run.
