### PR TITLE
LPD-101498 Prevent DB2 BLOB truncation at 1 MB

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeDB2Test.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeDB2Test.java
@@ -49,7 +49,8 @@ public class UpgradeDB2Test {
 
 	@Before
 	public void setUp() throws Exception {
-		_db.runSQL("create table TestTable(column1 clob(1M))");
+		_db.runSQL(
+			"create table TestTable(column1 clob(1M), column2 blob(1M))");
 	}
 
 	@After
@@ -72,6 +73,20 @@ public class UpgradeDB2Test {
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				Assert.assertTrue(
 					"column1 not found in TestTable", resultSet.next());
+
+				Assert.assertEquals(2147483647, resultSet.getInt("length"));
+			}
+		}
+
+		try (Connection connection = DataAccess.getConnection();
+
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				"select length from syscat.columns where tabname = " +
+					"'TESTTABLE' and colname = 'COLUMN2'")) {
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				Assert.assertTrue(
+					"column2 not found in TestTable", resultSet.next());
 
 				Assert.assertEquals(2147483647, resultSet.getInt("length"));
 			}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeDB2Test.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_4_x/test/UpgradeDB2Test.java
@@ -64,29 +64,24 @@ public class UpgradeDB2Test {
 
 		upgradeProcess.upgrade();
 
-		try (Connection connection = DataAccess.getConnection();
-
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				"select length from syscat.columns where tabname = " +
-					"'TESTTABLE' and colname = 'COLUMN1'")) {
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				Assert.assertTrue(
-					"column1 not found in TestTable", resultSet.next());
-
-				Assert.assertEquals(2147483647, resultSet.getInt("length"));
-			}
+		try (Connection connection = DataAccess.getConnection()) {
+			_assertColumnLength(connection, "COLUMN1");
+			_assertColumnLength(connection, "COLUMN2");
 		}
+	}
 
-		try (Connection connection = DataAccess.getConnection();
+	private void _assertColumnLength(Connection connection, String columnName)
+		throws Exception {
 
-			PreparedStatement preparedStatement = connection.prepareStatement(
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
 				"select length from syscat.columns where tabname = " +
-					"'TESTTABLE' and colname = 'COLUMN2'")) {
+					"'TESTTABLE' and colname = ?")) {
+
+			preparedStatement.setString(1, columnName);
 
 			try (ResultSet resultSet = preparedStatement.executeQuery()) {
 				Assert.assertTrue(
-					"column2 not found in TestTable", resultSet.next());
+					columnName + " not found in TestTable", resultSet.next());
 
 				Assert.assertEquals(2147483647, resultSet.getInt("length"));
 			}

