### PR TITLE
LPD-98370 Land on Pages admin so the Product Menu renders

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/productnavigation/ProductMenu.macro
@@ -88,7 +88,7 @@ definition {
 
 			var siteNameURL = StringUtil.lowerCase(${siteNameURL});
 
-			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage");
+			Navigator.openWithAppendToBaseURL(urlAppend = "group/${siteNameURL}/~/control_panel/manage?p_p_id=com_liferay_layout_admin_web_portlet_GroupPagesPortlet");
 		}
 		else if (IsElementNotPresent(locator1 = "ProductMenu#TOGGLE")) {
 			ApplicationsMenu.gotoSite(site = ${site});


### PR DESCRIPTION
## What Is Being Fixed

`DatabasePartitioning#ExportAndAddDBPartition` fails inside `Smoke.runSmoke()` when the post-migration assertion expands the "Site Builder" Product Menu category. The same failure hits `#ExportNonPartitionedCompanyAndAddDBPartition`, `DatabasePartitioningUpgrade#ExportAndAddDBPartitionWithUpgradedDB`, and `DBMigrationImport#CanImportDatabaseToPostgreSQL` (LPD-91364, closed as a duplicate of this ticket) — all on the identical `ProductMenu.gotoPortlet(category = "Site Builder", portlet = "Pages", site = "Site Name")` call.

The failure is not a product or migration defect. `ProductMenu.gotoPortlet` navigated to `group/<site>/~/control_panel/manage` with no `p_p_id`, so the current portlet was the Applications Menu. `ProductNavigationProductMenuHelperImpl.isShowProductMenu` returns false when `PanelCategoryHelper.isApplicationsMenuApp(ppid)` is true, so the Product Menu and its toggle were absent and the side navigation rendered in their place. The side navigation is scoped to `PanelCategoryKeys.APPLICATIONS_MENU` (`SideNavigationDisplayContext` calls `getActivePanelCategory(APPLICATIONS_MENU, …)`), while "Site Builder" is `PanelCategoryKeys.SITE_ADMINISTRATION_BUILD` — a different panel tree. The requested category could therefore never be found, under any locator.

A second defect sits in the same macro. Since the `isSet(site)` branch took over the navigation, the `else if (IsElementNotPresent(TOGGLE))` branch could only ever run with `site` unset, so `ApplicationsMenu.gotoSite` always received null and went on to select a null site in the site selector or open a null site URL.

## How It Is Being Fixed

**`LPD-98370 Land on Pages admin so the Product Menu renders`** — supply the Pages admin portlet ID on the landing URL. `GroupPagesPanelApp` registers `LayoutAdminPortletKeys.GROUP_PAGES` under `SITE_ADMINISTRATION_BUILD`, so `isApplicationsMenuApp` is false, `isShowProductMenu` stays true, and the `group/<site>/~/` prefix scopes the menu to the site — restoring the Site Administration categories the existing `appGroup` locators target. This mirrors `PagesAdmin.openPagesAdmin`, which already reaches site administration with the same `control_panel/manage?p_p_id=…` form used across roughly forty macros.

**`LPD-98370 Remove the unreachable site navigation fallback`** — drop the dead `else if`. Callers that omit `site` now fail in `openProductMenu`, where a missing product menu is actually asserted, rather than inside a site selector they never asked for.

## Verification

Reproduced and confirmed locally on a plain portal — no PostgreSQL migration, partitioning, or upgrade needed, since the defect is purely navigational.

Before the fix:

```
com.liferay.poshi.runner.exception.ElementNotFoundPoshiRunnerException: Element is not
present at "//*[@data-qa-id='productMenu'] | //*[@data-qa-id='sideNavigationToggler']"
	at ProductMenuHelper.openProductMenu(ProductMenuHelper.macro:53)
	at ProductMenu.gotoPortlet(ProductMenu.macro:97)
```

After the fix the same navigation completes and reaches the requested portlet. Verified for a category that is already active ("Site Builder") and for one that must be expanded ("Content & Data" → Documents and Media). Poshi validation passes on both commits.

Reviewer note: the second commit changes behavior for `site`-less callers whose product menu toggle is absent. Every such path was already broken — `SiteSelector.selectSite(null)` cannot succeed — so this converts a misleading failure into an accurate one rather than fixing a working path. `ContentPages.macro` and the other `site`-less callers reach `gotoPortlet` with the toggle present and are unaffected.