### PR TITLE
LPD-97433 Clear the browser cache when hard refreshing

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SearchAdministration.macro
@@ -116,9 +116,7 @@ definition {
 
 	@summary = "Default summary"
 	macro startReindex(action = null) {
-		while ((IsElementNotPresent(locator1 = "SearchAdmin#EXECUTE_REINDEX_BUTTON")) && (maxIterations = "50")) {
-			TestUtils.hardRefresh();
-		}
+		TestUtils.hardRefresh();
 
 		Click(
 			key_action = ${action},

--- a/portal-web/test/functional/com/liferay/portalweb/tests/development/tools/testinginfrastructure/block/macro/TestUtils.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/development/tools/testinginfrastructure/block/macro/TestUtils.macro
@@ -234,20 +234,17 @@ return element.textContent;
 
 	@summary = "Default summary"
 	macro hardRefresh() {
-		var mac = OSDetector.isApple();
+		var cdpParameters = MapUtil.newObjectHashMap();
 
-		if (${mac} == "true") {
-			Type.sendKeys(
-				locator1 = "//body",
-				value1 = "Shift + Command + r");
-		}
-		else {
-			Type.sendKeys(
-				locator1 = "//body",
-				value1 = "Ctrl + Shift + r");
-		}
+		ExecuteCDPCommand(
+			value1 = "Network.enable",
+			value2 = ${cdpParameters});
 
-		WaitForPageLoad();
+		ExecuteCDPCommand(
+			value1 = "Network.clearBrowserCache",
+			value2 = ${cdpParameters});
+
+		Refresh();
 	}
 
 	@summary = "Default summary"


### PR DESCRIPTION
## What

The continuous-upgrade Poshi test `LocalFile.PortalContinuousUpgrade#AutoUpgradeFromLatest7413Update` (and its `WithDBPartitionEnabled` variant) failed on `[master] ci:test:upgrade` across DB2/PostgreSQL/MySQL: after the 7.4.13 to master upgrade, `SearchAdministration.startReindex` could not find the "All Search Indexes" Reindex button and threw `ElementNotFoundPoshiRunnerException`.

## Root cause

The test reuses a single Chrome instance across both the 7.4.13 and the upgraded-master phases. After the in-place upgrade the browser served **stale cached assets**, so the Search > Index Actions page never rendered its React content (blank panel, no Reindex button). The recovery mechanism, `TestUtils.hardRefresh`, sent a synthetic `Ctrl+Shift+R` keystroke, which Chrome does not honor as a hard-reload accelerator when injected through WebDriver, so the 50-iteration refresh loop was a **no-op** and never cleared the stale cache. Reproduced locally: a manual `Ctrl+Shift+R` recovered the page; a plain F5 did not.

## Fix

`TestUtils.hardRefresh` now performs a genuine cache bypass over the Chrome DevTools Protocol (`Network.clearBrowserCache` followed by a reload), the automation equivalent of `Ctrl+Shift+R`. With a working hard refresh, `SearchAdministration.startReindex` no longer needs its retry loop and calls `hardRefresh` once.

(`Page.reload {ignoreCache: true}` would be the one-shot equivalent, but Poshi can only pass the boolean as a String, which Chrome rejects, hence `clearBrowserCache` + reload.)

## Testing

- Reproduced the failure locally by running the full 7.4.13 (2026.Q2.10) to master continuous upgrade, confirming the reindex step got stuck on the stale cache.
- With the fix, the upgraded Index Actions page renders and the full test passes.

**pr-check: PASS** — tested on `12bd575ba9cce`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |