### PR TITLE
LPD-100292 Load language override bundles per company

### DIFF
--- a/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/PLOOverrideResourceBundleManager.java
+++ b/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/PLOOverrideResourceBundleManager.java
@@ -8,8 +8,6 @@ package com.liferay.portal.language.override.internal;
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.language.LanguageResources;
 import com.liferay.portal.language.override.internal.provider.PLOOriginalTranslationThreadLocal;
 import com.liferay.portal.language.override.model.PLOEntry;
@@ -23,7 +21,6 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -35,13 +32,31 @@ import org.osgi.service.component.annotations.Reference;
 public class PLOOverrideResourceBundleManager {
 
 	public ResourceBundle getOverrideResourceBundle(Locale locale) {
-		Map<Long, Map<String, OverrideResourceBundle>> overrideResourceBundles =
-			_overrideResourceBundlesDCLSingleton.getSingleton(_supplier);
+		long companyId = CompanyThreadLocal.getCompanyId();
+
+		DCLSingleton<Map<String, OverrideResourceBundle>>
+			overrideResourceBundleDCLSingleton =
+				_overrideResourceBundleMaps.get(companyId);
+
+		if (overrideResourceBundleDCLSingleton == null) {
+			overrideResourceBundleDCLSingleton = new DCLSingleton<>();
+
+			DCLSingleton<Map<String, OverrideResourceBundle>>
+				previousOverrideResourceBundleDCLSingleton =
+					_overrideResourceBundleMaps.putIfAbsent(
+						companyId, overrideResourceBundleDCLSingleton);
+
+			if (previousOverrideResourceBundleDCLSingleton != null) {
+				overrideResourceBundleDCLSingleton =
+					previousOverrideResourceBundleDCLSingleton;
+			}
+		}
 
 		Map<String, OverrideResourceBundle> companyOverrideResourceBundles =
-			overrideResourceBundles.get(CompanyThreadLocal.getCompanyId());
+			overrideResourceBundleDCLSingleton.getSingleton(
+				() -> _createOverrideResourceBundles(companyId));
 
-		if (MapUtil.isEmpty(companyOverrideResourceBundles) ||
+		if (companyOverrideResourceBundles.isEmpty() ||
 			PLOOriginalTranslationThreadLocal.isUseOriginalTranslation()) {
 
 			return null;
@@ -52,61 +67,45 @@ public class PLOOverrideResourceBundleManager {
 	}
 
 	protected static void clearCache() {
-		_overrideResourceBundlesDCLSingleton.destroy(null);
+		_overrideResourceBundleMaps.clear();
 
 		LanguageResources.clearResourceBundles();
 	}
 
-	private Map<Long, Map<String, OverrideResourceBundle>>
-		_createOverrideResourceBundles() {
+	private Map<String, OverrideResourceBundle> _createOverrideResourceBundles(
+		long companyId) {
 
-		Map<Long, Map<String, OverrideResourceBundle>> overrideResourceBundles =
-			new ConcurrentHashMap<>();
+		Map<String, OverrideResourceBundle> companyOverrideResourceBundles =
+			new HashMap<>();
 
-		_companyLocalService.forEachCompanyId(
-			companyId -> {
-				Map<String, OverrideResourceBundle>
-					companyOverrideResourceBundles = new HashMap<>();
+		for (PLOEntry ploEntry :
+				_ploEntryLocalService.getPLOEntries(companyId)) {
 
-				for (PLOEntry ploEntry :
-						_ploEntryLocalService.getPLOEntries(companyId)) {
+			companyOverrideResourceBundles.compute(
+				ploEntry.getLanguageId(),
+				(key, value) -> {
+					if (value == null) {
+						value = new OverrideResourceBundle(new HashMap<>());
+					}
 
-					companyOverrideResourceBundles.compute(
-						ploEntry.getLanguageId(),
-						(key, value) -> {
-							if (value == null) {
-								value = new OverrideResourceBundle(
-									new HashMap<>());
-							}
+					value.put(ploEntry.getKey(), ploEntry.getValue());
 
-							value.put(ploEntry.getKey(), ploEntry.getValue());
+					return value;
+				});
+		}
 
-							return value;
-						});
-				}
-
-				overrideResourceBundles.put(
-					companyId, companyOverrideResourceBundles);
-			});
-
-		return overrideResourceBundles;
+		return companyOverrideResourceBundles;
 	}
 
-	private static final DCLSingleton
-		<Map<Long, Map<String, OverrideResourceBundle>>>
-			_overrideResourceBundlesDCLSingleton = new DCLSingleton<>();
-
-	@Reference
-	private CompanyLocalService _companyLocalService;
+	private static final Map
+		<Long, DCLSingleton<Map<String, OverrideResourceBundle>>>
+			_overrideResourceBundleMaps = new ConcurrentHashMap<>();
 
 	@Reference
 	private Language _language;
 
 	@Reference
 	private PLOEntryLocalService _ploEntryLocalService;
-
-	private final Supplier<Map<Long, Map<String, OverrideResourceBundle>>>
-		_supplier = this::_createOverrideResourceBundles;
 
 	private static class OverrideResourceBundle extends ResourceBundle {
 

--- a/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/internal/test/PLOOverrideResourceBundleManagerTest.java
+++ b/modules/apps/portal-language/portal-language-override-test/src/testIntegration/java/com/liferay/portal/language/override/internal/test/PLOOverrideResourceBundleManagerTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.language.override.internal.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge Díaz
+ */
+@RunWith(Arquillian.class)
+public class PLOOverrideResourceBundleManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testGetOverrideResourceBundleWithUnregisteredCompany()
+		throws Exception {
+
+		long companyId = RandomTestUtil.randomLong();
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"insert into PLOEntry (ploEntryId, companyId, key_, " +
+					"languageId, value) values (?, ?, ?, ?, ?)");
+
+			SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(companyId)) {
+
+			String key = RandomTestUtil.randomString();
+			Locale locale = LocaleUtil.getDefault();
+			String value = RandomTestUtil.randomString();
+
+			preparedStatement.setLong(1, RandomTestUtil.randomLong());
+			preparedStatement.setLong(2, companyId);
+			preparedStatement.setString(3, key);
+			preparedStatement.setString(4, LanguageUtil.getLanguageId(locale));
+			preparedStatement.setString(5, value);
+
+			preparedStatement.executeUpdate();
+
+			Assert.assertEquals(value, LanguageUtil.get(locale, key));
+		}
+		finally {
+			try (Connection connection = DataAccess.getConnection();
+
+				PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						"delete from PLOEntry where companyId = ?")) {
+
+				preparedStatement.setLong(1, companyId);
+
+				preparedStatement.executeUpdate();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100292

## What Is Being Fixed

Creating a virtual instance hangs forever under database partitioning. The request thread blocks inside the DSR site initializer, nothing is logged, PostgreSQL never breaks the deadlock, and the node can only be stopped with `kill -9`.

A single request thread ends up holding two JDBC connections, each waiting on the other:

```
DSRInitialRequestPortalInstanceLifecycleListener        [NEW TRANSACTION]
  BundleSiteInitializer._addObjectDefinitions
    ObjectDefinitionResourceImpl.postObjectDefinition
      _addSystemObjectFields
        _language.get(LocaleUtil.getDefault(), "external-reference-code")
          PLOOverrideResourceBundleManager._createOverrideResourceBundles
            CompanyLocalServiceImpl.forEachCompanyId          <- iterates ALL companies
              CompanyThreadLocal.setCompanyIdWithSafeCloseable
                _syncLastDBPartitionSessionState
                  LastSessionRecorderUtil._syncSessionState   <- session.flush() + clear()
                    PgPreparedStatement.executeBatch          <- BLOCKS FOREVER
```

An ordinary language lookup for a field label lazily initializes the PLO override bundles, which iterates every company. Each company switch flushes and clears the caller's open Hibernate session, replaying the initializer's pending `ObjectDefinition` inserts onto a second connection where they collide with the still-uncommitted rows from the first. The holder waits on `ClientRead`, so there is no lock cycle for PostgreSQL to detect: no deadlock error, no timeout.

LPD-97613 exposed this by removing the Digital Sales Rooms beta feature flag, so the DSR site initializer now runs on every instance creation.

## How It Is Being Fixed

`getOverrideResourceBundle` only ever read `CompanyThreadLocal.getCompanyId()`'s entry, so building the map for every company was pure waste. The map is now keyed by company id with one `DCLSingleton` per company, the idiom already used in `LanguageResources.getSuperLocale`, so population stays exactly once per company, no lock is held across a company switch, and the deadlock is structurally impossible.

This also fixes a second defect: a copied or imported partition never saw its own overrides. `clearCache()` is only reached from `PLOEntryModelListener`, but `copyDBPartition` is a raw schema copy that bypasses the service layer, so no model listener fires. Under the previous code the whole map was built once for the companies existing at that moment, so a copied company had no entry and its overrides were silently ignored until an unrelated `PLOEntry` change happened to clear the cache. With per company lazy population the copied company is simply absent from the map and is read from the database on first lookup, after the copy has already landed.

The added integration test covers a company whose `PLOEntry` rows are inserted outside the service layer, as happens when a partition is copied.

## PR Check

**pr-check: PASS** — tested on `24070bcca6572810a5d881633feda00e3bf1a48a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "24070bcca6572810a5d881633feda00e3bf1a48a"} -->
