### PR TITLE
LPD-91510 Open the search admin reindex page by URL after upgrade

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
@@ -13,16 +13,7 @@ definition {
 			specificURL = "http://localhost:8080",
 			userEmailAddress = "test@liferay.com");
 
-		TestUtils.hardRefresh();
-
-		ApplicationsMenu.gotoPortlet(
-			category = "Configuration",
-			panel = "Control Panel",
-			portlet = "Search");
-
-		Click(
-			key_navItem = "Index Actions",
-			locator1 = "NavBar#NAV_ITEM_LINK");
+		SearchAdministration.openIndexActions();
 
 		SearchAdministration.startReindex(action = "All Search Indexes");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91510

## What Is Being Fixed

The Poshi upgrade test `PortalContinuousUpgrade#AutoUpgradeFromLatest7413UpdateWithDBPartitionEnabledAndHeadlessAPI` fails almost every run. Despite what the ticket describes, the failure is not at the testcase's own `ProductMenu.gotoPortlet` calls but inside the shared `Upgrade.restoreOriginalBundleAndUpgrade()` macro, in its post-upgrade "reindex" step. After restarting into the upgraded bundle and logging back in, the macro reached Control Panel > Configuration > Search through the applications menu, and the "Search" side-navigation entry was frequently not yet rendered after the auto-upgrade restart, so the click failed with an ElementNotFound. A single hard refresh (added earlier in LPD-84251) was not enough to make it reliable. This menu-navigation step lives in a shared macro used by several upgrade tests, so the same navigation flakiness can appear in any of them.

## How It Is Being Fixed

The applications-menu click chain, its hard refresh, and the separate "Index Actions" nav click are replaced with a single call to the existing `SearchAdministration.openIndexActions()` macro, which navigates straight to the Search admin Index Actions tab by URL. This is the same strategy used in LPD-80594 for `ProductMenu.gotoPortlet`: navigate by URL instead of clicking through menus, so the timing-sensitive menu rendering is bypassed entirely. The subsequent `startReindex` already retries with a hard refresh until the reindex button appears, so the reindex step remains robust while the Search portlet finishes coming up. The fix is in the shared macro, so the menu navigation is hardened for every upgrade test that calls it. This change only removes that navigation failure; failures at later steps — for example LPD-97433, where the post-upgrade reindex button is stuck behind a progress bar — have a different root cause and are out of scope here.

## Why Are There No Tests?

The change modifies a Poshi test macro (test infrastructure), not product code, so there is no product behavior to cover with a new automated test. Correctness was verified locally by driving the repaired navigation and reindex against a running portal and by Poshi syntax validation; the fix is exercised by the very upgrade tests it repairs.

## PR Check

**pr-check: PASS** — tested on `ff09ef9ca9aaf204f0130c9944f43f2bae11e8f9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

_Full Portal Build matched mechanically on the `portal-web/**` path but was intentionally skipped: the only change is a Poshi `.macro` under `portal-web/test/functional`, which `ant all` does not compile, so it yields no signal; Poshi Syntax covers it._

<!-- pr-check {"result": "success", "sha": "ff09ef9ca9aaf204f0130c9944f43f2bae11e8f9"} -->

