### PR TITLE
LPD-100533 Keep the scale when copying NUMERIC source columns

### DIFF
--- a/modules/util/portal-tools-db-migration-importer-test/src/testIntegration/java/com/liferay/portal/tools/db/migration/importer/test/DBCopyTablesProcessTest.java
+++ b/modules/util/portal-tools-db-migration-importer-test/src/testIntegration/java/com/liferay/portal/tools/db/migration/importer/test/DBCopyTablesProcessTest.java
@@ -98,7 +98,7 @@ public class DBCopyTablesProcessTest {
 	public void testBigDecimalColumn() throws Exception {
 		_testColumnTypeOf(
 			Function.identity(), GetterUtil::getDouble, "BIGDECIMAL",
-			RandomTestUtil::nextDouble);
+			() -> RandomTestUtil.nextDouble() + 0.5);
 	}
 
 	@Test
@@ -154,7 +154,7 @@ public class DBCopyTablesProcessTest {
 	public void testDoubleColumn() throws Exception {
 		_testColumnTypeOf(
 			Function.identity(), GetterUtil::getDouble, "DOUBLE",
-			RandomTestUtil::nextDouble);
+			() -> RandomTestUtil.nextDouble() + 0.5);
 	}
 
 	@Test

--- a/modules/util/portal-tools-db-migration-importer/src/main/java/com/liferay/portal/tools/db/migration/importer/DBCopyTablesProcess.java
+++ b/modules/util/portal-tools-db-migration-importer/src/main/java/com/liferay/portal/tools/db/migration/importer/DBCopyTablesProcess.java
@@ -212,7 +212,7 @@ public class DBCopyTablesProcess {
 
 		String valueString = null;
 
-		if ((sourceType == Types.BIGINT) || (sourceType == Types.NUMERIC)) {
+		if (sourceType == Types.BIGINT) {
 			long value = resultSet.getLong(columnName);
 
 			if ((value == 0L) && resultSet.wasNull()) {
@@ -327,11 +327,31 @@ public class DBCopyTablesProcess {
 				valueString = sb.toString();
 			}
 		}
-		else if (sourceType == Types.DECIMAL) {
+		else if ((sourceType == Types.DECIMAL) ||
+				 (sourceType == Types.NUMERIC)) {
+
 			BigDecimal value = resultSet.getBigDecimal(columnName);
 
 			if (value == null) {
 				preparedStatement.setNull(index, targetType);
+
+				return;
+			}
+
+			if (targetType == Types.BIGINT) {
+				preparedStatement.setLong(index, value.longValue());
+
+				return;
+			}
+
+			if (targetType == Types.BIT) {
+				preparedStatement.setBoolean(index, value.signum() != 0);
+
+				return;
+			}
+
+			if (targetType == Types.INTEGER) {
+				preparedStatement.setInt(index, value.intValue());
 
 				return;
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-100533

## What Is Being Fixed

The DB Schema Importer silently truncated the decimal places of every NUMERIC source column. `DBCopyTablesProcess` grouped `Types.NUMERIC` together with `Types.BIGINT` and read the value through `getLong()`, so a Journal Article version of 1.1 arrived at the target as 1. Since `version` participates in a unique index, the truncated rows collided and the import failed while creating `ix_ja_g_a_v`. Oracle is the affected source, because it is the only supported database that reports `Types.NUMERIC`.

## How It Is Being Fixed

`Types.NUMERIC` now shares the branch with `Types.DECIMAL`, which reads the column through `getBigDecimal()` and therefore keeps the scale intact. That branch alone is not sufficient, because Oracle collapses four Liferay column types onto `NUMBER` — BIGDECIMAL, BOOLEAN, INTEGER and LONG all report `Types.NUMERIC` — while PostgreSQL keeps them apart as `decimal`, `bool`, `integer` and `bigint`. Every one of those columns now enters the BigDecimal branch, so it sets the value according to the target type rather than assuming a decimal, which is what the new BIGINT, BIT and INTEGER blocks do alongside the existing NUMERIC one.

The change was verified with the integration test run against each supported source database, copying into a PostgreSQL target, both before and after the fix. Oracle 19.3 fails `testBigDecimalColumn` on master with `expected:<57404.5> but was:<57404.0>` and passes on this branch. MySQL 8.0, SQL Server 2019 and DB2 11.5 report 12/12 on both sides, which is expected since all three emit `Types.DECIMAL` and are untouched by the change.

## PR Check

**pr-check: PASS** — tested on `7eaafd60eaab5b1249856be6307a315e8613b7f3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7eaafd60eaab5b1249856be6307a315e8613b7f3"} -->