--- a/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/main/java/com/liferay/portal/dao/db/DB2DB.java
@@ -690,7 +690,7 @@ public class DB2DB extends BaseDB {
 
 	private static final String[] _DB2 = {
 		"--", "1", "0", "'1970-01-01-00.00.00.000000'", "current timestamp",
-		" blob", " blob", " decimal(30, 16)", " smallint", " timestamp",
+		" blob(2G)", " blob", " decimal(30, 16)", " smallint", " timestamp",
 		" double", " integer", " bigint", " varchar(4000)", " clob(2G)",
 		" varchar", " generated always as identity", "commit"
 	};

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
@@ -34,6 +34,13 @@ public class DB2DBTest extends BaseDBTestCase {
 	}
 
 	@Test
+	public void testBlobColumnType() throws Exception {
+		Assert.assertEquals(
+			"create table TestTable (largeColumnValue blob(2G))\n",
+			buildSQL("create table TestTable (largeColumnValue BLOB)"));
+	}
+
+	@Test
 	public void testGetLongDefaultValue() {
 		Assert.assertEquals("10", db.getDefaultValue("10"));
 	}

--- a/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
+++ b/modules/dxp/apps/portal/portal-dao-db/src/test/java/com/liferay/portal/dao/db/DB2DBTest.java
@@ -41,6 +41,12 @@ public class DB2DBTest extends BaseDBTestCase {
 	}
 
 	@Test
+	public void testBlobColumnTypeSize() {
+		Assert.assertEquals(
+			Integer.valueOf(DB.SQL_SIZE_NONE), db.getSQLTypeSize("BLOB"));
+	}
+
+	@Test
 	public void testGetLongDefaultValue() {
 		Assert.assertEquals("10", db.getDefaultValue("10"));
 	}

--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -1103,7 +1103,7 @@ public abstract class BaseDB implements DB {
 				matcher.matches() ? GetterUtil.getInteger(matcher.group(1)) :
 					DB.SQL_SIZE_NONE);
 
-			if (templateType.equals("DATE")) {
+			if (templateType.equals("BLOB") || templateType.equals("DATE")) {
 				_sqlTypeSizes.put(templateType, DB.SQL_SIZE_NONE);
 
 				continue;

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -814,6 +814,8 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(
 			new Version(38, 7, 6),
 			new LayoutStagingExternalReferenceCodeUpgradeProcess());
+
+		upgradeVersionTreeMap.put(new Version(38, 8, 0), new UpgradeDB2());
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDB2.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDB2.java
@@ -22,76 +22,48 @@ import java.sql.ResultSet;
  */
 public class UpgradeDB2 extends UpgradeProcess {
 
-	protected void alterBlobColumns() throws Exception {
-		try (LoggingTimer loggingTimer = new LoggingTimer();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"select tabname, colname from syscat.columns where ",
-					"generated != 'N' and hidden != 'N' and length = 1048576 ",
-					"and typename = 'BLOB' and tabschema = ?"))) {
-
-			preparedStatement.setString(1, connection.getSchema());
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String tableName = resultSet.getString("tabname");
-					String columnName = resultSet.getString("colname");
-
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Alter column ", tableName, StringPool.PERIOD,
-								columnName, " type to blob(2G)"));
-					}
-
-					runSQL(
-						StringBundler.concat(
-							"alter table ", tableName, " alter column ",
-							columnName, " set data type blob(2G)"));
-				}
-			}
-		}
-	}
-
-	protected void alterClobColumns() throws Exception {
-		try (LoggingTimer loggingTimer = new LoggingTimer();
-			PreparedStatement preparedStatement = connection.prepareStatement(
-				StringBundler.concat(
-					"select tabname, colname from syscat.columns where ",
-					"generated != 'N' and hidden != 'N' and length = 1048576 ",
-					"and typename = 'CLOB' and tabschema = ?"))) {
-
-			preparedStatement.setString(1, connection.getSchema());
-
-			try (ResultSet resultSet = preparedStatement.executeQuery()) {
-				while (resultSet.next()) {
-					String tableName = resultSet.getString("tabname");
-					String columnName = resultSet.getString("colname");
-
-					if (_log.isInfoEnabled()) {
-						_log.info(
-							StringBundler.concat(
-								"Alter column ", tableName, StringPool.PERIOD,
-								columnName, " type to clob(2G)"));
-					}
-
-					runSQL(
-						StringBundler.concat(
-							"alter table ", tableName, " alter column ",
-							columnName, " set data type clob(2G)"));
-				}
-			}
-		}
-	}
-
 	@Override
 	protected void doUpgrade() throws Exception {
 		if (DBManagerUtil.getDBType() != DBType.DB2) {
 			return;
 		}
 
-		alterBlobColumns();
-		alterClobColumns();
+		_alterColumnTypes("blob(2G)", "BLOB");
+		_alterColumnTypes("clob(2G)", "CLOB");
+	}
+
+	private void _alterColumnTypes(String newColumnType, String typeName)
+		throws Exception {
+
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select tabname, colname from syscat.columns where ",
+					"generated != 'N' and hidden != 'N' and length = 1048576 ",
+					"and typename = ? and tabschema = ?"))) {
+
+			preparedStatement.setString(1, typeName);
+			preparedStatement.setString(2, connection.getSchema());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String tableName = resultSet.getString("tabname");
+					String columnName = resultSet.getString("colname");
+
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Alter column ", tableName, StringPool.PERIOD,
+								columnName, " type to ", newColumnType));
+					}
+
+					runSQL(
+						StringBundler.concat(
+							"alter table ", tableName, " alter column ",
+							columnName, " set data type ", newColumnType));
+				}
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(UpgradeDB2.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDB2.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/UpgradeDB2.java
@@ -22,6 +22,37 @@ import java.sql.ResultSet;
  */
 public class UpgradeDB2 extends UpgradeProcess {
 
+	protected void alterBlobColumns() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select tabname, colname from syscat.columns where ",
+					"generated != 'N' and hidden != 'N' and length = 1048576 ",
+					"and typename = 'BLOB' and tabschema = ?"))) {
+
+			preparedStatement.setString(1, connection.getSchema());
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				while (resultSet.next()) {
+					String tableName = resultSet.getString("tabname");
+					String columnName = resultSet.getString("colname");
+
+					if (_log.isInfoEnabled()) {
+						_log.info(
+							StringBundler.concat(
+								"Alter column ", tableName, StringPool.PERIOD,
+								columnName, " type to blob(2G)"));
+					}
+
+					runSQL(
+						StringBundler.concat(
+							"alter table ", tableName, " alter column ",
+							columnName, " set data type blob(2G)"));
+				}
+			}
+		}
+	}
+
 	protected void alterClobColumns() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -59,6 +90,7 @@ public class UpgradeDB2 extends UpgradeProcess {
 			return;
 		}
 
