### PR TITLE
LPD-100558 Restore leftover data detection in the smoke company test

### DIFF
--- a/modules/test/portal-smoke-test/src/testIntegration/java/com/liferay/portal/smoke/test/CompanyLocalServiceTest.java
+++ b/modules/test/portal-smoke-test/src/testIntegration/java/com/liferay/portal/smoke/test/CompanyLocalServiceTest.java
@@ -6,14 +6,23 @@
 package com.liferay.portal.smoke.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.instance.PortalInstancePool;
+import com.liferay.portal.kernel.model.ClassName;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.List;
+
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,6 +32,7 @@ import org.junit.runner.RunWith;
  * @author Mika Koivisto
  * @author Dale Shan
  */
+@DataGuard(autoDelete = false, scope = DataGuard.Scope.METHOD)
 @RunWith(Arquillian.class)
 public class CompanyLocalServiceTest {
 
@@ -30,6 +40,16 @@ public class CompanyLocalServiceTest {
 	@Rule
 	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_initializeClassNames();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_cleanUpData();
+	}
 
 	@Test
 	public void testAddAndDeleteCompany() throws Exception {
@@ -45,6 +65,27 @@ public class CompanyLocalServiceTest {
 			Assert.assertNotEquals(company.getWebId(), curWebId);
 		}
 	}
+
+	private void _cleanUpData() throws Exception {
+		List<ClassName> classNames = ListUtil.remove(
+			_classNameLocalService.getClassNames(
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS),
+			_classNames);
+
+		for (ClassName className : classNames) {
+			_classNameLocalService.deleteClassName(className);
+		}
+	}
+
+	private void _initializeClassNames() throws Exception {
+		_classNames = _classNameLocalService.getClassNames(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+	}
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	private List<ClassName> _classNames;
 
 	@Inject
 	private CompanyLocalService _companyLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100558

## What Is Being Fixed

LRCI-7790 consolidated the stable integration tests into `portal-smoke-test`. Six of the seven tests were moved line-for-line, but `CompanyLocalServiceTest` was rewritten by hand to keep only `testAddAndDeleteCompany` out of its thirteen methods, and the rewrite dropped the DataGuard configuration together with the cleanup it depends on.

Without `autoDelete = false`, `DataGuardTestRuleUtil._autoDeleteAndAssert` runs `_autoDeleteLeftovers` *before* it captures the snapshot that feeds its assertion, so the leftovers are already gone when the assertion evaluates and it can never fail. The stable routine therefore stopped detecting data that survives `CompanyLocalService.deleteCompany` — which is precisely what that test was in the stable routine to catch.

## How It Is Being Fixed

The four coupled pieces are ported back from `modules/apps/company/company-test`: the `@DataGuard(autoDelete = false, scope = DataGuard.Scope.METHOD)` annotation, `_initializeClassNames()` in `@Before` to record the expected `ClassName` baseline, and the `ClassName`-deleting half of `_cleanUpData()` in `@After`. They only work together — restoring the annotation alone would fail the test on the legitimate `classname_` rows that `addCompany` creates.

`_resetBackgroundTaskThreadLocal()` and the `_serviceRegistrations` unregistration are deliberately left out: the original needs them for its staging tests, and this copy registers no model listeners and exercises no staging path.

Verified locally by running the test against a deployed bundle. It fails as intended, reporting `caused leftover data for class :com.liferay.list.type.model.ListTypeDefinition` and `…ListTypeEntry`, with DataGuard's backtrace pointing at the CMS list-type-definition batch import.

Note that this makes the stable batch red until that leak is fixed. The orphaned rows are tracked by LPD-100559, so this should not land ahead of it unless the red is wanted as a forcing function.

## PR Check

**pr-check: PASS** — tested on `1e02d56c17a71`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "1e02d56c17a71d8de0709ca9b7e953d678305cfb"} -->
