### PR TITLE
LPD-92877 Fix OptimisticLockException deleting a CT collection

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -36,6 +36,7 @@ import com.liferay.change.tracking.model.CTEntryTable;
 import com.liferay.change.tracking.model.CTPreferences;
 import com.liferay.change.tracking.model.CTSchemaVersion;
 import com.liferay.change.tracking.model.CTScore;
+import com.liferay.change.tracking.model.impl.CTScoreImpl;
 import com.liferay.change.tracking.service.CTEntryLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.change.tracking.service.CTSchemaVersionLocalService;
@@ -66,6 +67,8 @@ import com.liferay.portal.kernel.change.tracking.sql.CTSQLModeThreadLocal;
 import com.liferay.portal.kernel.cluster.ClusterExecutorUtil;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.jdbc.CurrentConnection;
+import com.liferay.portal.kernel.dao.orm.LockMode;
+import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -572,7 +575,22 @@ public class CTCollectionLocalServiceImpl
 			ctCollection.getCtCollectionId());
 
 		if (ctScore != null) {
-			_ctScorePersistence.remove(ctScore);
+			Session session = _ctScorePersistence.openSession();
+
+			try {
+				session.evict(CTScoreImpl.class, ctScore.getCtScoreId());
+
+				ctScore = (CTScore)session.get(
+					CTScoreImpl.class, ctScore.getCtScoreId(),
+					LockMode.UPGRADE);
+
+				if (ctScore != null) {
+					_ctScorePersistence.remove(ctScore);
+				}
+			}
+			finally {
+				_ctScorePersistence.closeSession(session);
+			}
 		}
 
 		Group group = _groupLocalService.fetchGroup(

--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTScoreLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTScoreLocalServiceImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
 import com.liferay.portal.kernel.service.SQLStateAcceptor;
 import com.liferay.portal.kernel.spring.aop.Property;
 import com.liferay.portal.kernel.spring.aop.Retry;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 
@@ -205,7 +206,14 @@ public class CTScoreLocalServiceImpl extends CTScoreLocalServiceBaseImpl {
 			ctScorePersistence.closeSession(session);
 		}
 
-		_sendUserNotificationEvents(ctScore, originalCTScore);
+		CTScore updatedCTScore = ctScore;
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> {
+				_sendUserNotificationEvents(updatedCTScore, originalCTScore);
+
+				return null;
+			});
 
 		return ctScore;
 	}

--- a/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTScoreLocalServiceTest.java
+++ b/modules/apps/change-tracking/change-tracking-test/src/testIntegration/java/com/liferay/change/tracking/service/test/CTScoreLocalServiceTest.java
@@ -8,8 +8,10 @@ package com.liferay.change.tracking.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.change.tracking.model.CTCollection;
+import com.liferay.change.tracking.model.CTScore;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTScoreLocalService;
+import com.liferay.change.tracking.service.persistence.CTScorePersistence;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.test.util.DLTestUtil;
@@ -20,7 +22,10 @@ import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.change.tracking.CTCollectionThreadLocal;
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -147,6 +152,39 @@ public class CTScoreLocalServiceTest {
 	}
 
 	@Test
+	public void testDeleteCTCollectionWithOutdatedCTScoreVersion()
+		throws Throwable {
+
+		long ctCollectionId = _ctCollection1.getCtCollectionId();
+
+		TransactionConfig transactionConfig = TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {Exception.class});
+
+		TransactionInvokerUtil.invoke(
+			transactionConfig,
+			() -> {
+				CTScore ctScore = _ctScorePersistence.fetchByCtCollectionId(
+					ctCollectionId, false);
+
+				DB db = DBManagerUtil.getDB();
+
+				db.runSQL(
+					StringBundler.concat(
+						"update CTScore set mvccVersion = mvccVersion + 1 ",
+						"where ctScoreId = ", ctScore.getCtScoreId()));
+
+				_ctCollectionLocalService.deleteCTCollection(_ctCollection1);
+
+				return null;
+			});
+
+		_ctCollection1 = null;
+
+		Assert.assertNull(
+			_ctScoreLocalService.fetchCTScoreByCTCollectionId(ctCollectionId));
+	}
+
+	@Test
 	public void testUpdateCTScore() throws Throwable {
 		_ctCollection1 = _ctCollectionLocalService.fetchCTCollection(
 			_ctCollection1.getCtCollectionId());
@@ -206,6 +244,9 @@ public class CTScoreLocalServiceTest {
 
 	@Inject
 	private CTScoreLocalService _ctScoreLocalService;
+
+	@Inject
+	private CTScorePersistence _ctScorePersistence;
 
 	@Inject
 	private DDMStructureLocalService _ddmStructureLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92877

## What Is Being Fixed

`UpgradeVirtualHostTest.testMissingCtCollectionId` fails intermittently in `ci:test:upgrade` with `OptimisticLockException: ... delete from CTScore where ctScoreId=? and mvccVersion=?; actual row count: 0; expected: 1`.

Adding a `CTEntry` registers a transaction commit callback that sends a CT_SCORE message after the request commits. `CTScoreMessageListener` handles it on a serial destination, and because `incrementScore` is `@BufferedIncrement`, the work lands on yet another thread in its own transaction. That transaction takes `LockMode.UPGRADE` on the CT score row and holds it until commit. Meanwhile `deleteCTCollection` reads the CT score without a lock and removes it, and because `CTScore` is MVCC-enabled the removal is a version-checked delete. The delete blocks on the increment's row lock, the increment commits a new version, and the delete then matches no rows.

This is not test-only. A user who edits content in a publication and then discards it can land in the same window, in which case the discard rolls back with an error. The same applies to the REST and GraphQL delete endpoints and to the batch delete loop.

## How It Is Being Fixed

`deleteCTCollection` now evicts the CT score from the persistence context and rereads it under `LockMode.UPGRADE` before removing it. The locked read waits for a pending increment and returns the version that is actually committed, so the delete always matches. The evict is what keeps Hibernate from performing a version-checked lock upgrade on an already attached stale instance, which would replace the failure with a `StaleObjectStateException` whenever the finder cache misses. Nothing is added to the increment path, so the hot path pays no extra flush.

A second change moves the user notification fan-out in `_updateScore` into a commit callback. The fan-out was running inside the increment transaction while the row lock was still held, so it set the ceiling on how long a concurrent delete waits.

The first commit adds the regression test. It reproduces the race deterministically without threads by loading the CT score into the session and then changing its version behind Hibernate's back. Verified locally: the test fails with the exact stack above when the fix is reverted and passes with it, and the full `CTScoreLocalServiceTest` and `CTCollectionLocalServiceTest` suites pass (12 of 12) on a clean portal boot.

## PR Check

**pr-check: FAIL** — tested on `480e27615ae313220a659ddd43a99561074f0539`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | FAIL |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

**Transaction usage requires Core Infrastructure review.** New transaction code (`@Transactional`, `TransactionInvokerUtil`, etc.) has heavy performance implications and requires additional review. After team review is complete, please send this pull request to @liferay-core-infra and request review from @shuyangzhou. For additional questions, use #t-core-infrastructure on Slack.

<!-- pr-check {"result": "failure", "sha": "480e27615ae313220a659ddd43a99561074f0539"} -->
