### PR TITLE
LPD-99960 Avoid generating group friendly URLs with reserved keywords

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/GroupFriendlyURLRandomizerBumper.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/GroupFriendlyURLRandomizerBumper.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.randomizerbumpers;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.FriendlyURLKeywordsUtil;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+public class GroupFriendlyURLRandomizerBumper
+	implements RandomizerBumper<String> {
+
+	public static final GroupFriendlyURLRandomizerBumper INSTANCE =
+		new GroupFriendlyURLRandomizerBumper();
+
+	@Override
+	public boolean accept(String randomValue) {
+		if (Validator.isNull(randomValue)) {
+			return false;
+		}
+
+		return !FriendlyURLKeywordsUtil.hasFriendlyURLKeyword(
+			StringPool.SLASH +
+				FriendlyURLNormalizerUtil.normalize(randomValue));
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.randomizerbumpers.GroupFriendlyURLRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
@@ -80,6 +81,7 @@ public class GroupTestUtil {
 		throws Exception {
 
 		String name = RandomTestUtil.randomString(
+			GroupFriendlyURLRandomizerBumper.INSTANCE,
 			NumericStringRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
 
@@ -156,6 +158,7 @@ public class GroupTestUtil {
 		throws Exception {
 
 		String name = RandomTestUtil.randomString(
+			GroupFriendlyURLRandomizerBumper.INSTANCE,
 			NumericStringRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
 
@@ -230,6 +233,7 @@ public class GroupTestUtil {
 		throws Exception {
 
 		String name = RandomTestUtil.randomString(
+			GroupFriendlyURLRandomizerBumper.INSTANCE,
 			NumericStringRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99960

## What Is Being Fixed

GroupTestUtil.addGroup derives a site friendly URL from an eight character random name, without checking it against the reserved keywords in the sites.friendly.url.keywords portal property. When the random name happens to start with one of the wildcard keywords, such as api, webdav, widget, sharepoint or sitemap, GroupLocalServiceImpl rejects it with a GroupFriendlyURLException and whichever integration test drew that name fails. The odds are roughly 3.5e-5 per call, so it surfaces as a rare flaky spread across the whole integration suite rather than a failure attributable to any one test. It was last seen on DatabaseSchemaExportResourceTest, which passed on seven of eight database configurations in the same build and passed again on a later commit.

## How It Is Being Fixed

A new GroupFriendlyURLRandomizerBumper rejects any candidate whose normalized friendly URL matches FriendlyURLKeywordsUtil.hasFriendlyURLKeyword, which reads the same property the product validation consults, so the bumper and the validation can never disagree. It is the group counterpart of the existing LayoutFriendlyURLRandomizerBumper, and simpler, since the keywords utility returns a boolean instead of throwing. The bumper is then applied to the three GroupTestUtil methods that generate a name themselves; the overloads that take a caller supplied name are left alone, since the caller owns that value. Adding a class to an exported package takes the randomizer bumpers package to 1.1.0.

## Why Are There No Tests?

The change is itself shared test infrastructure, and the acceptance criteria on the ticket require it to stay confined there. The guard is exercised by every integration test that calls GroupTestUtil.addGroup. It was verified locally by generating 500,000 names through the bumper and confirming none collide with a reserved keyword, where the unguarded rate would have produced roughly 17.

## PR Check

**pr-check: PASS** — tested on `601680db2ff51ebaf436f2db007518e881fa10a5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Baseline | PASS |

Full Portal Build matched mechanically (`portal-test/` is in its include list) but was trimmed: the diff is confined to `portal-test`, which is not on the compile classpath of the portal or any module. `ant compile` in `portal-test` covers it and passed, as did `ant jar`.

<!-- pr-check {"result": "success", "sha": "601680db2ff51ebaf436f2db007518e881fa10a5"} -->
