### PR TITLE
LPD-100989 Accept newer compatible schema versions as upgrade success

### DIFF
--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/executor/UpgradeExecutor.java
@@ -165,7 +165,7 @@ public class UpgradeExecutor {
 		_bundleContext = bundleContext;
 
 		try (Connection connection = DataAccess.getConnection()) {
-			_portalUpgraded = PortalUpgradeProcess.isInLatestSchemaVersion(
+			_portalUpgraded = PortalUpgradeProcess.isInCompatibleSchemaVersion(
 				connection);
 		}
 		catch (SQLException sqlException) {

--- a/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
+++ b/modules/apps/portal/portal-upgrade-impl/src/main/java/com/liferay/portal/upgrade/internal/release/ReleaseManagerImpl.java
@@ -69,7 +69,7 @@ public class ReleaseManagerImpl implements ReleaseManager {
 		String where = StringPool.BLANK;
 
 		try (Connection connection = DataAccess.getConnection()) {
-			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
+			if (!PortalUpgradeProcess.isInCompatibleSchemaVersion(connection)) {
 				where = "portal";
 			}
 		}
@@ -100,7 +100,7 @@ public class ReleaseManagerImpl implements ReleaseManager {
 	@Override
 	public String getStatus() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
-			if (!PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
+			if (!PortalUpgradeProcess.isInCompatibleSchemaVersion(connection) ||
 				_isPendingModuleUpgrades()) {
 
 				return "failure";

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/PortalUpgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/PortalUpgradeProcessTest.java
@@ -230,12 +230,12 @@ public class PortalUpgradeProcessTest {
 	}
 
 	@Test
-	public void testIsInLatestSchemaVersion() throws Exception {
+	public void testIsInCompatibleSchemaVersion() throws Exception {
 		_updateSchemaVersion(PortalUpgradeProcess.getLatestSchemaVersion());
 
 		try (Connection connection = DataAccess.getConnection()) {
 			Assert.assertTrue(
-				PortalUpgradeProcess.isInLatestSchemaVersion(connection));
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection));
 		}
 	}
 
@@ -250,12 +250,12 @@ public class PortalUpgradeProcessTest {
 	}
 
 	@Test
-	public void testIsNotInLatestSchemaVersion() throws Exception {
+	public void testIsNotInCompatibleSchemaVersion() throws Exception {
 		_updateSchemaVersion(_ORIGINAL_SCHEMA_VERSION);
 
 		try (Connection connection = DataAccess.getConnection()) {
 			Assert.assertFalse(
-				PortalUpgradeProcess.isInLatestSchemaVersion(connection));
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection));
 		}
 	}
 
@@ -267,6 +267,9 @@ public class PortalUpgradeProcessTest {
 		_updateSchemaVersion(nextMajorSchemaVersion);
 
 		try (Connection connection = DataAccess.getConnection()) {
+			Assert.assertFalse(
+				"Newer major schema versions must not be compatible",
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection));
 			Assert.assertFalse(
 				"Major schema version changes must be nonrevertible",
 				PortalUpgradeProcess.isInRequiredSchemaVersion(connection));
@@ -283,6 +286,9 @@ public class PortalUpgradeProcessTest {
 
 		try (Connection connection = DataAccess.getConnection()) {
 			Assert.assertTrue(
+				"Newer micro schema versions must be compatible",
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection));
+			Assert.assertTrue(
 				"Micro schema version changes must be revertible",
 				PortalUpgradeProcess.isInRequiredSchemaVersion(connection));
 		}
@@ -297,6 +303,9 @@ public class PortalUpgradeProcessTest {
 		_updateSchemaVersion(nextMinorSchemaVersion);
 
 		try (Connection connection = DataAccess.getConnection()) {
+			Assert.assertTrue(
+				"Newer minor schema versions must be compatible",
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection));
 			Assert.assertTrue(
 				"Minor schema version changes must be revertible",
 				PortalUpgradeProcess.isInRequiredSchemaVersion(connection));
@@ -356,7 +365,7 @@ public class PortalUpgradeProcessTest {
 
 		try (Connection connection = DataAccess.getConnection()) {
 			Assert.assertTrue(
-				PortalUpgradeProcess.isInLatestSchemaVersion(connection));
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection));
 		}
 	}
 
@@ -381,7 +390,7 @@ public class PortalUpgradeProcessTest {
 
 		try (Connection connection = DataAccess.getConnection()) {
 			Assert.assertTrue(
-				PortalUpgradeProcess.isInLatestSchemaVersion(connection));
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection));
 		}
 	}
 

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/test/ReleaseManagerTest.java
@@ -116,6 +116,34 @@ public class ReleaseManagerTest {
 	}
 
 	@Test
+	public void testSuccessfulUpgradeWithNewerCompatibleSchemaVersion()
+		throws Exception {
+
+		try (Connection connection = DataAccess.getConnection()) {
+			Version version = PortalUpgradeProcess.getCurrentSchemaVersion(
+				connection);
+
+			try {
+				PortalUpgradeProcess.updateSchemaVersion(
+					connection,
+					new Version(
+						version.getMajor(), version.getMinor(),
+						version.getMicro() + 1));
+
+				Assert.assertTrue(
+					Validator.isBlank(
+						_releaseManager.getShortStatusMessage(false)));
+				Assert.assertEquals("success", _releaseManager.getStatus());
+				Assert.assertTrue(
+					Validator.isBlank(_releaseManager.getStatusMessage(false)));
+			}
+			finally {
+				PortalUpgradeProcess.updateSchemaVersion(connection, version);
+			}
+		}
+	}
+
+	@Test
 	public void testUnsuccessfulUpgradeByMissingModuleUpgradeWithAutorun()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
+++ b/portal-impl/src/com/liferay/portal/tools/DBUpgrader.java
@@ -463,7 +463,8 @@ public class DBUpgrader {
 			int buildNumber = _getBuildNumber();
 
 			try (Connection connection = DataAccess.getConnection()) {
-				if (PortalUpgradeProcess.isInLatestSchemaVersion(connection) &&
+				if (PortalUpgradeProcess.isInCompatibleSchemaVersion(
+						connection) &&
 					(buildNumber == ReleaseInfo.getParentBuildNumber())) {
 
 					_checkClassNamesAndResourceActions();
@@ -516,7 +517,9 @@ public class DBUpgrader {
 			IndexUpdaterUtil.updatePortalIndexes();
 
 			try (Connection connection = DataAccess.getConnection()) {
-				if (PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
+				if (PortalUpgradeProcess.isInCompatibleSchemaVersion(
+						connection)) {
+
 					updatePortalServiceComponent();
 				}
 

--- a/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/PortalUpgradeProcess.java
@@ -227,12 +227,24 @@ public class PortalUpgradeProcess extends UpgradeProcess {
 		return true;
 	}
 
-	public static boolean isInLatestSchemaVersion(Connection connection)
+	public static boolean isInCompatibleSchemaVersion(Connection connection)
 		throws SQLException {
+
+		Version currentSchemaVersion = getCurrentSchemaVersion(connection);
 
 		Version latestSchemaVersion = getLatestSchemaVersion();
 
-		return latestSchemaVersion.equals(getCurrentSchemaVersion(connection));
+		int result = latestSchemaVersion.compareTo(currentSchemaVersion);
+
+		if ((result == 0) ||
+			((result < 0) &&
+			 (latestSchemaVersion.getMajor() ==
+				 currentSchemaVersion.getMajor()))) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	public static boolean isInRequiredSchemaVersion(Connection connection)

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DataCleanupPreupgradeProcessSuite.java
@@ -33,7 +33,7 @@ public class DataCleanupPreupgradeProcessSuite {
 	public void cleanUp() throws Exception {
 		try (Connection connection = DataAccess.getConnection()) {
 			if (StartupHelperUtil.isDBNew() ||
-				PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
+				PortalUpgradeProcess.isInCompatibleSchemaVersion(connection) ||
 				(PortalUpgradeProcess.getCurrentState(connection) !=
 					ReleaseConstants.STATE_GOOD)) {
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1788,7 +1788,7 @@ public class PortalImpl implements Portal {
 		}
 
 		try (Connection connection = DataAccess.getConnection()) {
-			if (PortalUpgradeProcess.isInLatestSchemaVersion(connection)) {
+			if (PortalUpgradeProcess.isInCompatibleSchemaVersion(connection)) {
 				return ClassNameLocalServiceUtil.getClassNameId(value);
 			}
 

--- a/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
+++ b/portal-impl/src/com/liferay/portal/verify/PreupgradeVerifyDatabaseState.java
@@ -57,7 +57,8 @@ public class PreupgradeVerifyDatabaseState extends PreupgradeVerifyProcess {
 		try {
 			try (Connection connection = getConnection()) {
 				if (StartupHelperUtil.isDBNew() ||
-					PortalUpgradeProcess.isInLatestSchemaVersion(connection) ||
+					PortalUpgradeProcess.isInCompatibleSchemaVersion(
+						connection) ||
 					(PortalUpgradeProcess.getCurrentState(connection) !=
 						ReleaseConstants.STATE_GOOD)) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100989

## What Is Being Fixed

Starting a DXP build whose expected portal schema version is lower than the version stored in the database is a supported scenario when the difference is at the micro or minor level within the same major version: this happens when a database already upgraded by a newer update of the same release line is started with an older build, for example 2025.Q1.8 (expected schema 31.14.2) on a database upgraded by 2025.Q1.22 (stored schema 31.14.4). In this state startup logs "Major upgrade finished with result failure" and the upgrade report shows "Result: failure" even though there is nothing to upgrade.

## How It Is Being Fixed

`PortalUpgradeProcess.isInLatestSchemaVersion` required the stored schema version to be equal to the latest schema version known to the running code. The method is renamed to `isInCompatibleSchemaVersion` and now accepts a stored version that is equal to or newer than the latest one within the same major version, applying the same tolerance `isInRequiredSchemaVersion` already applies at startup. A stored version behind the latest one (pending upgrades) or ahead on a different major version still reports failure.

Every caller picks up the new semantics. `ReleaseManagerImpl#getStatus` resolves the reported bug: the scenario logs "No pending upgrades to run" and the report shows "Result: success". `ReleaseManagerImpl#getShortStatusMessage` stops logging the false "Optional upgrades in portal are pending" INFO line at startup, so `MainServlet` refreshes the stored build number and version display name to the running build's values, the same refresh it performs on any other up to date database. The remaining callers (`UpgradeExecutor`, `PortalImpl#getClassNameId`, `DBUpgrader`, `PreupgradeVerifyDatabaseState`, `DataCleanupPreupgradeProcessSuite`) were reviewed one by one; for all of them the stored version can only be ahead in the supported scenario, where the relaxed check is the correct answer.

The existing revert tests in `PortalUpgradeProcessTest` now assert `isInCompatibleSchemaVersion` next to `isInRequiredSchemaVersion` for the newer micro, newer minor, and newer major cases, and `ReleaseManagerTest` covers the wiring with a newer micro version.

## PR Check

**pr-check: PASS** — tested on `daa78e4ad34aff8a65a1b2390d0bd9f51ec48774`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "daa78e4ad34aff8a65a1b2390d0bd9f51ec48774"} -->
