### PR TITLE
Revert "LPD-91510 Open the search admin reindex page by URL after upgrade"

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/upgrades/Upgrade.macro
@@ -13,7 +13,16 @@ definition {
 			specificURL = "http://localhost:8080",
 			userEmailAddress = "test@liferay.com");
 
-		SearchAdministration.openIndexActions();
+		TestUtils.hardRefresh();
+
+		ApplicationsMenu.gotoPortlet(
+			category = "Configuration",
+			panel = "Control Panel",
+			portlet = "Search");
+
+		Click(
+			key_navItem = "Index Actions",
+			locator1 = "NavBar#NAV_ITEM_LINK");
 
 		SearchAdministration.startReindex(action = "All Search Indexes");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91510

## What Is Being Fixed

The LPD-91510 change (merged as 10ea02c) replaced the applications-menu navigation to the Search admin reindex page with a direct URL call — SearchAdministration.openIndexActions() — inside Upgrade.restoreOriginalBundleAndUpgrade(). After it landed on master it broke the ci:test:upgrade suite. This reverts it to restore the previous, known-green behavior while the navigation change is reworked.

## How It Is Being Fixed

Straight git revert of 10ea02c: restores the ApplicationsMenu.gotoPortlet(Configuration > Search) navigation, the preceding hard refresh, and the Index Actions nav click. No other changes.

## Why Are There No Tests?

This is a revert of a Poshi test-macro change; it restores previously shipped test infrastructure and touches no product code.

## PR Check

**pr-check: SKIPPED** — Straight revert of merged commit 10ea02c to unbreak the ci:test:upgrade suite; restores previously-green Poshi macro code.

<!-- pr-check {"reason": "Straight revert of merged commit 10ea02c to unbreak the ci:test:upgrade suite; restores previously-green Poshi macro code.", "result": "skipped", "sha": "d900479d437c844fcda600fe80e1558007db61b0"} -->
