### PR TITLE
LPD-98371 Schedule web content with a date the publish modal accepts

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/journal/WebContent.macro
@@ -1547,7 +1547,7 @@ definition {
 
 	@summary = "Default summary"
 	macro increaseDisplayDate(minuteIncrease = null) {
-		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd HH:mm", "UTC");
+		var displayDate = DateUtil.getDateOffsetByMinutes(${minuteIncrease}, "yyyy-MM-dd hh:mm a", "UTC");
 
 		WebContent.scheduleWCArticleWithPermissions(displayDate = ${displayDate});
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentdashboard/ContentDashboard.testcase
@@ -1894,7 +1894,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-01-01 01:00 AM");
 		}
 
 		task ("Go to Content Dashboard and click on the title") {
@@ -3694,7 +3694,7 @@ definition {
 
 			WebContentNavigator.gotoEditCP(webContentTitle = "WC Title Scheduled");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:00 AM");
 		}
 
 		task ("Filter asset at Content Dashboard using status") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/publications/Publications.testcase
@@ -1596,7 +1596,7 @@ definition {
 			webContentContent = "Web Content Content",
 			webContentTitle = "Web Content Title");
 
-		WebContent.scheduleWCArticleWithPermissions(displayDate = "01/01/2050");
+		WebContent.scheduleWCArticleWithPermissions(displayDate = "2050-01-01 01:00 AM");
 
 		Publications.publishPublication(
 			gotoPublicationsAdmin = "true",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContent.testcase
@@ -1113,7 +1113,7 @@ definition {
 				webContentContent = "Web Content Content",
 				webContentTitle = "Web Content Title");
 
-			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01");
+			WebContent.scheduleWCArticleWithPermissions(displayDate = "2100-11-20 01:01 AM");
 		}
 
 		task ("Add a page with a Web Content Display widget and display the Web Content article in the Web Content Display widget") {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98371

## What Is Being Fixed

The Poshi test LocalFile.DatabasePartitioning#CanScheduleJobInVariousCompaniesWhenAutoUpgradeIsEnabled failed because scheduled web content never rendered a status label — the label-item span the assertion looks for was missing. The scheduled-publish modal requires a display date in the yyyy-MM-dd hh:mm a format (nineteen characters, with AM/PM), but these tests passed sixteen-character yyyy-MM-dd HH:mm literals (and, in Publications, a ten-character MM/dd/yyyy one). The modal rejected the malformed date before scheduling anything, so the article stayed a draft, never reached SCHEDULED, and never showed a status label. The schedule macro reports the rejected date as a warning rather than a failure, so the run continued and failed later on the opaque missing-label assertion, keeping the real cause hidden.

## How It Is Being Fixed

Every scheduling call now passes a display date in the yyyy-MM-dd hh:mm a format the publish modal accepts. The increaseDisplayDate macro is corrected at the source so all of its callers get the right format, and the ContentDashboard, Publications, and WebContent testcases are updated to match. Publications used an entirely different MM/dd/yyyy literal and is rewritten rather than appended to. As a consequence, Publications and ContentDashboard#FilterByStatusScheduled — which never actually scheduled anything and passed only because they did not assert SCHEDULED — schedule for the first time with this change.

## Why Are There No Tests?

This change repairs existing functional (Poshi) tests. LPD-98371 is a test-fix task with no product code change, so there is no new production behavior to cover with additional tests.

## PR Check

**pr-check: PASS** — tested on `6094cb0ef4ef87d60ee61b74f8f14f5b9bf32d0c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Poshi Syntax | PASS |

<!-- pr-check {"result": "success", "sha": "6094cb0ef4ef87d60ee61b74f8f14f5b9bf32d0c"} -->
