### PR TITLE
LPD-90739 Upgrade portlet preferences serially on DB2

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/BasePortletPreferencesUpgradeProcess.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/BasePortletPreferencesUpgradeProcess.java
@@ -5,8 +5,12 @@
 
 package com.liferay.portal.kernel.upgrade;
 
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
@@ -24,6 +28,7 @@ import jakarta.portlet.ReadOnlyException;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.Statement;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -365,6 +370,28 @@ public abstract class BasePortletPreferencesUpgradeProcess
 		return preferenceValuesMap;
 	}
 
+	private void _process(
+			String sql,
+			UnsafeFunction<ResultSet, Object[], Exception> unsafeFunction,
+			UnsafeConsumer<Object[], Exception> unsafeConsumer)
+		throws Exception {
+
+		if (DBManagerUtil.getDBType() != DBType.DB2) {
+			processConcurrently(sql, unsafeFunction, unsafeConsumer, null);
+
+			return;
+		}
+
+		try (Statement statement = connection.createStatement();
+
+			ResultSet resultSet = statement.executeQuery(sql)) {
+
+			while (resultSet.next()) {
+				unsafeConsumer.accept(unsafeFunction.apply(resultSet));
+			}
+		}
+	}
+
 	private String _toXMLString(Map<String, PreferenceValues> preferenceMap) {
 		if (preferenceMap.isEmpty()) {
 			return PortletConstants.DEFAULT_PREFERENCES;
@@ -409,7 +436,7 @@ public abstract class BasePortletPreferencesUpgradeProcess
 			sb.append(whereClause);
 		}
 
-		processConcurrently(
+		_process(
 			sb.toString(),
 			resultSet -> {
 				long portletPreferencesId = resultSet.getLong(
@@ -426,7 +453,7 @@ public abstract class BasePortletPreferencesUpgradeProcess
 					portletId, preferences
 				};
 			},
-			values -> _updatePortletPreferences(values), null);
+			values -> _updatePortletPreferences(values));
 	}
 
 	private void _updatePortletPreferences(Object[] values) throws Exception {
@@ -511,7 +538,7 @@ public abstract class BasePortletPreferencesUpgradeProcess
 			sb.append(whereClause);
 		}
 
-		processConcurrently(
+		_process(
 			sb.toString(),
 			resultSet -> {
 				long portletPreferencesId = resultSet.getLong(
@@ -528,7 +555,7 @@ public abstract class BasePortletPreferencesUpgradeProcess
 					portletId, ctCollectionId
 				};
 			},
-			values -> _updatePortletPreferenceValues(values), null);
+			values -> _updatePortletPreferenceValues(values));
 	}
 
 	private void _updatePortletPreferenceValues(Object[] values)


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90739

## What Is Being Fixed

On DB2, the upgrade stalls for more than ten minutes on a single step: `ALTER TABLE PORTLETPREFERENCES DROP PRIMARY KEY`, run by `CTModelUpgradeProcess`. `UpgradeQueryMonitor` reports it as LOCKWAIT, and the delay blows the smoke upgrade time budget.

The cause is a connection-scoped DB2 lock. An update against a table that carries pending row-format variations from an earlier add column takes a VARIATION lock in share mode, and that lock survives the commit, survives the rollback, and survives the connection's return to the pool: only a physical disconnect releases it. `BasePortletPreferencesUpgradeProcess` dispatches its updates with `processConcurrently`, so every worker leaves a pooled connection holding VARIATION in share mode. The drop needs the same lock in exclusive mode, so it waits for the connection pool to evict those idle connections. With an infinite lock timeout the upgrade still finishes correctly, so this is a liveness problem rather than a correctness one.

## How It Is Being Fixed

`BasePortletPreferencesUpgradeProcess` now routes both of its fan-out call sites through a helper that runs a serial loop on DB2 and delegates to `processConcurrently` everywhere else, mirroring the guard `BaseCompanyIdUpgradeProcess` already applies to SQLServer. Keeping the updates on the upgrade's own connection means no foreign connection holds the lock when the primary key is dropped.

Measured with an A/B on a local from-6.2 upgrade against DB2 11.5.9. Unpatched, the step stalled past thirteen minutes and `db2pd` showed five granted VARIATION share holders against the drop's exclusive request. With only this process serialized, the step took 156 ms and the whole upgrade completed successfully in 742 seconds. `v7_0_0.UpgradeCompanyId` stayed concurrent in the passing run, so it needs no change. Serializing is also cheaper per process here: the four affected processes went from about 1009 ms each to between 8 ms and 24 ms, because the fan-out spent roughly a second starting workers for a handful of rows.

## Why Are There No Tests?

The change guards an upgrade-time concurrency interaction that only manifests against a live DB2 instance: it needs a table carrying pending row-format variations, a concurrent update fan-out over pooled connections, and a subsequent DDL requiring the VARIATION lock in exclusive mode. That is not reachable from a unit test or from the integration suite, which runs against a single database with no lock instrumentation. It was validated instead by the A/B on a real DB2 11.5.9 from-6.2 upgrade described above. The existing `BasePortletPreferencesUpgradeProcessTest` integration test covers the process itself and still compiles and applies unchanged, and the analogous SQLServer guard in `BaseCompanyIdUpgradeProcess` carries no test either.

## PR Check

**pr-check: PASS** — tested on `a3071f7bdab1d55216ab7826d03c1720a3ef9d93`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a3071f7bdab1d55216ab7826d03c1720a3ef9d93"} -->
