### PR TITLE
LPD-101413 Enable widget pages in the DB migration import smoke test

### DIFF
--- a/modules/util/portal-tools-db-migration-importer-test/src/testFunctional/tests/DBMigrationImport.testcase
+++ b/modules/util/portal-tools-db-migration-importer-test/src/testFunctional/tests/DBMigrationImport.testcase
@@ -51,6 +51,8 @@ definition {
 		task ("Ensure that portal main functionalities work correctly") {
 			SignIn.signInTestSetup();
 
+			PagesAdmin.enableWidgetPages();
+
 			Smoke.runSmoke();
 
 			SignOut.signOut();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101413

## What Is Being Fixed

`LocalFile.DBMigrationImport#CanImportDatabaseToPostgreSQL` fails in `Smoke.runSmoke()` because the "Widget Page" card is missing from the add-page selector. [LPD-89086](https://liferay.atlassian.net/browse/LPD-89086) deprecated the Widget Page page type and gated it behind the [LPD-76864](https://liferay.atlassian.net/browse/LPD-76864) feature flag, which is disabled on every newly created company. The test runs on a virtual instance freshly created in `setUp`, so the smoke test runs with the flag off and the page type it relies on is filtered out of the selector.

## How It Is Being Fixed

Enable the Widget Pages feature flag right after signing in and before running the smoke test. This is the same fix https://github.com/liferay-database-infra/liferay-portal/pull/3815 applied to the database partition export tests for the same root cause.

## Why Are There No Tests?

This change is itself a fix to a Poshi functional test. It only enables the feature flag the smoke test already requires. There is no product code change, so no additional test coverage applies.

## PR Check

**pr-check: PASS** — tested on `bb49f7e13c4f863925e643202cb43e8627f759f4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "bb49f7e13c4f863925e643202cb43e8627f759f4"} -->


[LPD-89086]: https://liferay.atlassian.net/browse/LPD-89086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LPD-76864]: https://liferay.atlassian.net/browse/LPD-76864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