### PR TITLE
LPD-99960 Avoid generating site friendly URLs with reserved keywords

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/checker/FriendlyURLPublicMappingCheckerImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/checker/FriendlyURLPublicMappingCheckerImpl.java
@@ -162,7 +162,7 @@ public class FriendlyURLPublicMappingCheckerImpl
 		String title) {
 
 		if (Validator.isNull(friendlyURL) ||
-			!FriendlyURLKeywordsUtil.hasFriendlyURLKeyword(friendlyURL)) {
+			!FriendlyURLKeywordsUtil.hasSiteFriendlyURLKeyword(friendlyURL)) {
 
 			return;
 		}

--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.FriendlyURLKeywordsUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
@@ -121,9 +122,7 @@ import java.util.TreeSet;
 public class LayoutImpl extends LayoutBaseImpl {
 
 	public static boolean hasFriendlyURLKeyword(String friendlyURL) {
-		String keyword = _getFriendlyURLKeyword(friendlyURL);
-
-		return Validator.isNotNull(keyword);
+		return FriendlyURLKeywordsUtil.hasLayoutFriendlyURLKeyword(friendlyURL);
 	}
 
 	public static int validateFriendlyURL(String friendlyURL) {
@@ -183,7 +182,8 @@ public class LayoutImpl extends LayoutBaseImpl {
 	public static void validateFriendlyURLKeyword(String friendlyURL)
 		throws LayoutFriendlyURLException {
 
-		String keyword = _getFriendlyURLKeyword(friendlyURL);
+		String keyword = FriendlyURLKeywordsUtil.getLayoutFriendlyURLKeyword(
+			friendlyURL);
 
 		if (Validator.isNotNull(keyword)) {
 			LayoutFriendlyURLException layoutFriendlyURLException =
@@ -1614,22 +1614,6 @@ public class LayoutImpl extends LayoutBaseImpl {
 		super.setTypeSettings(_typeSettingsUnicodeProperties.toString());
 	}
 
-	private static String _getFriendlyURLKeyword(String friendlyURL) {
-		friendlyURL = StringUtil.toLowerCase(friendlyURL);
-
-		for (String keyword : _FRIENDLY_URL_KEYWORDS) {
-			if (friendlyURL.startsWith(keyword)) {
-				return keyword;
-			}
-
-			if (keyword.equals(friendlyURL + StringPool.SLASH)) {
-				return friendlyURL;
-			}
-		}
-
-		return null;
-	}
-
 	private ColorScheme _getColorScheme() throws PortalException {
 		if (isInheritLookAndFeel()) {
 			LayoutSet layoutSet = getLayoutSet();
@@ -1901,33 +1885,7 @@ public class LayoutImpl extends LayoutBaseImpl {
 		return url;
 	}
 
-	private static final String[] _FRIENDLY_URL_KEYWORDS;
-
 	private static final Log _log = LogFactoryUtil.getLog(LayoutImpl.class);
-
-	static {
-		_FRIENDLY_URL_KEYWORDS =
-			new String[PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length];
-
-		for (int i = 0; i < PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS.length;
-			 i++) {
-
-			String keyword = PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS[i];
-
-			keyword = StringPool.SLASH + keyword;
-
-			if (!keyword.contains(StringPool.PERIOD)) {
-				if (keyword.endsWith(StringPool.STAR)) {
-					keyword = keyword.substring(0, keyword.length() - 1);
-				}
-				else {
-					keyword = keyword + StringPool.SLASH;
-				}
-			}
-
-			_FRIENDLY_URL_KEYWORDS[i] = StringUtil.toLowerCase(keyword);
-		}
-	}
 
 	private ColorScheme _colorScheme;
 	private String _faviconURL;

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -5635,7 +5635,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 	private void _validateFriendlyURLKeyword(String friendlyURL)
 		throws PortalException {
 
-		String keyword = FriendlyURLKeywordsUtil.getFriendlyURLKeyword(
+		String keyword = FriendlyURLKeywordsUtil.getSiteFriendlyURLKeyword(
 			friendlyURL);
 
 		if (Validator.isNull(keyword)) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
@@ -12,15 +12,34 @@ import com.liferay.petra.string.StringPool;
  */
 public class FriendlyURLKeywordsUtil {
 
+	public static String getLayoutFriendlyURLKeyword(String friendlyURL) {
+		return _getFriendlyURLKeyword(
+			friendlyURL, _LAYOUT_FRIENDLY_URL_KEYWORDS);
+	}
+
 	public static String getSiteFriendlyURLKeyword(String friendlyURL) {
+		return _getFriendlyURLKeyword(friendlyURL, _SITE_FRIENDLY_URL_KEYWORDS);
+	}
+
+	public static boolean hasLayoutFriendlyURLKeyword(String friendlyURL) {
+		return Validator.isNotNull(getLayoutFriendlyURLKeyword(friendlyURL));
+	}
+
+	public static boolean hasSiteFriendlyURLKeyword(String friendlyURL) {
+		return Validator.isNotNull(getSiteFriendlyURLKeyword(friendlyURL));
+	}
+
+	private static String _getFriendlyURLKeyword(
+		String friendlyURL, String[] friendlyURLKeywords) {
+
 		friendlyURL = StringUtil.toLowerCase(friendlyURL);
 
-		for (String keyword : _SITE_FRIENDLY_URL_KEYWORDS) {
-			if (friendlyURL.startsWith(keyword)) {
-				return keyword;
+		for (String friendlyURLKeyword : friendlyURLKeywords) {
+			if (friendlyURL.startsWith(friendlyURLKeyword)) {
+				return friendlyURLKeyword;
 			}
 
-			if (keyword.equals(friendlyURL + StringPool.SLASH)) {
+			if (friendlyURLKeyword.equals(friendlyURL + StringPool.SLASH)) {
 				return friendlyURL;
 			}
 		}
@@ -28,24 +47,11 @@ public class FriendlyURLKeywordsUtil {
 		return null;
 	}
 
-	public static boolean hasSiteFriendlyURLKeyword(String friendlyURL) {
-		String keyword = getSiteFriendlyURLKeyword(friendlyURL);
+	private static String[] _toFriendlyURLKeywords(String[] keywords) {
+		String[] friendlyURLKeywords = new String[keywords.length];
 
-		return Validator.isNotNull(keyword);
-	}
-
-	private static final String[] _SITE_FRIENDLY_URL_KEYWORDS;
-
-	static {
-		_SITE_FRIENDLY_URL_KEYWORDS =
-			new String[PropsValues.SITES_FRIENDLY_URL_KEYWORDS.length];
-
-		for (int i = 0; i < PropsValues.SITES_FRIENDLY_URL_KEYWORDS.length;
-			 i++) {
-
-			String keyword = PropsValues.SITES_FRIENDLY_URL_KEYWORDS[i];
-
-			keyword = StringPool.SLASH + keyword;
+		for (int i = 0; i < keywords.length; i++) {
+			String keyword = StringPool.SLASH + keywords[i];
 
 			if (!keyword.contains(StringPool.PERIOD)) {
 				if (keyword.endsWith(StringPool.STAR)) {
@@ -56,8 +62,16 @@ public class FriendlyURLKeywordsUtil {
 				}
 			}
 
-			_SITE_FRIENDLY_URL_KEYWORDS[i] = StringUtil.toLowerCase(keyword);
+			friendlyURLKeywords[i] = StringUtil.toLowerCase(keyword);
 		}
+
+		return friendlyURLKeywords;
 	}
+
+	private static final String[] _LAYOUT_FRIENDLY_URL_KEYWORDS =
+		_toFriendlyURLKeywords(PropsValues.LAYOUT_FRIENDLY_URL_KEYWORDS);
+
+	private static final String[] _SITE_FRIENDLY_URL_KEYWORDS =
+		_toFriendlyURLKeywords(PropsValues.SITES_FRIENDLY_URL_KEYWORDS);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/FriendlyURLKeywordsUtil.java
@@ -12,10 +12,10 @@ import com.liferay.petra.string.StringPool;
  */
 public class FriendlyURLKeywordsUtil {
 
-	public static String getFriendlyURLKeyword(String friendlyURL) {
+	public static String getSiteFriendlyURLKeyword(String friendlyURL) {
 		friendlyURL = StringUtil.toLowerCase(friendlyURL);
 
-		for (String keyword : _FRIENDLY_URL_KEYWORDS) {
+		for (String keyword : _SITE_FRIENDLY_URL_KEYWORDS) {
 			if (friendlyURL.startsWith(keyword)) {
 				return keyword;
 			}
@@ -28,16 +28,16 @@ public class FriendlyURLKeywordsUtil {
 		return null;
 	}
 
-	public static boolean hasFriendlyURLKeyword(String friendlyURL) {
-		String keyword = getFriendlyURLKeyword(friendlyURL);
+	public static boolean hasSiteFriendlyURLKeyword(String friendlyURL) {
+		String keyword = getSiteFriendlyURLKeyword(friendlyURL);
 
 		return Validator.isNotNull(keyword);
 	}
 
-	private static final String[] _FRIENDLY_URL_KEYWORDS;
+	private static final String[] _SITE_FRIENDLY_URL_KEYWORDS;
 
 	static {
-		_FRIENDLY_URL_KEYWORDS =
+		_SITE_FRIENDLY_URL_KEYWORDS =
 			new String[PropsValues.SITES_FRIENDLY_URL_KEYWORDS.length];
 
 		for (int i = 0; i < PropsValues.SITES_FRIENDLY_URL_KEYWORDS.length;
@@ -56,7 +56,7 @@ public class FriendlyURLKeywordsUtil {
 				}
 			}
 
-			_FRIENDLY_URL_KEYWORDS[i] = StringUtil.toLowerCase(keyword);
+			_SITE_FRIENDLY_URL_KEYWORDS[i] = StringUtil.toLowerCase(keyword);
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 99.0.0
+version 100.0.0

--- a/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/SiteFriendlyURLKeywordRandomizerBumper.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/SiteFriendlyURLKeywordRandomizerBumper.java
@@ -1,0 +1,33 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.randomizerbumpers;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.FriendlyURLKeywordsUtil;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Mariano Álvaro Sáiz
+ */
+public class SiteFriendlyURLKeywordRandomizerBumper
+	implements RandomizerBumper<String> {
+
+	public static final SiteFriendlyURLKeywordRandomizerBumper INSTANCE =
+		new SiteFriendlyURLKeywordRandomizerBumper();
+
+	@Override
+	public boolean accept(String randomValue) {
+		if (Validator.isNull(randomValue)) {
+			return false;
+		}
+
+		return !FriendlyURLKeywordsUtil.hasSiteFriendlyURLKeyword(
+			StringPool.SLASH +
+				FriendlyURLNormalizerUtil.normalize(randomValue));
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/randomizerbumpers/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/GroupTestUtil.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
+import com.liferay.portal.kernel.test.randomizerbumpers.SiteFriendlyURLKeywordRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -81,6 +82,7 @@ public class GroupTestUtil {
 
 		String name = RandomTestUtil.randomString(
 			NumericStringRandomizerBumper.INSTANCE,
+			SiteFriendlyURLKeywordRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
 
 		Group group = GroupLocalServiceUtil.fetchGroup(companyId, name);
@@ -157,6 +159,7 @@ public class GroupTestUtil {
 
 		String name = RandomTestUtil.randomString(
 			NumericStringRandomizerBumper.INSTANCE,
+			SiteFriendlyURLKeywordRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
 
 		return addGroup(parentGroupId, name, serviceContext);
@@ -231,6 +234,7 @@ public class GroupTestUtil {
 
 		String name = RandomTestUtil.randomString(
 			NumericStringRandomizerBumper.INSTANCE,
+			SiteFriendlyURLKeywordRandomizerBumper.INSTANCE,
 			UniqueStringRandomizerBumper.INSTANCE);
 
 		Group group = GroupLocalServiceUtil.fetchGroup(companyId, name);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99960

## What Is Being Fixed

GroupTestUtil.addGroup derives a site friendly URL from an eight character random name, without checking it against the reserved keywords in the sites.friendly.url.keywords portal property. When the random name happens to start with one of the wildcard keywords, such as api, webdav, widget, sharepoint or sitemap, GroupLocalServiceImpl rejects it with a GroupFriendlyURLException and whichever integration test drew that name fails. The odds are roughly 3.5e-5 per call, so it surfaces as a rare flaky spread across the whole integration suite rather than a failure attributable to any one test.

The keyword lookup the fix needs was also misnamed. FriendlyURLKeywordsUtil was extracted over layout.friendly.url.keywords and later repointed to sites.friendly.url.keywords without being renamed, so its getFriendlyURLKeyword and hasFriendlyURLKeyword claimed no scope while reading the site list, and LayoutImpl carried a private duplicate of the same matching and normalization logic over the layout list.

## How It Is Being Fixed

The site lookups are renamed to getSiteFriendlyURLKeyword and hasSiteFriendlyURLKeyword, so each method names the property it reads. The layout counterparts are then added to the same class and LayoutImpl delegates to them, which removes the duplicated keyword matching and the duplicated keyword normalization; LayoutImpl keeps its public signatures, so its callers are untouched.

On top of that, a new SiteFriendlyURLKeywordRandomizerBumper rejects any candidate whose normalized friendly URL matches hasSiteFriendlyURLKeyword, which reads the same property the product validation consults, so the bumper and the validation can never disagree. It is applied to the three GroupTestUtil methods that generate a name themselves; the overloads that take a caller supplied name are left alone, since the caller owns that value.

## Why Are There No Tests?

The bumper is itself shared test infrastructure, and the acceptance criteria on the ticket require it to stay confined there. The kernel changes are a rename and a de-duplication with no behavior change: the layout lookups resolve against the same layout.friendly.url.keywords property, through the same matching and normalization, so the existing group and layout friendly URL coverage exercises them unchanged.

## PR Check

**pr-check: PASS** — tested on `e65d9b6014a261e93c596b766cc4747859eb0d72`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e65d9b6014a261e93c596b766cc4747859eb0d72"} -->
