### PR TITLE
LPD-98371 Schedule web content with a date the publish modal accepts

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1547,7 +1547,7 @@ definition {
 
 	@summary = "Default summary"
 	macro increaseDisplayDate(minuteIncrease = null) {
-		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd HH:mm", "UTC");
+		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd hh:mm a", "UTC");
 
 		WebContent.scheduleWCArticleWithPermissions(displayDate = ${displayDate});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
@@ -1894,7 +1894,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00 AM");
 		}
 
 		task ("Go to Content Dashboard and click on the title") {
@@ -3694,7 +3694,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title Scheduled");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00 AM");
 		}
 
 		task ("Filter asset at Content Dashboard using status") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
@@ -1596,7 +1596,7 @@ definition {
 			webContentContent = "Web Content Content",
 			webContentTitle = "Web Content Title");
 
-		WebContent.scheduleWCArticleWithPermissions(displayDate = "01/01/2050");
+		WebContent.scheduleWCArticleWithPermissions(displayDate = "2050-01-01 01:00 AM");
 
 		Publications.publishPublication(
 			gotoPublicationsAdmin = "true",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
@@ -1113,7 +1113,7 @@ definition {
 				webContentContent = "Web Content Content",
 				webContentTitle = "Web Content Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01 AM");
 		}
 
 		task ("Add a page with a Web Content Display widget and display the Web Content article in the Web Content Display widget") {


### PR DESCRIPTION
Four hardcoded date literals never satisfied the publish scheduler's format, so the tests they drive were silently not scheduling anything.

## What was wrong

LPD-96224 made the publish scheduler require `yyyy-MM-dd hh:mm a` at exactly nineteen characters. Three literals were sixteen characters and one was a ten-character `MM/dd/yyyy`. All four are rejected before anything is scheduled, so the article stays a draft, never reaches SCHEDULED, and its status label never renders — which is what the `label-item` assertions were failing on. The locator is correct; the label is genuinely absent.

Poshi reports the missing success message as a warning rather than a failure, so the run continued to the SCHEDULED assertion and the real cause stayed hidden. Confirmed from the `summary.html` step trail rather than inferred:

```
Type to SCHEDULE_DATE the value 2026-07-23 03:17   -> PASSED    (16 chars, needs 19)
Click on SCHEDULE_IN_MODAL                        -> PASSED
Verify SUCCESS_DISMISSIBLE is available           -> WARNING   (swallowed)
Assert ENTRY_LIST_WORKFLOW_STATUS == SCHEDULED    -> FAILED
```

## Two behaviour changes to check

`Publications.testcase:1599` and `ContentDashboard#FilterByStatusScheduled` have never actually scheduled anything. They pass today only because they never assert SCHEDULED. After this change they schedule for the first time, so the remainder of each testcase must tolerate a scheduled rather than immediately-published article.

`Publications` is a full rewrite rather than an append — it used a different format, so treating this as a uniform "add the meridiem" would miss it.

## Scope

Fixes LPD-98371 and LPD-98372, which are the same defect against different fixtures. Also repairs `ContentDashboard#FilterByStatusScheduled`, which fails from the same cause in a non-partitioned suite and has no ticket of its own.

Nothing here is partition-specific; LPD-98371 has been recomponented to Web Content and linked to LPD-96224 as the cause.