+		alterBlobColumns();
 		alterClobColumns();
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101498

## What Is Being Fixed

On DB2, Liferay declared BLOB columns as a bare ` blob`, which DB2 resolves to its default size of 1 MB. Values larger than that were rejected, so binary payloads above 1 MB could not be stored. The CLOB entry alongside it already carried an explicit ` clob(2G)`, so only the BLOB side was affected. Databases already deployed on DB2 also carry the undersized columns on disk, so correcting the declaration alone would leave existing installations broken.

## How It Is Being Fixed

The DB2 type substitution for BLOB now emits ` blob(2G)` instead of ` blob`, matching the CLOB entry beside it, so newly created tables get the maximum capacity. To repair databases that already exist, `UpgradeDB2` queries `syscat.columns` for columns still sitting at the 1 MB default length and issues `alter table ... set data type` for each one. That alter logic previously existed only for CLOB, so rather than duplicating the block per type it is parameterized into a single `_alterColumnTypes(newColumnType, typeName)` method that `doUpgrade` calls twice, once for `blob(2G)` and once for `clob(2G)`. The upgrade is registered at version 38.8.0 in `PortalUpgradeProcessRegistryImpl` and, like the CLOB path, returns early on any database that is not DB2.

Widening the BLOB template entry also changed the SQL type size `BaseDB` registers for BLOB. The `_sqlTypeSizePattern` captures the parenthesized digits, so against `blob(2G)` it registered a size of 2 where plain `blob` registered `SQL_SIZE_NONE`. That made `DBInspector.hasColumnType` compare an expected size of 2 against the real column size and return false for every DB2 BLOB column, which broke the idempotency guards in `BaseDBProcess`. Tightening the pattern is not an option, because the trailing wildcard is what lets `decimal(30, 16)` report a size, so BLOB now short circuits to `SQL_SIZE_NONE` alongside DATE. That restores the previous value and is a no-op for every other database, whose templates carry no parenthesized blob capacity.

## PR Check

**pr-check: PASS** — tested on `08a3b55e773809a74223f7a3e7159dfb173de12d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "08a3b55e773809a74223f7a3e7159dfb173de12d"} -->
